### PR TITLE
fix(security): loop HTML tag stripping to handle incomplete sequences

### DIFF
--- a/scripts/standard-site-publish.mjs
+++ b/scripts/standard-site-publish.mjs
@@ -101,10 +101,13 @@ async function readPost(slug) {
   }
 
   // Extract plain text from body (strip MDX/markdown syntax)
-  const textContent = body
+  let stripped = body
     .replace(/import\s+.*?from\s+['"].*?['"]\s*;?\s*/g, '')
-    .replace(/export\s+.*?;?\s*/g, '')
-    .replace(/<[^>]+>/g, '')
+    .replace(/export\s+.*?;?\s*/g, '');
+  // Loop HTML tag removal until stable to handle incomplete multi-char sequences
+  let prev;
+  do { prev = stripped; stripped = stripped.replace(/<[^>]+>/g, ''); } while (stripped !== prev);
+  const textContent = stripped
     .replace(/!\[.*?\]\(.*?\)/g, '')
     .replace(/\[([^\]]+)\]\(.*?\)/g, '$1')
     .replace(/#{1,6}\s+/g, '')


### PR DESCRIPTION
## Summary
- Fix CodeQL alert #24: incomplete multi-character sanitization in `standard-site-publish.mjs`
- Loop the HTML tag regex removal until the string is stable, preventing partial tag sequences from surviving

## Changes
- `scripts/standard-site-publish.mjs` - Replace single-pass `replace(/<[^>]+>/g, '')` with a do/while loop

## Test plan
- [ ] CI passes
- [ ] CodeQL alert #24 resolves