### PR TITLE
fix(styles): use !important on all Bluesky comment icon size rules

### DIFF
--- a/src/content/post/atmosphere-conf-2026/index.mdx
+++ b/src/content/post/atmosphere-conf-2026/index.mdx
@@ -41,7 +41,10 @@ The participant mix was interesting too. Older folks (like me) who remember the 
 
 > the ecosystem is delicate. there's a LOT of enthusiasm + talent, but: no magical investor monies, grant options are THIN, many first time founders, many don't want investment, few other options, scary macro env. it's a collective challenge. we can just pay for things?
 >
-> <footer>[Dietrich Ayala](https://sifa.id/p/burrito.space), [on Bluesky](https://bsky.app/profile/burrito.space/post/3mi4ymt3lqs2k)</footer>
+> <footer>
+>   [Dietrich Ayala](https://sifa.id/p/burrito.space), [on
+>   Bluesky](https://bsky.app/profile/burrito.space/post/3mi4ymt3lqs2k)
+> </footer>
 
 ## Why that last point matters to me
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -220,16 +220,15 @@
     @apply text-base-600 dark:text-base-400 text-sm mb-4;
   }
 
-  /* Constrain SVG icons to library's intended size */
-  [class*="_icon_"] {
+  /* Constrain SVG icons to library's intended size.
+     .prose svg sets h-auto which overrides the library's sizing,
+     so we need !important on all size rules here. */
+  svg[class*="_icon_"],
+  [class*="_statItem_"] svg,
+  [class*="_actionsRow_"] svg,
+  [class*="_actionsContainer_"] svg {
     width: 1.25rem !important;
     height: 1.25rem !important;
-  }
-
-  [class*="_statItem_"] svg,
-  [class*="_actionsRow_"] svg {
-    width: 1.25rem;
-    height: 1.25rem;
     flex-shrink: 0;
   }
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,10 +1,10 @@
 /* Import Component Styles */
-@use './utilities/utilities';
-@use './components/alerts';
-@use './components/cards';
-@use './components/links';
-@use './base/typography';
-@use './prose';
+@use "./utilities/utilities";
+@use "./components/alerts";
+@use "./components/cards";
+@use "./components/links";
+@use "./base/typography";
+@use "./prose";
 
 /* Base Styles */
 @tailwind base;
@@ -30,7 +30,7 @@
 @layer components {
   /* Card Base Styles */
   .card {
-    @apply bg-base-50 dark:bg-base-900 rounded-xl shadow-lg transition-all duration-300 overflow-hidden;
+    @apply overflow-hidden rounded-xl bg-base-50 shadow-lg transition-all duration-300 dark:bg-base-900;
   }
 
   .card-container {
@@ -38,15 +38,15 @@
   }
 
   .card-content {
-    @apply p-4 sm:p-6 md:p-8 flex flex-col;
+    @apply flex flex-col p-4 sm:p-6 md:p-8;
   }
 
   .card-title {
-    @apply text-xl font-semibold mb-4 text-base-900 dark:text-base-100;
+    @apply mb-4 text-xl font-semibold text-base-900 dark:text-base-100;
   }
 
   .card-meta {
-    @apply text-sm text-base-500 dark:text-base-400 flex flex-wrap gap-2 mb-4;
+    @apply mb-4 flex flex-wrap gap-2 text-sm text-base-500 dark:text-base-400;
   }
 
   .cards-grid {
@@ -56,21 +56,21 @@
   /* Card Media */
   .card img:first-child,
   .card iframe:first-child {
-    @apply aspect-video object-cover mb-0;
+    @apply mb-0 aspect-video object-cover;
   }
 
   /* Video Card */
   .lazy-youtube {
-    @apply aspect-video relative;
+    @apply relative aspect-video;
 
     img {
-      @apply w-full h-full object-cover;
+      @apply h-full w-full object-cover;
     }
   }
 
   /* Horizontal Scroll Container */
   .scroll-container {
-    @apply flex overflow-x-auto gap-3 pb-6 snap-x snap-mandatory px-2;
+    @apply flex snap-x snap-mandatory gap-3 overflow-x-auto px-2 pb-6;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -86,7 +86,7 @@
   }
 
   .scroll-item {
-    @apply flex-none snap-center w-[calc(100%-1rem)] sm:w-[calc(50%-0.5rem)] max-w-full box-border;
+    @apply box-border w-[calc(100%-1rem)] max-w-full flex-none snap-center sm:w-[calc(50%-0.5rem)];
   }
 
   /* Carousel Header and Progress */
@@ -95,29 +95,29 @@
   }
 
   .carousel-progress {
-    @apply flex gap-2 justify-center items-center mt-2;
+    @apply mt-2 flex items-center justify-center gap-2;
   }
 
   .progress-dot {
-    @apply w-2 h-2 rounded-full transition-all duration-300;
+    @apply h-2 w-2 rounded-full transition-all duration-300;
     @apply bg-base-300 dark:bg-base-600;
 
     &[data-active="true"] {
-      @apply w-3 h-3;
+      @apply h-3 w-3;
       @apply bg-primary-500 dark:bg-primary-400;
     }
   }
 
   /* Navigation Buttons */
   .nav-button {
-    @apply absolute top-1/2 -translate-y-1/2 z-10;
-    @apply w-12 h-12 flex items-center justify-center;
-    @apply bg-base-50/95 dark:bg-base-800/95 rounded-full;
-    @apply text-base-800 dark:text-base-200 text-2xl;
+    @apply absolute top-1/2 z-10 -translate-y-1/2;
+    @apply flex h-12 w-12 items-center justify-center;
+    @apply rounded-full bg-base-50/95 dark:bg-base-800/95;
+    @apply text-2xl text-base-800 dark:text-base-200;
     @apply shadow-lg transition-all duration-300;
     @apply hover:bg-base-100 dark:hover:bg-base-700;
     @apply focus:outline-none focus:ring-2 focus:ring-primary-500;
-    @apply disabled:opacity-30 disabled:cursor-not-allowed;
+    @apply disabled:cursor-not-allowed disabled:opacity-30;
     @apply disabled:hover:bg-base-50/95 dark:disabled:hover:bg-base-800/95;
     /* Improved touch target size */
     @apply touch-manipulation;
@@ -132,7 +132,7 @@
 
     /* Prevent button clicks from triggering card links */
     &::before {
-      content: '';
+      content: "";
       @apply absolute inset-0;
     }
 
@@ -143,9 +143,8 @@
   }
 
   .site-container {
-    @apply mx-auto max-w-7xl w-full box-border px-2 sm:px-4;
+    @apply mx-auto box-border w-full max-w-7xl px-2 sm:px-4;
   }
-
 
   /* Z-index Management */
   .z-background {
@@ -185,12 +184,12 @@
   }
   to {
     outline-offset: 3px;
-    outline-color: theme('colors.primary.500');
+    outline-color: theme("colors.primary.500");
   }
 }
 
 :focus-visible {
-  outline: 2px solid theme('colors.primary.500');
+  outline: 2px solid theme("colors.primary.500");
   outline-offset: 3px;
   animation: focus-ring-expand 0.2s cubic-bezier(0.33, 1, 0.68, 1);
 }
@@ -211,13 +210,13 @@
 .bluesky-comments-wrapper {
   /* Style the library's "Comments" title to match our design */
   [class*="_commentsTitle_"] {
-    @apply text-xl font-bold mb-4 text-base-900 dark:text-base-100;
+    @apply mb-4 text-xl font-bold text-base-900 dark:text-base-100;
     margin-top: 0 !important; /* Override library's margin-top */
   }
 
   /* Style the stats bar (likes, reposts, etc.) */
   [class*="_statsBar_"] {
-    @apply text-base-600 dark:text-base-400 text-sm mb-4;
+    @apply mb-4 text-sm text-base-600 dark:text-base-400;
   }
 
   /* Constrain SVG icons to library's intended size.
@@ -291,12 +290,12 @@
 
   /* Actions container */
   [class*="_actionsContainer_"] {
-    @apply text-base-500 dark:text-base-400 text-xs;
+    @apply text-xs text-base-500 dark:text-base-400;
   }
 
   /* Show more button */
   [class*="_showMoreButton_"] {
-    @apply text-base-600 dark:text-base-300 border-base-300 dark:border-base-600;
+    @apply border-base-300 text-base-600 dark:border-base-600 dark:text-base-300;
     @apply hover:bg-base-100 dark:hover:bg-base-800;
     @apply rounded-md px-3 py-1.5;
     background: transparent !important;


### PR DESCRIPTION
## Summary
- Consolidate Bluesky comment icon size selectors and use `!important` on all of them
- Previous fix (#75) didn't fully resolve the issue because Tailwind preflight makes SVGs block-level, overriding the library's CSS module sizes
- Add `svg[class*="_icon_"]` and `[class*="_actionsContainer_"] svg` selectors for full coverage

## Test plan
- [ ] CI checks pass
- [ ] Bluesky comment stats bar icons (heart/repost/reply) render at ~20px, not full-width
- [ ] Check on /post/introducing-barazo-community-forums/