### PR TITLE
fix(retainer): rewrite about paragraph contrasting psychology and CRO

### DIFF
--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -192,13 +192,13 @@ const testimonials = [
               Enterprise leading the function (Spryker).
             </p>
             <p>
-              My background is cognitive psychology, then conversion
-              optimisation, then community and DevRel. That order matters.
-              Psychology mostly taught me you can't reliably predict what
-              developers will do, which is exactly why measurement and iteration
-              matter. So I think about community design as an experimentation
-              programme: build a small thing, see what people actually do with
-              it, and adjust.
+              My background is cognitive psychology, conversion optimisation and
+              community/DevRel. Where psychology mostly taught me you can't
+              reliably predict what people do, CRO taught me how to implement
+              measurement and experimentation to reliably improve your business.
+              So I think about community design as an experimentation programme:
+              build a small thing, see what people actually do with it, and
+              adjust.
             </p>
             <p>
               At Spryker I built the enterprise community function from scratch,


### PR DESCRIPTION
## Summary

Reframes the cognitive psychology / CRO heritage paragraph in the About section.

The new version contrasts what psychology taught (you can't reliably predict behavior) against what CRO taught (how to measure and experiment to reliably improve the business), then ties both into community design as an experimentation programme.

User-supplied phrasing applied with light typo cleanup ('tought' → 'taught', supplied a missing 'taught me' verb after 'psychology mostly'). Kept 'Where' as a Dutch-flavored subordinator per voice.md guidance on Dutch-English interference patterns.

## Test plan

- [ ] CI passes
- [ ] Deploy preview: About section reads cleanly with the new phrasing