### PR TITLE
feat(retainer): Phase 4 — Schema.org Service, internal links, copy confidence

### DIFF
--- a/src/components/About/WhatsNext.astro
+++ b/src/components/About/WhatsNext.astro
@@ -20,7 +20,7 @@ import Badge from "@components/Badge/Badge.astro";
         class="space-y-4 text-lg text-base-700 md:text-xl dark:text-base-300"
       >
         <p class="description">
-          I'm exploring community leadership opportunities at companies with
+          I'm taking on community leadership opportunities at companies with
           momentum. Where technical ecosystems can become genuine growth
           engines.
         </p>

--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -216,7 +216,7 @@ const communities = [
           engines. Particularly interested in open source, AI, automation,
           commerce and privacy-focused organizations.
         </p>
-        <Button variant="primary" href="/contact/"> Get in Touch </Button>
+        <Button variant="primary" href="/retainer/"> Work with me </Button>
       </div>
     </div>
   </section>

--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -60,6 +60,45 @@ const faqs = [
   },
 ];
 
+// Schema.org Service structured data
+// Pricing intentionally omitted (priced by application, not publicly disclosed)
+const serviceSchema = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: "Community and Ecosystem Advisory Retainer",
+  url: "https://gui.do/retainer/",
+  description:
+    "A six-month minimum advisory engagement on community, ecosystem, and DevRel strategy for technical companies. Three concurrent seats. Application or 30-min scoping call.",
+  serviceType: "Strategic advisory",
+  category: ["Community strategy", "Developer relations", "Ecosystem strategy"],
+  provider: {
+    "@type": "Person",
+    name: "Guido X Jansen",
+    url: "https://gui.do/",
+    jobTitle: "Community strategist and advisor",
+    sameAs: [
+      "https://www.linkedin.com/in/gxjansen/",
+      "https://bsky.app/profile/gui.do",
+      "https://sifa.id/p/gui.do",
+    ],
+  },
+  audience: {
+    "@type": "BusinessAudience",
+    audienceType:
+      "Series A to Series C technical SaaS companies with developer-led products",
+  },
+  areaServed: {
+    "@type": "Place",
+    name: "Worldwide (remote, based in the Netherlands)",
+  },
+  offers: {
+    "@type": "Offer",
+    availability: "https://schema.org/LimitedAvailability",
+    url: "https://gui.do/retainer/#apply",
+    businessFunction: "https://schema.org/Sell",
+  },
+};
+
 // Testimonials, locked from retainer-page-plan.md §16
 // (preserved verbatim, these are authentic quotes from real recommendations)
 const testimonials = [
@@ -94,6 +133,12 @@ const testimonials = [
   title="Retainer: Senior community leadership for companies not yet ready to hire one"
   description="A community and ecosystem advisory engagement. Six-month minimum, then rolling. Three concurrent seats. Apply or schedule a 30-min scoping call."
 >
+  <script
+    type="application/ld+json"
+    is:inline
+    set:html={JSON.stringify(serviceSchema)}
+  />
+
   <!-- Hero (mt-14 matches fixed nav height h-14) -->
   <section
     id="hero"


### PR DESCRIPTION
## Summary

Phase 4 of the retainer rollout: indexing, structured data, and internal linking polish.

### Schema.org Service JSON-LD (new)

Added a Service schema script on `/retainer` covering:
- **Name + URL + description** (matches the page meta)
- **provider** as a Person (Guido) with sameAs links to LinkedIn / Bluesky / Sifa
- **audience** as BusinessAudience targeting Series A–C technical SaaS
- **areaServed** as worldwide remote (NL-based)
- **offers** with `LimitedAvailability` and a deep-link to the application section
- **No price** — pricing is intentionally hidden per plan §11, so the schema doesn't expose it either

Verified the script is rendered in the build output and that `/retainer` is auto-included in the sitemap.

### About page copy confidence

In `WhatsNext.astro`: "I'm exploring community leadership opportunities" → **"I'm taking on community leadership opportunities"**. Same meaning, more confidence.

### Communities page footer CTA

Caught a Phase 2 gap: the "What's Next" footer CTA on `/communities` still pointed to `/contact` with "Get in Touch". Updated to **"Work with me"** → `/retainer`, consistent with the rest of the rollout.

### Phase 3 — explicitly skipped

Per Guido's direction, the Cal.com / form backend work is deferred. Mailto links are fine for current inbound volume.

### What's still deferred

- Custom OG image for `/retainer` (1200×630). Current site default is in use; a bespoke design can come later when there's a clear visual direction.
- Internal links from blog posts about community work (manual content task).

## Test plan

- [ ] CI passes
- [ ] Deploy preview: `/retainer` page source contains the Service JSON-LD
- [ ] Validate the JSON-LD with Google's Rich Results Test (or schema.org validator) once live
- [ ] Sitemap (`https://gui.do/sitemap-0.xml`) lists `/retainer/`
- [ ] About page shows updated "taking on" wording
- [ ] Communities page footer button reads "Work with me" and links to `/retainer`