### PR TITLE
fix(security): update vulnerable deps and fix alert workflow

### DIFF
--- a/.github/workflows/security-alerts.yml
+++ b/.github/workflows/security-alerts.yml
@@ -15,6 +15,7 @@ permissions:
   contents: read
   issues: write
   security-events: read
+  vulnerability-alerts: read
 
 jobs:
   check-dependabot-alerts:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@astrojs/sitemap": "^3.7.0",
         "@astrojs/tailwind": "^6.0.2",
         "@atproto/api": "^0.19.0",
-        "@rollup/rollup-linux-x64-gnu": "4.59.0",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/typography": "^0.5.16",
         "@types/animejs": "^3.1.13",
@@ -1188,9 +1187,9 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-      "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5614,9 +5613,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -8149,9 +8148,9 @@
       "license": "MIT"
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -15464,9 +15463,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
-      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
+      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
   "overrides": {
     "sharp": "^0.33.0",
     "lodash": "^4.17.23",
-    "@isaacs/brace-expansion": "^5.0.1"
+    "@isaacs/brace-expansion": "^5.0.1",
+    "tar": "^7.5.9",
+    "devalue": "^5.6.3",
+    "ajv": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
- Add npm overrides for `tar` (7.5.9), `devalue` (5.6.3), `ajv` (8.18.0) to address security advisories
- Add `vulnerability-alerts: read` permission to security-alerts workflow (fixes HTTP 403)
- Closes superseded Dependabot PRs #28, #29, #31 (which had merge conflicts after #34)

### Security advisories addressed
| Package | Severity | Issue |
|---------|----------|-------|
| tar | High | Arbitrary file read/write via hardlink target escape |
| ajv | Medium | ReDoS when using `$data` option |
| devalue | Low | Prototype pollution + CPU/memory amplification |

### Remaining (no fix available)
- `minimatch` (High) -- ReDoS via repeated wildcards. No patched version upstream; affects 13 transitive paths through `glob`, `archiver`, `readdir-glob`, `@typescript-eslint`

## Test plan
- [ ] CI checks pass (build, typecheck, format, tests)
- [ ] `npm ls tar devalue ajv` shows overridden versions