### PR TITLE
feat: add Standard.site ATProto long-form publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "dev:netlify": "netlify dev",
-    "build": "astro build && node scripts/test-robots.js",
+    "build": "node scripts/standard-site-publish.mjs && astro build && node scripts/test-robots.js",
     "preview": "astro build --mode preview",
     "production": "astro build --mode production",
     "astro": "astro",
@@ -16,6 +16,8 @@
     "test:robots": "node scripts/test-robots.js",
     "validate-content": "node scripts/validate-content.js",
     "bluesky:link": "node scripts/bluesky-link.mjs",
+    "standard-site:setup": "node scripts/standard-site-setup.mjs",
+    "standard-site:publish": "node scripts/standard-site-publish.mjs",
     "check:trailing-slashes": "node scripts/check-trailing-slashes.js",
     "format:check": "prettier --check \"src/**/*.{astro,ts,tsx,js,jsx,mjs,css,md,mdx}\"",
     "typecheck": "astro check"

--- a/public/.well-known/site.standard.publication
+++ b/public/.well-known/site.standard.publication
@@ -1,0 +1,1 @@
+at://did:plc:45uheisi25szrjvjurfpritx/site.standard.publication/3mgfeypogdk2r

--- a/scripts/standard-site-publish.mjs
+++ b/scripts/standard-site-publish.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+
+/**
+ * Standard.site Publish Script
+ *
+ * Syncs blog posts to ATProto as site.standard.document records.
+ * Uses post slug as the record key for deterministic AT-URIs.
+ *
+ * Handles:
+ *   - Creating new document records for new posts
+ *   - Updating existing records for edited posts
+ *   - Deleting records for removed/drafted posts
+ *
+ * Usage:
+ *   npm run standard-site:publish             # sync all posts
+ *   npm run standard-site:publish -- --dry-run # preview changes
+ *
+ * Environment variables:
+ *   BLUESKY_APP_PASSWORD - App password from https://bsky.app/settings/app-passwords
+ *
+ * Designed to run as part of the Netlify build command.
+ */
+
+import { AtpAgent } from '@atproto/api';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SITE_URL = 'https://gui.do';
+const HANDLE = 'gui.do';
+const POSTS_DIR = path.join(__dirname, '..', 'src', 'content', 'post');
+const CONFIG_FILE = path.join(__dirname, '..', 'src', 'config', 'standardSite.json');
+
+// Parse command line arguments
+function parseArgs() {
+  const args = process.argv.slice(2);
+  return { dryRun: args.includes('--dry-run') };
+}
+
+// Load environment variables from .env.local (for local dev)
+async function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  try {
+    const content = await fs.readFile(envPath, 'utf-8');
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        const value = valueParts.join('=').replace(/^["']|["']$/g, '');
+        if (!process.env[key]) {
+          process.env[key] = value;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+// Load the Standard.site config
+async function loadConfig() {
+  try {
+    const content = await fs.readFile(CONFIG_FILE, 'utf-8');
+    return JSON.parse(content);
+  } catch (err) {
+    return { enabled: false, did: '', publicationUri: '' };
+  }
+}
+
+// Read and parse MDX frontmatter for a single post
+async function readPost(slug) {
+  const postPath = path.join(POSTS_DIR, slug, 'index.mdx');
+
+  let content = await fs.readFile(postPath, 'utf-8');
+  content = content.replace(/\r\n/g, '\n');
+
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatterMatch) return null;
+
+  const frontmatter = frontmatterMatch[1];
+  const body = content.slice(frontmatterMatch[0].length);
+
+  const get = (key) => {
+    const match = frontmatter.match(new RegExp(`^${key}:\\s*["']?(.+?)["']?\\s*$`, 'm'));
+    return match ? match[1] : null;
+  };
+
+  const draftMatch = frontmatter.match(/^draft:\s*(true|false)\s*$/m);
+  const isDraft = draftMatch ? draftMatch[1] === 'true' : false;
+
+  // Extract categories/tags
+  const categoriesMatch = frontmatter.match(/^categories:\s*\n((?:\s+-\s+.+\n?)*)/m);
+  let tags = [];
+  if (categoriesMatch) {
+    tags = categoriesMatch[1]
+      .split('\n')
+      .map(line => line.replace(/^\s+-\s+/, '').replace(/^["']|["']$/g, '').trim())
+      .filter(Boolean);
+  }
+
+  // Extract plain text from body (strip MDX/markdown syntax)
+  const textContent = body
+    .replace(/import\s+.*?from\s+['"].*?['"]\s*;?\s*/g, '')
+    .replace(/export\s+.*?;?\s*/g, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]+)\]\(.*?\)/g, '$1')
+    .replace(/#{1,6}\s+/g, '')
+    .replace(/[*_~`]+/g, '')
+    .replace(/>\s+/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  return {
+    slug,
+    title: get('title'),
+    pubDate: get('pubDate'),
+    updatedDate: get('updatedDate'),
+    description: get('description'),
+    isDraft,
+    tags,
+    textContent,
+  };
+}
+
+// Get all post slugs
+async function getAllPostSlugs() {
+  const entries = await fs.readdir(POSTS_DIR, { withFileTypes: true });
+  const slugs = [];
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      try {
+        await fs.access(path.join(POSTS_DIR, entry.name, 'index.mdx'));
+        slugs.push(entry.name);
+      } catch {
+        // Skip directories without index.mdx
+      }
+    }
+  }
+
+  return slugs;
+}
+
+async function main() {
+  const { dryRun } = parseArgs();
+
+  console.log('\nStandard.site Publish');
+  console.log('='.repeat(50));
+
+  const config = await loadConfig();
+  if (!config.enabled) {
+    console.log('Standard.site not enabled yet. Run: npm run standard-site:setup');
+    process.exit(0);
+  }
+
+  const { did, publicationUri } = config;
+  console.log(`Publication: ${publicationUri}`);
+
+  // Read all posts
+  const slugs = await getAllPostSlugs();
+  const posts = [];
+  const publishedSlugs = new Set();
+
+  for (const slug of slugs) {
+    try {
+      const post = await readPost(slug);
+      if (!post || post.isDraft) continue;
+      posts.push(post);
+      publishedSlugs.add(slug);
+    } catch (err) {
+      console.error(`  Error reading ${slug}: ${err.message}`);
+    }
+  }
+
+  console.log(`Found ${posts.length} published posts`);
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would sync the following posts:');
+    for (const post of posts) {
+      console.log(`  + ${post.slug}: ${post.title}`);
+    }
+    console.log('\n[DRY RUN] Would also delete records for posts no longer published.');
+    process.exit(0);
+  }
+
+  // Load credentials
+  await loadEnv();
+  const password = process.env.BLUESKY_APP_PASSWORD;
+
+  if (!password) {
+    console.log('No BLUESKY_APP_PASSWORD set, skipping Standard.site publish.');
+    process.exit(0);
+  }
+
+  // Login
+  console.log(`\nLogging in as ${HANDLE}...`);
+  const agent = new AtpAgent({ service: 'https://bsky.social' });
+
+  try {
+    await agent.login({ identifier: HANDLE, password });
+  } catch (err) {
+    console.error('Error: Failed to login to Bluesky');
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  // Get existing document records to detect deletes
+  console.log('Fetching existing records...');
+  const existingRecords = new Map();
+  let cursor;
+  do {
+    const res = await agent.api.com.atproto.repo.listRecords({
+      repo: did,
+      collection: 'site.standard.document',
+      limit: 100,
+      cursor,
+    });
+    for (const record of res.data.records) {
+      const rkey = record.uri.split('/').pop();
+      existingRecords.set(rkey, record);
+    }
+    cursor = res.data.cursor;
+  } while (cursor);
+
+  console.log(`Existing records on PDS: ${existingRecords.size}`);
+
+  // Sync: create/update posts
+  let created = 0;
+  let updated = 0;
+  let deleted = 0;
+  let unchanged = 0;
+  let failed = 0;
+
+  for (const post of posts) {
+    const rkey = post.slug;
+    const existing = existingRecords.get(rkey);
+
+    const record = {
+      $type: 'site.standard.document',
+      site: publicationUri,
+      title: post.title,
+      path: `/post/${post.slug}/`,
+      publishedAt: new Date(post.pubDate).toISOString(),
+      textContent: post.textContent.slice(0, 100000),
+    };
+
+    if (post.description) record.description = post.description;
+    if (post.updatedDate) record.updatedAt = new Date(post.updatedDate).toISOString();
+    if (post.tags.length > 0) record.tags = post.tags;
+
+    // Check if update is needed by comparing key fields
+    if (existing) {
+      const val = existing.value;
+      const same = val.title === record.title
+        && val.path === record.path
+        && val.publishedAt === record.publishedAt
+        && val.description === record.description
+        && val.updatedAt === record.updatedAt;
+
+      if (same) {
+        unchanged++;
+        continue;
+      }
+    }
+
+    try {
+      await agent.api.com.atproto.repo.putRecord({
+        repo: did,
+        collection: 'site.standard.document',
+        rkey,
+        record,
+      });
+
+      if (existing) {
+        console.log(`  Updated: ${post.slug}`);
+        updated++;
+      } else {
+        console.log(`  Created: ${post.slug}`);
+        created++;
+      }
+    } catch (err) {
+      console.error(`  Failed ${post.slug}: ${err.message}`);
+      failed++;
+    }
+  }
+
+  // Delete records for posts that no longer exist or are now drafts
+  for (const [rkey] of existingRecords) {
+    if (!publishedSlugs.has(rkey)) {
+      try {
+        await agent.api.com.atproto.repo.deleteRecord({
+          repo: did,
+          collection: 'site.standard.document',
+          rkey,
+        });
+        console.log(`  Deleted: ${rkey}`);
+        deleted++;
+      } catch (err) {
+        console.error(`  Failed to delete ${rkey}: ${err.message}`);
+        failed++;
+      }
+    }
+  }
+
+  console.log(`\n${'='.repeat(50)}`);
+  console.log(`Created: ${created}, Updated: ${updated}, Unchanged: ${unchanged}, Deleted: ${deleted}, Failed: ${failed}`);
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/scripts/standard-site-setup.mjs
+++ b/scripts/standard-site-setup.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * Standard.site Setup Script
+ *
+ * One-time script to create a site.standard.publication record on your PDS
+ * and generate the config + .well-known verification file.
+ *
+ * Usage:
+ *   npm run standard-site:setup
+ *   npm run standard-site:setup -- --dry-run
+ *
+ * Environment variables (from .env.local):
+ *   BLUESKY_APP_PASSWORD - App password from https://bsky.app/settings/app-passwords
+ */
+
+import { AtpAgent } from '@atproto/api';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SITE_URL = 'https://gui.do';
+const HANDLE = 'gui.do';
+const SITE_NAME = 'Guido Jansen';
+const SITE_DESCRIPTION = 'Personal website of Guido Jansen - writing about technology, psychology, and e-commerce.';
+const WELL_KNOWN_DIR = path.join(__dirname, '..', 'public', '.well-known');
+const WELL_KNOWN_FILE = path.join(WELL_KNOWN_DIR, 'site.standard.publication');
+const CONFIG_FILE = path.join(__dirname, '..', 'src', 'config', 'standardSite.json');
+
+// Parse command line arguments
+function parseArgs() {
+  return { dryRun: process.argv.slice(2).includes('--dry-run') };
+}
+
+// Load environment variables from .env.local
+async function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  try {
+    const content = await fs.readFile(envPath, 'utf-8');
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed && !trimmed.startsWith('#')) {
+        const [key, ...valueParts] = trimmed.split('=');
+        const value = valueParts.join('=').replace(/^["']|["']$/g, '');
+        if (!process.env[key]) {
+          process.env[key] = value;
+        }
+      }
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
+// Write both config files from a publication URI and DID
+async function writeConfig(did, publicationUri) {
+  // Write .well-known file
+  await fs.mkdir(WELL_KNOWN_DIR, { recursive: true });
+  await fs.writeFile(WELL_KNOWN_FILE, publicationUri + '\n', 'utf-8');
+  console.log('  Created public/.well-known/site.standard.publication');
+
+  // Write Astro config
+  const config = { enabled: true, did, publicationUri };
+  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+  console.log('  Updated src/config/standardSite.json');
+}
+
+async function main() {
+  const { dryRun } = parseArgs();
+
+  console.log('\nStandard.site Setup');
+  console.log('='.repeat(50));
+
+  if (dryRun) {
+    console.log('\n[DRY RUN] Would create publication:');
+    console.log(`  Name: ${SITE_NAME}`);
+    console.log(`  URL: ${SITE_URL}`);
+    console.log(`  Description: ${SITE_DESCRIPTION}`);
+    console.log('\n[DRY RUN] Would write:');
+    console.log('  public/.well-known/site.standard.publication');
+    console.log('  src/config/standardSite.json');
+    process.exit(0);
+  }
+
+  // Load environment and check credentials
+  await loadEnv();
+  const password = process.env.BLUESKY_APP_PASSWORD;
+
+  if (!password) {
+    console.error('\nError: Missing BLUESKY_APP_PASSWORD');
+    console.error('Please create .env.local with:');
+    console.error('  BLUESKY_APP_PASSWORD=xxxx-xxxx-xxxx-xxxx');
+    console.error('\nGet an app password at: https://bsky.app/settings/app-passwords');
+    process.exit(1);
+  }
+
+  // Login
+  console.log(`\nLogging in as ${HANDLE}...`);
+  const agent = new AtpAgent({ service: 'https://bsky.social' });
+
+  try {
+    await agent.login({ identifier: HANDLE, password });
+  } catch (err) {
+    console.error('Error: Failed to login to Bluesky');
+    console.error(err.message);
+    process.exit(1);
+  }
+
+  const did = agent.session.did;
+  console.log(`DID: ${did}`);
+
+  // Check if a publication record already exists
+  console.log('\nChecking for existing publication records...');
+  try {
+    const existing = await agent.api.com.atproto.repo.listRecords({
+      repo: did,
+      collection: 'site.standard.publication',
+      limit: 10,
+    });
+
+    if (existing.data.records.length > 0) {
+      const record = existing.data.records[0];
+      console.log(`Found existing publication: ${record.value.name}`);
+      console.log(`AT-URI: ${record.uri}`);
+
+      await writeConfig(did, record.uri);
+
+      console.log(`\n${'='.repeat(50)}`);
+      console.log('Setup complete! Existing publication record reused.');
+      console.log('\nNext steps:');
+      console.log('  1. Commit the new files');
+      console.log('  2. Add BLUESKY_APP_PASSWORD to Netlify env vars');
+      console.log('  3. Deploy');
+      process.exit(0);
+    }
+  } catch (err) {
+    // Collection might not exist yet
+  }
+
+  // Create the publication record
+  console.log('\nCreating publication record...');
+  const response = await agent.api.com.atproto.repo.createRecord({
+    repo: did,
+    collection: 'site.standard.publication',
+    record: {
+      $type: 'site.standard.publication',
+      url: SITE_URL,
+      name: SITE_NAME,
+      description: SITE_DESCRIPTION,
+      preferences: {
+        showInDiscover: true,
+      },
+      createdAt: new Date().toISOString(),
+    },
+  });
+
+  const publicationUri = response.data.uri;
+  console.log(`Publication created: ${publicationUri}`);
+
+  await writeConfig(did, publicationUri);
+
+  console.log(`\n${'='.repeat(50)}`);
+  console.log('Setup complete!');
+  console.log('\nNext steps:');
+  console.log('  1. Commit the new files');
+  console.log('  2. Add BLUESKY_APP_PASSWORD to Netlify env vars');
+  console.log('  3. Deploy');
+}
+
+main().catch(err => {
+  console.error('Error:', err.message);
+  process.exit(1);
+});

--- a/src/config/standardSite.json
+++ b/src/config/standardSite.json
@@ -1,0 +1,5 @@
+{
+  "enabled": true,
+  "did": "did:plc:45uheisi25szrjvjurfpritx",
+  "publicationUri": "at://did:plc:45uheisi25szrjvjurfpritx/site.standard.publication/3mgfeypogdk2r"
+}

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -9,6 +9,7 @@ import { MarkdownAlternateLink } from "astro-md-alternate/components";
 
 // data
 import siteSettings from "@config/siteSettings.json";
+import standardSiteConfig from "@config/standardSite.json";
 import { CONFIG } from "../config"; // Use .env for indexing
 
 export interface Props {
@@ -140,6 +141,13 @@ const noindex = !CONFIG.ALLOW_INDEXING;
 
 <!-- Markdown alternate for AI agents (blog posts only) -->
 <MarkdownAlternateLink patterns={["/post/"]} />
+
+{/* Standard.site document verification (ATProto long-form publishing) */}
+{standardSiteConfig.enabled && type === "blog" && (() => {
+  const slug = Astro.url.pathname.replace(/^\/post\//, '').replace(/\/$/, '');
+  const href = `at://${standardSiteConfig.did}/site.standard.document/${slug}`;
+  return <link rel="site.standard.document" href={href} />;
+})()}
 
 <!-- Performance optimizations -->
 <PassiveEvents />


### PR DESCRIPTION
## Summary
- Adds [Standard.site](https://standard.site) support to publish blog posts as `site.standard.document` records on ATProto
- Makes the site discoverable in ATProto readers (Leaflet, pckt, docs.surf) and Bluesky clients (Heron)
- Syncs posts automatically at build time (creates new, updates changed, deletes removed/drafted)

## How it works
- **Build-time sync**: `standard-site-publish.mjs` runs before `astro build`, syncing all published posts to the PDS
- **Deterministic URIs**: Uses post slug as ATProto record key, so `<link>` verification tags can be computed without storing URIs in frontmatter
- **Verification**: `.well-known/site.standard.publication` endpoint + `<link rel="site.standard.document">` tags on each post
- **No new dependencies**: Uses existing `@atproto/api` package

## Files
- `scripts/standard-site-setup.mjs` - One-time setup (already run, publication record created)
- `scripts/standard-site-publish.mjs` - Build-time post sync (create/update/delete)
- `src/config/standardSite.json` - DID + publication URI config
- `public/.well-known/site.standard.publication` - Verification endpoint
- `src/layouts/BaseHead.astro` - Document verification link tag
- `package.json` - Build command + npm scripts

## Prerequisites before merge
- [x] Publication record created on PDS
- [x] `.well-known` verification file generated
- [ ] Add `BLUESKY_APP_PASSWORD` to Netlify environment variables

## Test plan
- [ ] Verify `npm run standard-site:publish -- --dry-run` lists posts correctly
- [ ] Verify build succeeds with `npm run build`
- [ ] After deploy, check `https://gui.do/.well-known/site.standard.publication` returns the AT-URI
- [ ] After deploy, check a blog post's HTML contains `<link rel="site.standard.document">`
- [ ] Verify posts appear on [Standard.site validator](https://site-validator.fly.dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)