### PR TITLE
feat: add rel="me" link to Sifa identity page

### DIFF
--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -139,6 +139,7 @@ const noindex = !CONFIG.ALLOW_INDEXING;
 <!-- other -->
 <meta name="generator" content={Astro.generator} />
 <link rel="sitemap" href="/sitemap-index.xml" />
+<link rel="me" href="https://sifa.id/p/gui.do" />
 
 <!-- TODO: Re-enable after updating astro-md-alternate for Astro 6 -->
 <!-- <MarkdownAlternateLink patterns={["/post/"]} /> -->


### PR DESCRIPTION
## Summary
- Adds `<link rel="me" href="https://sifa.id/p/gui.do" />` to BaseHead.astro for cross-site identity verification

## Test plan
- [ ] Verify the link appears in the `<head>` of all pages
- [ ] Confirm identity verification works on sifa.id

Generated with [Claude Code](https://claude.com/claude-code)