### PR TITLE
fix(retainer): chip overlap on timeline + missing list bullets

### DIFF
--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -493,7 +493,7 @@ const testimonials = [
         <ol class="space-y-10 border-l-2 border-primary-500/30 pl-8">
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               W1
@@ -513,7 +513,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               ✕12
@@ -533,7 +533,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               ✕6
@@ -552,7 +552,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               M3
@@ -571,7 +571,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               M6
@@ -591,7 +591,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white"
               aria-hidden="true"
             >
               ↻
@@ -610,7 +610,7 @@ const testimonials = [
 
           <li class="relative">
             <span
-              class="absolute -left-[2.4rem] flex h-12 w-12 items-center justify-center rounded-full bg-base-300 text-sm font-bold text-base-900 dark:bg-base-700 dark:text-base-100"
+              class="absolute -left-[3.5rem] flex h-12 w-12 items-center justify-center rounded-full bg-base-300 text-sm font-bold text-base-900 dark:bg-base-700 dark:text-base-100"
               aria-hidden="true"
             >
               ⇄
@@ -653,7 +653,9 @@ const testimonials = [
         <div class="grid gap-10 md:grid-cols-2">
           <div>
             <h3 class="h3 mb-4 text-base-900 dark:text-base-100">In scope</h3>
-            <ul class="space-y-2 text-base-700 dark:text-base-300">
+            <ul
+              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+            >
               <li>Community / DevRel / ecosystem strategy</li>
               <li>
                 Community ops design: governance, contribution structures,
@@ -673,7 +675,9 @@ const testimonials = [
             <h3 class="h3 mb-4 text-base-900 dark:text-base-100">
               Out of scope
             </h3>
-            <ul class="space-y-2 text-base-700 dark:text-base-300">
+            <ul
+              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+            >
               <li>Implementation or hands-on community management</li>
               <li>Content production for your community</li>
               <li>Hands-on engineering, SDK work, or demo coding</li>
@@ -688,7 +692,9 @@ const testimonials = [
             class="rounded-2xl border border-pine/30 bg-pine/5 p-6 dark:border-pine/40 dark:bg-pine/10"
           >
             <h3 class="h3 mb-4 text-base-900 dark:text-base-100">Good fit</h3>
-            <ul class="space-y-2 text-base-700 dark:text-base-300">
+            <ul
+              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+            >
               <li>Series A–C company, technical or developer-led product</li>
               <li>
                 Has product traction but no senior community/ecosystem hire yet,
@@ -706,7 +712,9 @@ const testimonials = [
             class="rounded-2xl border border-love/30 bg-love/5 p-6 dark:border-love/40 dark:bg-love/10"
           >
             <h3 class="h3 mb-4 text-base-900 dark:text-base-100">Not a fit</h3>
-            <ul class="space-y-2 text-base-700 dark:text-base-300">
+            <ul
+              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+            >
               <li>
                 Need someone to <em>run</em> community ops. This is advisory, not
                 fractional execution.


### PR DESCRIPTION
## Summary

Two visual fixes on the live `/retainer` page:

1. **Timeline chip overlap.** The W1 / ✕12 / ✕6 / M3 / M6 / ↻ / ⇄ chips on Section 03 were overlapping the h3 titles. Changed the chip offset from `-left-[2.4rem]` to `-left-[3.5rem]` so the chip's center sits on the spine border line instead of bleeding into the content area.

   Math: chip is `w-12` (3rem) wide. The `<ol>` has `pl-8` (2rem) padding plus a left border. To center the chip on the border line, the chip's left edge needs to be at `-(2rem + 1.5rem) = -3.5rem` from the `<li>` content. Old value of `-2.4rem` put the chip's right edge at `+0.6rem` past the li content edge, causing the overlap.

2. **Missing list markers in scope/fit section.** The `In scope`, `Out of scope`, `Good fit`, and `Not a fit` lists had no visible bullets because Tailwind preflight resets list styles. Added `list-disc pl-5` to all four `<ul>` elements, matching the existing styling already used in the application form section.

## Test plan

- [ ] CI checks pass
- [ ] Deploy preview: timeline chips no longer overlap any h3 in Section 03
- [ ] Deploy preview: bullet markers visible on all four scope/fit lists
- [ ] Mobile responsive: chips still positioned correctly at narrow widths
- [ ] No regression on the existing application-form bullet list