### PR TITLE
chore(deps): bump astro-embed 0.12→0.13 and prettier-plugin-tailwindcss 0.7→0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "animejs": "^3.2.2",
         "astro": "^6.2.1",
         "astro-auto-import": "^0.5.1",
-        "astro-embed": "^0.12.0",
+        "astro-embed": "^0.13.0",
         "astro-icon": "^1.1.5",
         "astro-seo": "^0.8.4",
         "autoprefixer": "^10.4.27",
@@ -58,7 +58,7 @@
         "jsdom": "^27.4.0",
         "lightningcss": "^1.31.1",
         "prettier-plugin-astro": "^0.14.0",
-        "prettier-plugin-tailwindcss": "^0.7.2",
+        "prettier-plugin-tailwindcss": "^0.8.0",
         "svgo": "^2.8.2",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
@@ -181,75 +181,16 @@
       }
     },
     "node_modules/@astro-community/astro-embed-bluesky": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-bluesky/-/astro-embed-bluesky-0.1.6.tgz",
-      "integrity": "sha512-3y6Y3cRelLnR9AYMItmEAjcr83KAEa6WvsxQ1eHq1cPBzICXknuzphaZlmQZ+QG5NTtmEJD+2lQWrFba/BfM1A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-bluesky/-/astro-embed-bluesky-0.2.1.tgz",
+      "integrity": "sha512-rp6pgyEviUH+ysVCVi6bGcHycFSBTc7q3u5IDNyZOiGtCL4BCurDyDvanbKRVlgn50TWKBziomXxvHSLzQPTQQ==",
       "license": "MIT",
       "dependencies": {
-        "@atproto/api": "^0.13.14"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/@atproto/api": {
-      "version": "0.13.35",
-      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.13.35.tgz",
-      "integrity": "sha512-vsEfBj0C333TLjDppvTdTE0IdKlXuljKSveAeI4PPx/l6eUKNnDTsYxvILtXUVzwUlTDmSRqy5O4Ryh78n1b7g==",
-      "license": "MIT",
-      "dependencies": {
-        "@atproto/common-web": "^0.4.0",
-        "@atproto/lexicon": "^0.4.6",
-        "@atproto/syntax": "^0.3.2",
-        "@atproto/xrpc": "^0.6.8",
-        "await-lock": "^2.2.2",
-        "multiformats": "^9.9.0",
-        "tlds": "^1.234.0",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/@atproto/lexicon": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@atproto/lexicon/-/lexicon-0.4.14.tgz",
-      "integrity": "sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@atproto/common-web": "^0.4.2",
-        "@atproto/syntax": "^0.4.0",
-        "iso-datestring-validator": "^2.2.2",
-        "multiformats": "^9.9.0",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/@atproto/lexicon/node_modules/@atproto/syntax": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.4.3.tgz",
-      "integrity": "sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.1"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/@atproto/syntax": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@atproto/syntax/-/syntax-0.3.4.tgz",
-      "integrity": "sha512-8CNmi5DipOLaVeSMPggMe7FCksVag0aO6XZy9WflbduTKM4dFZVCs4686UeMLfGRXX+X966XgwECHoLYrovMMg==",
-      "license": "MIT"
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/@atproto/xrpc": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/@atproto/xrpc/-/xrpc-0.6.12.tgz",
-      "integrity": "sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@atproto/lexicon": "^0.4.10",
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-bluesky/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+        "@atcute/atproto": "^3.1.11",
+        "@atcute/bluesky": "^3.3.3",
+        "@atcute/bluesky-richtext-segmenter": "^3.0.0",
+        "@atcute/client": "^4.2.1",
+        "@atcute/lexicons": "^1.3.0"
       }
     },
     "node_modules/@astro-community/astro-embed-gist": {
@@ -262,39 +203,24 @@
       }
     },
     "node_modules/@astro-community/astro-embed-integration": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-integration/-/astro-embed-integration-0.11.0.tgz",
-      "integrity": "sha512-xmwXN8039zUT0/lBO2GUr8cm5t/v+9Fh8QkPUhTWy+A7RR0+PwT1M3PBm8q01A1rK9q0myOyFHEcSOp+WkH5tg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@astro-community/astro-embed-integration/-/astro-embed-integration-0.12.0.tgz",
+      "integrity": "sha512-ozw6ObA5/6tEEynitxKJAtiuSeAaXQmlD1SWbvlCz1vaYyDW9So7xHFVaHtqFYVhonAW3k/9scTJC98cu6xI8Q==",
       "license": "MIT",
       "dependencies": {
-        "@astro-community/astro-embed-bluesky": "^0.1.6",
+        "@astro-community/astro-embed-bluesky": "^0.2.0",
         "@astro-community/astro-embed-gist": "^0.1.0",
-        "@astro-community/astro-embed-link-preview": "^0.3.0",
-        "@astro-community/astro-embed-mastodon": "^0.1.0",
-        "@astro-community/astro-embed-twitter": "^0.5.10",
+        "@astro-community/astro-embed-link-preview": "^0.3.1",
+        "@astro-community/astro-embed-mastodon": "^0.1.1",
+        "@astro-community/astro-embed-twitter": "^0.5.11",
         "@astro-community/astro-embed-vimeo": "^0.3.12",
         "@astro-community/astro-embed-youtube": "^0.5.10",
         "@types/unist": "^3.0.3",
-        "astro-auto-import": "^0.4.5",
+        "astro-auto-import": "^0.5.1",
         "unist-util-select": "^5.1.0"
       },
       "peerDependencies": {
         "astro": "^5.0.0 || ^6.0.0-alpha"
-      }
-    },
-    "node_modules/@astro-community/astro-embed-integration/node_modules/astro-auto-import": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/astro-auto-import/-/astro-auto-import-0.4.6.tgz",
-      "integrity": "sha512-8EgeOTChgHX6x31s2CjeOUCDuG2s0wgT9D9zXI4CxgmljEoJeCAWIq/henhdmvZ+Y103MfH7CYNw5VW7GiM6xQ==",
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.8.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "astro": "^2.0.0 || ^3.0.0-beta || ^4.0.0-beta || ^5.0.0-beta"
       }
     },
     "node_modules/@astro-community/astro-embed-link-preview": {
@@ -587,6 +513,78 @@
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.2"
+      }
+    },
+    "node_modules/@atcute/atproto": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@atcute/atproto/-/atproto-3.1.11.tgz",
+      "integrity": "sha512-yh+ASvA+iHHQij6UeHEKp2+rwvFvQR8A6/5Dk/xvqDslIikWEFx9VlprNwm/clQIPl2bLuQg+LHS8uY9o5nFTA==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.2.10"
+      }
+    },
+    "node_modules/@atcute/bluesky": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky/-/bluesky-3.3.3.tgz",
+      "integrity": "sha512-R1VyEmbvIUhub6ONnt7sm6FcRoKJISWf+I0qraXtk59KLmNCsJYMX8fLdIcdv5o1i9XtDg8/Um/wqLrl84IuFg==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/atproto": "^3.1.11",
+        "@atcute/lexicons": "^1.3.0"
+      }
+    },
+    "node_modules/@atcute/bluesky-richtext-segmenter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky-richtext-segmenter/-/bluesky-richtext-segmenter-3.0.0.tgz",
+      "integrity": "sha512-NhZTUKtFpeBBbILwAcxj5u4RobIoHOmGw3CAaaEFNebKYSvmTecrXJ7XufHw5DFOUdr8SiKXQVRQxGAxulMNWg==",
+      "license": "0BSD"
+    },
+    "node_modules/@atcute/client": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@atcute/client/-/client-4.2.1.tgz",
+      "integrity": "sha512-ZBFM2pW075JtgGFu5g7HHZBecrClhlcNH8GVP9Zz1aViWR+cjjBsTpeE63rJs+FCOHFYlirUyo5L8SGZ4kMINw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/identity": "^1.1.3",
+        "@atcute/lexicons": "^1.2.6"
+      }
+    },
+    "node_modules/@atcute/identity": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@atcute/identity/-/identity-1.1.4.tgz",
+      "integrity": "sha512-RCw1IqflfuSYCxK5m0lZCm0UnvIzcUnuhngiBhJEJb9a9Mc2SEf1xP3H8N5r8pvEH1LoAYd6/zrvCNU+uy9esw==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.2.9",
+        "@badrap/valita": "^0.4.6"
+      }
+    },
+    "node_modules/@atcute/lexicons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@atcute/lexicons/-/lexicons-1.3.0.tgz",
+      "integrity": "sha512-Eq5y+9onnCXNVUlNiMf31beSXHKqptB7lUo/68YbhlmxdaR7ooywHmahya9goP5AsmlYEA1z+dRPXIDAa9O7cg==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/uint8array": "^1.1.1",
+        "@atcute/util-text": "^1.2.0",
+        "@standard-schema/spec": "^1.1.0",
+        "esm-env": "^1.2.2"
+      }
+    },
+    "node_modules/@atcute/uint8array": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@atcute/uint8array/-/uint8array-1.1.1.tgz",
+      "integrity": "sha512-3LsC8XB8TKe9q/5hOA5sFuzGaIFdJZJNewC5OKa3o/eU6+K7JR6see9Zy2JbQERNVnRl11EzbNov1efgLMAs4g==",
+      "license": "0BSD"
+    },
+    "node_modules/@atcute/util-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@atcute/util-text/-/util-text-1.3.1.tgz",
+      "integrity": "sha512-MRgJXkx67znuBXuoAYCJkBZyd3OApL7zZlNf5kXhuoCXcdiu1nblRDycYTADSkym4epBSQWxh26kmI9sewaq6A==",
+      "license": "0BSD",
+      "dependencies": {
+        "unicode-segmenter": "^0.14.5"
       }
     },
     "node_modules/@atproto/api": {
@@ -995,6 +993,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@badrap/valita": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@badrap/valita/-/valita-0.4.6.tgz",
+      "integrity": "sha512-4kdqcjyxo/8RQ8ayjms47HCWZIF5981oE5nIenbfThKDxWXtEHKipAOWlflpPJzZx9y/JWYQkp18Awr7VuepFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@capsizecss/unpack": {
@@ -5218,6 +5225,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@sveltejs/acorn-typescript": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
@@ -6558,18 +6571,18 @@
       }
     },
     "node_modules/astro-embed": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/astro-embed/-/astro-embed-0.12.0.tgz",
-      "integrity": "sha512-Hp/zfIFsibBSCXEC09Lk38uYq5IJyXClbNASiT/06fqrMvgWJzPEPvtnCEo1qIw8hxIh+4+esAJoktu5YKRIEA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/astro-embed/-/astro-embed-0.13.0.tgz",
+      "integrity": "sha512-SIp+ES9zYpCOLGJbbgnzbzjmSeYvNXteHnOwD1tu3UX5cyeQ6eOFRBos6a96pyJ7GQxdcn/R/NK1KUH/h/Mamg==",
       "license": "MIT",
       "dependencies": {
         "@astro-community/astro-embed-baseline-status": "^0.2.2",
-        "@astro-community/astro-embed-bluesky": "^0.1.6",
+        "@astro-community/astro-embed-bluesky": "^0.2.0",
         "@astro-community/astro-embed-gist": "^0.1.0",
-        "@astro-community/astro-embed-integration": "^0.11.0",
-        "@astro-community/astro-embed-link-preview": "^0.3.0",
-        "@astro-community/astro-embed-mastodon": "^0.1.0",
-        "@astro-community/astro-embed-twitter": "^0.5.10",
+        "@astro-community/astro-embed-integration": "^0.12.0",
+        "@astro-community/astro-embed-link-preview": "^0.3.1",
+        "@astro-community/astro-embed-mastodon": "^0.1.1",
+        "@astro-community/astro-embed-twitter": "^0.5.11",
         "@astro-community/astro-embed-vimeo": "^0.3.12",
         "@astro-community/astro-embed-youtube": "^0.5.10"
       },
@@ -9011,6 +9024,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -14834,9 +14853,9 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.7.4.tgz",
-      "integrity": "sha512-UKii4RjY05SNt/WQi6/NcOn/LsT0/ILLXsxygjbRg5/YZelsSu5jTqorYHPDGq4nZy5q5hpCu+XdGZ1xaJEQgw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "animejs": "^3.2.2",
     "astro": "^6.2.1",
     "astro-auto-import": "^0.5.1",
-    "astro-embed": "^0.12.0",
+    "astro-embed": "^0.13.0",
     "astro-icon": "^1.1.5",
     "astro-seo": "^0.8.4",
     "autoprefixer": "^10.4.27",
@@ -73,7 +73,7 @@
     "jsdom": "^27.4.0",
     "lightningcss": "^1.31.1",
     "prettier-plugin-astro": "^0.14.0",
-    "prettier-plugin-tailwindcss": "^0.7.2",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "svgo": "^2.8.2",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"


### PR DESCRIPTION
## Summary

The final two items from dependabot bundle #90. These are 0.x-minor bumps that npm caret ranges treat as breaking, so they didn't update via `npm update` in #91 and need explicit installs.

After this lands, all 18 other items in #90 are already covered by #91 — #90 can be closed.

## Test plan
- [x] `astro check` — 0 errors
- [x] `prettier --check` — clean
- [x] `astro build` — completes successfully
- [ ] Test job + Netlify preview pass on CI