### PR TITLE
fix: resolve 11 remaining broken links

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,6 +1,5 @@
-# LinkedIn returns 999 for automated requests
-https?://www\.linkedin\.com/.*
-https?://linkedin\.com/.*
+# LinkedIn returns 999 for automated requests (includes country subdomains)
+https?://([a-z]{2}\.)?linkedin\.com/.*
 
 # Twitter/X rate-limits aggressively
 https?://(www\.)?twitter\.com/.*

--- a/src/content/post/how-to-build-an-online-b2b-community/index.mdx
+++ b/src/content/post/how-to-build-an-online-b2b-community/index.mdx
@@ -225,7 +225,7 @@ If you made it this far down then A) I'm impressed and B) you might be eager to 
    - [The Community-Led Growth show](https://open.spotify.com/show/7eQhR01Fs098yMZ5qXtvjC), by [Joel Primack](https://www.linkedin.com/in/joel-primack/)
    - [Community Signal](https://communitysignal.com/) by [Patrick O'Keefe](https://www.linkedin.com/in/patrickokeefe/)
    - [Lessons From The NEW Community Manager Handbook](https://communityroundtable.com/what-we-do/resources/community-management-podcasts/cmgr-handbook-podcast/), by [The Community Roundtable](https://www.linkedin.com/company/the-community-roundtable/)
-   - [The B2B Growth Show](https://www.b2bgrowthshow.com/)
+   - [The B2B Growth Show](https://sweetfishmedia.com/b2b-growth)
 
 > TIP: If your community is catering towards a technical audience with a lot of developers, I can highly recommend the content of [Mary Thengvall](https://www.linkedin.com/in/marythengvall?trk=article-ssr-frontend-pulse_little-mention) ([website](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww%2Emarythengvall%2Ecom%2Fblog&urlhash=-oLt&trk=article-ssr-frontend-pulse_little-text-block)) and [Developer Relations](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww%2Eamazon%2Ecom%2FDeveloper-Relations-Build-Successful-Program-ebook%2Fdp%2FB09G9LGSJ1%3Fref_%3Dast_author_dp&urlhash=dufD&trk=article-ssr-frontend-pulse_little-text-block) by [Caroline Lewko](https://ca.linkedin.com/in/carolinelewko?trk=article-ssr-frontend-pulse_little-mention) , and for you to check out content everywhere marked [#DevRel](https://www.linkedin.com/feed/hashtag/devrel?trk=article-ssr-frontend-pulse_little-text-block).
 

--- a/src/content/post/proving-the-monetary-value-of-a-b-testing/index.mdx
+++ b/src/content/post/proving-the-monetary-value-of-a-b-testing/index.mdx
@@ -72,7 +72,7 @@ For obvious reasons I can’t share our own internal sheet (containing our compl
 
 ![](../proving-the-monetary-value-of-a-b-testing/Proving%20A-B%20Testing%20Value.png)
 
-[_Example of the calculation sheet_](https://docs.google.com/spreadsheets/d/10yG3lzoBMZG0Zw613qZiEdYToWc287FfQXCt_d-1MZs/edit?usp=sharing)
+_Example of the calculation sheet (the Google Spreadsheet is no longer available)_
 
 Let me know if you think some things are off or if you have any improvements.
 

--- a/src/content/post/the-cro-process/index.mdx
+++ b/src/content/post/the-cro-process/index.mdx
@@ -40,7 +40,7 @@ The table below gives you a global idea of the different levels for each:
 
 ![](../the-cro-process/process1.png)
 
-_\[[See the full table](https://docs.google.com/spreadsheets/d/1YejXE03AwT2yPd4f-FNEDM2QFaWnu-8uAYV2u3clF2Y/edit?usp=sharing)]_
+_\[The full table was previously available as a Google Spreadsheet, but is no longer online]_
 
 ### **CRO Cycle**
 
@@ -60,7 +60,7 @@ For this we made combination of the PIE (Potential Importance Ease) model and th
 
 ![](../the-cro-process/process3.png)
 
-_\[[View spreadsheet](https://docs.google.com/spreadsheets/d/18ZFrKqsZxndb5fef8hbnxw3uG_wj6ZSDSB3fvg2JpmQ/edit?usp=sharing) to use yourself]_
+_\[The prioritization spreadsheet was previously available as a Google Spreadsheet, but is no longer online]_
 
 If prioritizing your testing ideas is an issue for you, I’d highly recommend reading [4 Frameworks To Help Prioritize & Conduct Your Conversion Testing](https://conversionxl.com/4-frameworks-help-prioritize-conduct-conversion-testing/).
 
@@ -80,6 +80,6 @@ For example: if you find a SSL security issue during a usability test, you’re 
 
 3. Validate potential improvements through A/B testing and setup processes to continuously learn from your target audience.
 
-[See the complete presentation and cases on slideshare (in Dutch)](https://www.slideshare.net/slideshow/shoppingtomorrow-datagedreven-conversieoptimalisatiecases/28052765).
+The complete presentation and cases were previously available on SlideShare (in Dutch), but the link is no longer active.
 
 Hope this is useful to you, if you have any specific questions about the Dutch resources I linked to, let me know :).

--- a/src/content/presentations/why-becoming-a-marketplace-should-be-your-next-big-initiative.mdx
+++ b/src/content/presentations/why-becoming-a-marketplace-should-be-your-next-big-initiative.mdx
@@ -12,4 +12,4 @@ relatedEventSlugs: []
 
 Together with Marnix from SQLI I hosted a session about marketplaces for retail organizations. What are all marketplace variants? What is the difference between selling on a marketplace and becoming a marketplace? What are the latest developments and why do we think you really need to be the first mover in your industry when it comes to marketplaces...
 
-More info about [Sprykers Enterprise Marketplace Capabilities](https://spryker.com/marketplace/).
+More info about [Sprykers Enterprise Marketplace Capabilities](https://spryker.com/platform/portfolio/enterprise-marketplace).


### PR DESCRIPTION
## Summary
- Update `.lycheeignore` LinkedIn pattern to cover country subdomains (`uk.`, `ch.`, `de.linkedin.com`)
- Replace 3 dead Google Spreadsheet links (410 Gone) with text notes
- Replace dead SlideShare presentation link with text note
- Update Spryker marketplace URL to new path (`/platform/portfolio/enterprise-marketplace`)
- Update B2B Growth Show URL to new domain (`sweetfishmedia.com/b2b-growth`)

Follow-up to PR #36 which resolved 224 → 11 broken links. This PR resolves the remaining 11.

## Test plan
- [ ] CI checks pass (build, typecheck, format, link check)
- [ ] Lychee link checker reports 0 errors