### PR TITLE
feat(nav): Phase 2 — wire up Retainer page in nav, footer, hero, CTAs

### DIFF
--- a/src/components/About/WhatsNext.astro
+++ b/src/components/About/WhatsNext.astro
@@ -36,10 +36,10 @@ import Badge from "@components/Badge/Badge.astro";
       </div>
       <div class="mt-8">
         <a
-          href="/contact/"
+          href="/retainer/"
           class="inline-flex items-center rounded-lg bg-primary-600 px-6 py-3 font-medium text-white transition-colors duration-200 hover:bg-primary-700"
         >
-          Get in Touch
+          Work with me
           <svg
             class="ml-2 h-4 w-4"
             fill="none"

--- a/src/components/Cta/CtaCardCenter.astro
+++ b/src/components/Cta/CtaCardCenter.astro
@@ -39,14 +39,8 @@ import Button from "@components/Button/Button.astro";
           Ready to unlock the strategic value in your ecosystem?
         </h2>
         <!-- <p class="font-semibold text-base-100 dark:text-base-900">Level up with this theme.</p> -->
-        <Button
-          variant="primary"
-          href="/contact/"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="shadow-none"
-        >
-          Book Guido
+        <Button variant="primary" href="/retainer/" class="shadow-none">
+          Work with me
         </Button>
       </div>
     </div>

--- a/src/components/Cta/CtaCardSplit.astro
+++ b/src/components/Cta/CtaCardSplit.astro
@@ -57,13 +57,11 @@ import Button from "@components/Button/Button.astro";
         <div class="flex w-full p-3 md:w-1/2 md:justify-end">
           <Button
             variant="on-color"
-            href="/contact/"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/speaker/"
             class="shadow-none focus:outline-none focus:ring-2 focus:ring-base-100 focus:ring-offset-2 focus:ring-offset-primary-500"
-            aria-label="Book Guido for your event (opens in new tab)"
+            aria-label="Invite Guido to speak at your event"
           >
-            <span>Book Guido</span>
+            <span>Invite me to speak</span>
           </Button>
         </div>
       </div>

--- a/src/components/Cta/CtaCenter.astro
+++ b/src/components/Cta/CtaCenter.astro
@@ -25,13 +25,11 @@ import Button from "@components/Button/Button.astro";
       <div>
         <Button
           variant="primary"
-          href="/contact/"
-          target="_blank"
-          rel="noopener noreferrer"
+          href="/retainer/"
           umamiEvent="cta-click"
-          umamiEventTarget="book-guido-cta"
+          umamiEventTarget="work-with-me-cta"
         >
-          Book Guido
+          Work with me
         </Button>
       </div>
     </div>

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -48,6 +48,14 @@ const today = new Date();
           </li>
           <li role="listitem">
             <FooterLink
+              href={getRelativeLocaleUrl(currLocale, "/retainer")}
+              aria-label="Work with Guido on a community advisory engagement"
+            >
+              Retainer
+            </FooterLink>
+          </li>
+          <li role="listitem">
+            <FooterLink
               href={getRelativeLocaleUrl(currLocale, "/contact")}
               aria-label="Contact Guido"
             >

--- a/src/components/Hero/HeroCentered.astro
+++ b/src/components/Hero/HeroCentered.astro
@@ -51,14 +51,7 @@ const t = useTranslations(currLocale);
         />
       </p>
       <div class="flex flex-wrap justify-center gap-4">
-        <Button
-          variant="primary"
-          href="/contact/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Book Guido
-        </Button>
+        <Button variant="primary" href="/retainer/"> Work with me </Button>
         <VideoButton />
       </div>
 

--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -58,22 +58,23 @@ const t = useTranslations(currLocale);
         >
           <Button
             variant="primary"
-            href="https://sifa.id/p/gui.do"
-            aria-label="Follow Guido Jansen on Sifa ID (opens in new tab)"
+            href="/retainer/"
+            aria-label="Work with Guido on a community advisory engagement"
             class="min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-            target="_blank"
-            rel="noopener noreferrer"
+            umamiEvent="cta-click"
+            umamiEventTarget="work-with-me-hero"
           >
-            <span>Follow me on Sifa ID</span>
-            <span class="sr-only">(opens in new tab)</span>
+            Work with me
           </Button>
           <Button
             variant="outline"
-            href="/contact/"
-            aria-label="Book Guido Jansen for your event"
+            href="/speaker/"
+            aria-label="Invite Guido to speak at your event"
             class="min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+            umamiEvent="cta-click"
+            umamiEventTarget="invite-to-speak-hero"
           >
-            Book me for your event
+            Invite me to speak
           </Button>
         </div>
         <!-- Socials -->

--- a/src/components/Nav/MobileNav/MobileNav.astro
+++ b/src/components/Nav/MobileNav/MobileNav.astro
@@ -91,11 +91,11 @@ import { locales } from "@config/siteSettings.json";
         <Button
           variant="secondary"
           class="w-full shadow-none"
-          href="/contact/"
+          href="/retainer/"
           umamiEvent="cta-click"
-          umamiEventTarget="book-guido-mobile"
+          umamiEventTarget="work-with-me-mobile"
         >
-          Book Guido
+          Work with me
         </Button>
       </div>
 

--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -95,12 +95,12 @@ const shouldReduceMotion =
           <Button
             variant="secondary"
             class="my-auto hidden px-4 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:block"
-            href="/contact/"
-            aria-label="Book Guido for your event"
+            href="/retainer/"
+            aria-label="Work with Guido on a community advisory engagement"
             umamiEvent="cta-click"
-            umamiEventTarget="book-guido"
+            umamiEventTarget="work-with-me-nav"
           >
-            Book Guido
+            Work with me
           </Button>
 
           <!-- Language selector -->

--- a/src/components/Nav/__tests__/Nav.test.ts
+++ b/src/components/Nav/__tests__/Nav.test.ts
@@ -48,8 +48,8 @@ describe("Nav", () => {
                 <button type="button" class="hidden md:block" aria-label="Toggle dark mode">
                   Theme Toggle
                 </button>
-                <a href="/contact/" class="hidden md:block" aria-label="Book Guido for your event">
-                  Book Guido
+                <a href="/retainer/" class="hidden md:block" aria-label="Work with Guido on a community advisory engagement">
+                  Work with me
                 </a>
               </div>
             </header>
@@ -93,7 +93,7 @@ describe("Nav", () => {
     expect(themeToggle?.classList.contains("md:block")).toBe(true);
 
     const ctaButton = parsedHtml.querySelector(
-      'a[aria-label="Book Guido for your event"]',
+      'a[aria-label="Work with Guido on a community advisory engagement"]',
     );
     expect(ctaButton).toBeTruthy();
     expect(ctaButton?.classList.contains("hidden")).toBe(true);

--- a/src/config/en/navData.json.ts
+++ b/src/config/en/navData.json.ts
@@ -42,6 +42,16 @@ const navConfig = [
         icon: "tabler/outline/user",
       },
       {
+        text: "Retainer",
+        link: "/retainer",
+        icon: "tabler/outline/briefcase",
+      },
+      {
+        text: "Speak at your event",
+        link: "/speaker",
+        icon: "tabler/outline/microphone",
+      },
+      {
         text: "Press & Media Features",
         link: "/press",
         icon: "tabler/outline/news",


### PR DESCRIPTION
## Summary

Site-wide rollout of the two-CTA pattern locked in `retainer-page-plan.md` v2.1: **primary "Work with me" → /retainer**, **secondary "Invite me to speak" → /speaker**. Speaker funnel preserved (per the brand-expert review feedback) instead of being killed off by a single-replacement.

## Changes by surface

| Surface | Change |
|---|---|
| **Main nav (desktop)** | "Book Guido" CTA → "Work with me" → `/retainer`. About dropdown gets two new entries: **Retainer** + **Speak at your event** |
| **Mobile nav** | Same CTA swap. New entries appear via shared navData |
| **Hero (HeroSideImage)** | `[Sifa] [Book me for your event]` → `[Work with me] [Invite me to speak]`. Sifa link removed from the hero button row; SocialLinks below still surface it |
| **Footer** | Added "Retainer" between "Articles" and "Contact" |
| **CTA building blocks** | CtaCenter, CtaCardCenter, HeroCentered: "Book Guido" → "Work with me" → /retainer. **CtaCardSplit** (used in service-page layout, with speaker copy around it) → "Invite me to speak" → /speaker |
| **About page WhatsNext** | "Get in Touch" → "Work with me" → /retainer |
| **Nav test fixtures** | Updated assertions to match new aria-label, href, CTA text |

## Files touched (11)

- `src/config/en/navData.json.ts`
- `src/components/Footer/Footer.astro`
- `src/components/Nav/Nav.astro`
- `src/components/Nav/MobileNav/MobileNav.astro`
- `src/components/Nav/__tests__/Nav.test.ts`
- `src/components/Hero/HeroSideImage.astro`
- `src/components/Hero/HeroCentered.astro`
- `src/components/Cta/CtaCenter.astro`
- `src/components/Cta/CtaCardCenter.astro`
- `src/components/Cta/CtaCardSplit.astro`
- `src/components/About/WhatsNext.astro`

## Test plan

- [ ] CI passes (build, format, type-check, tests, lighthouse, links)
- [ ] Deploy preview — homepage hero shows two new buttons, both resolve correctly
- [ ] Deploy preview — desktop nav shows "Work with me" CTA pointing to /retainer
- [ ] Deploy preview — About dropdown shows Retainer + Speak entries with correct icons
- [ ] Deploy preview — mobile nav shows updated CTA + dropdown entries
- [ ] Deploy preview — footer shows Retainer link between Articles and Contact
- [ ] Deploy preview — /about shows updated "Work with me" button in WhatsNext section
- [ ] Deploy preview — speaker page still discoverable from hero, nav, and direct URL

## What's NOT in this PR

Deferred to later phases:
- Phase 3: form/scoping-call backend (Cal.com integration)
- Phase 4: OG image + Schema.org Service structured data
- Phase 5: speaker funnel verification + final cleanup