### PR TITLE
content(blog): link ATmosphere Conf 2026 post to Bluesky thread

### DIFF
--- a/src/content/post/atmosphere-conf-2026/index.mdx
+++ b/src/content/post/atmosphere-conf-2026/index.mdx
@@ -7,6 +7,7 @@ authors:
 pubDate: 2026-03-31
 heroImage: ./heroImage.jpg
 heroImageAlt: "Selfie at ATmosphere Conf 2026 in Vancouver, showing the main conference hall with hundreds of attendees"
+blueskyUri: "https://bsky.app/profile/gui.do/post/3micqgbodp22f"
 categories:
   - Technology
   - AT Protocol

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -220,6 +220,19 @@
     @apply text-base-600 dark:text-base-400 text-sm mb-4;
   }
 
+  /* Constrain SVG icons to library's intended size */
+  [class*="_icon_"] {
+    width: 1.25rem !important;
+    height: 1.25rem !important;
+  }
+
+  [class*="_statItem_"] svg,
+  [class*="_actionsRow_"] svg {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+  }
+
   /* Style the reply text */
   [class*="_replyText_"] {
     @apply text-base-600 dark:text-base-400;


### PR DESCRIPTION
## Summary
- Add `blueskyUri` frontmatter to ATmosphere Conf 2026 post, linking it to the Bluesky discussion thread for comments

## Test plan
- [ ] CI checks pass
- [ ] Post at gui.do/post/atmosphere-conf-2026/ shows Bluesky comments section