### PR TITLE
Fix deprecated String.substr() calls in detector.ts

### DIFF
--- a/src/js/aos/helpers/detector.ts
+++ b/src/js/aos/helpers/detector.ts
@@ -18,12 +18,12 @@ function ua() {
 class Detector {
   phone() {
     const a = ua();
-    return !!(fullNameRe.test(a) || prefixRe.test(a.substr(0, 4)));
+    return !!(fullNameRe.test(a) || prefixRe.test(a.substring(0, 4)));
   }
 
   mobile() {
     const a = ua();
-    return !!(fullNameMobileRe.test(a) || prefixMobileRe.test(a.substr(0, 4)));
+    return !!(fullNameMobileRe.test(a) || prefixMobileRe.test(a.substring(0, 4)));
   }
 
   tablet() {


### PR DESCRIPTION
Replace deprecated .substr(0, 4) with .substring(0, 4) in the AOS device detection helper. The substr() method is deprecated and substring() provides the same functionality for this use case.