### PR TITLE
style: fix prettier formatting in BaseHead.astro

### DIFF
--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -143,11 +143,17 @@ const noindex = !CONFIG.ALLOW_INDEXING;
 <MarkdownAlternateLink patterns={["/post/"]} />
 
 {/* Standard.site document verification (ATProto long-form publishing) */}
-{standardSiteConfig.enabled && type === "blog" && (() => {
-  const slug = Astro.url.pathname.replace(/^\/post\//, '').replace(/\/$/, '');
-  const href = `at://${standardSiteConfig.did}/site.standard.document/${slug}`;
-  return <link rel="site.standard.document" href={href} />;
-})()}
+{
+  standardSiteConfig.enabled &&
+    type === "blog" &&
+    (() => {
+      const slug = Astro.url.pathname
+        .replace(/^\/post\//, "")
+        .replace(/\/$/, "");
+      const href = `at://${standardSiteConfig.did}/site.standard.document/${slug}`;
+      return <link rel="site.standard.document" href={href} />;
+    })()
+}
 
 <!-- Performance optimizations -->
 <PassiveEvents />


### PR DESCRIPTION
## Summary
- Fix pre-existing prettier formatting failure in `src/layouts/BaseHead.astro`
- Standard.site document verification block reformatted to match prettier config

## Changes
- `src/layouts/BaseHead.astro`: Multi-line ternary reformatted, single quotes → double quotes

## Test plan
- [ ] CI passes (Format check should now pass)