### PR TITLE
fix(retainer): tweak about copy — multiple times + B2B Enterprise framing

### DIFF
--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -187,10 +187,9 @@ const testimonials = [
           >
             <p>
               I'm <strong>Guido X Jansen</strong>. I've built community
-              functions from zero three times: as a volunteer founder (Dutchento
-              / Meet Magento), as a creator (CRO.CAFE), and as an employee
-              leading the function (Spryker). Same pattern, three different
-              stages.
+              functions from zero multiple times: as a volunteer founder
+              (Dutchento / Meet Magento), as a creator (CRO.CAFE), and in B2B
+              Enterprise leading the function (Spryker).
             </p>
             <p>
               My background is cognitive psychology, then conversion


### PR DESCRIPTION
## Summary

Small copy adjustment in the About section of `/retainer`:

- "from zero three times" → "from zero multiple times" (less rigid count, more honest about the pattern continuing)
- "as an employee leading the function (Spryker)" → "in B2B Enterprise leading the function (Spryker)" (names the actual context — B2B enterprise community is a different beast than dev tools or media)
- Dropped trailing "Same pattern, three different stages." (now redundant given the framing change)

## Test plan

- [ ] CI passes
- [ ] Deploy preview: About section reads cleanly with the new phrasing