### PR TITLE
fix(blog): update broken Business of Belonging link

### DIFF
--- a/src/content/post/how-to-build-an-online-b2b-community/index.mdx
+++ b/src/content/post/how-to-build-an-online-b2b-community/index.mdx
@@ -218,7 +218,7 @@ If you made it this far down then A) I'm impressed and B) you might be eager to 
 
 2. Books:
    - [The Art of Community](https://www.jonobacon.com/books/artofcommunity/) and [People Powered](https://www.jonobacon.com/books/peoplepowered/) by [Jono Bacon](https://www.linkedin.com/in/jonobacon/)
-   - [The Businesss of Belonging](https://davidspinks.com/book/) by [David Spinks](https://www.linkedin.com/in/davidspinks/)
+   - [The Businesss of Belonging](https://www.davidspinks.com/) by [David Spinks](https://www.linkedin.com/in/davidspinks/)
 
 3. Podcasts:
    - [In Before The Lock](https://ib4tl.fm/), by Erica Kuhl and [Brian Oblinger](https://www.linkedin.com/in/brianoblinger/)


### PR DESCRIPTION
## Summary
- `davidspinks.com/book/` returns 404. Updated to `https://www.davidspinks.com/` (verified live, 200 OK).
- Fixes the `validateUrls.test.ts` failure that's been red on master since 2026-04-29.

## Test plan
- [x] Replacement URL returns HTTP 200
- [ ] Test job passes after merge