### PR TITLE
fix(retainer): drop redundant Good fit bullet

### DIFF
--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -759,11 +759,6 @@ const testimonials = [
               <li>
                 Organisation can act on architectural and design recommendations
               </li>
-              <li>
-                Team has admin access to your community platform, and ideally
-                some development capacity to make changes when the platform
-                needs to evolve
-              </li>
             </ul>
           </div>
           <div


### PR DESCRIPTION
## Summary

Drops the "Team has admin access to your community platform..." bullet added in PR #100. Guido pointed out the existing "Organisation can act on architectural and design recommendations" bullet directly above already implies admin/dev capability to act on recommendations, so the new one was duplication.

## Test plan

- [ ] CI passes
- [ ] Deploy preview: Good fit list now has 4 bullets, no duplicate