### PR TITLE
content(blog): add /retainer link to four community-themed posts

### DIFF
--- a/src/content/post/ditching-one-community-idea-per-month/index.mdx
+++ b/src/content/post/ditching-one-community-idea-per-month/index.mdx
@@ -166,6 +166,8 @@ For those working with less technical communities, how do you create similar val
 
 What am I missing in this approach? I'd love to hear your experiences in the comments!
 
+PS: If you're a community lead or DevRel manager wrestling with this exact tension between community expectations and product reality, that's the kind of work I take on as an advisor. Details at [/retainer](/retainer/).
+
 ---
 
 ### Research links

--- a/src/content/post/how-to-build-an-online-b2b-community/index.mdx
+++ b/src/content/post/how-to-build-an-online-b2b-community/index.mdx
@@ -234,3 +234,5 @@ By exploring these resources, you can gain a deeper understanding of how to buil
 ---
 
 Good luck and let me know your thoughts in the comments!
+
+PS: If you're building or scaling a B2B community and want a senior thinking partner alongside the person already doing the work, I take on a few advisory engagements at a time. Details at [/retainer](/retainer/).

--- a/src/content/post/introducing-barazo-community-forums/index.mdx
+++ b/src/content/post/introducing-barazo-community-forums/index.mdx
@@ -136,3 +136,5 @@ Check it out at [barazo.forum](https://barazo.forum) (for now just a direct link
 What would convince you to move your community to a platform where members actually own their data?
 
 PS: I'll write about the Barazo/ATproto reputation system next. This is not necessarily a forum-specific issue, but in these days of rapidly growing AI-slop content an important one to address from the foundational level.
+
+PPS: If you're rethinking your own community platform or trying to design portable, antifragile community infrastructure at your company, I take on a few advisory engagements at a time. Details at [/retainer](/retainer/).

--- a/src/content/post/start-building-anti-fragile-communities/index.mdx
+++ b/src/content/post/start-building-anti-fragile-communities/index.mdx
@@ -198,3 +198,5 @@ More chaos is always coming. The question is whether your community gains from i
 I'm truly optimistic about the future of digital communities, but we need to be intentional about it, and be conscious about the foundations we're using to build them on.
 
 **What's your single point of failure?**
+
+PS: If you want help making your community more antifragile (soft lock-in, signal loops back to product, governance that survives platform changes), that's the kind of work I take on as an advisor. Details at [/retainer](/retainer/).


### PR DESCRIPTION
## Summary

Internal-linking pass across community/DevRel-themed blog posts. Each post gets a single PS line at the end (matches Guido's PS voice pattern from voice.md), pointing to `/retainer` with copy tailored to the post's topic. No edits to the post body itself.

| Post | PS framing |
|---|---|
| `how-to-build-an-online-b2b-community` | B2B community thinking partner |
| `start-building-anti-fragile-communities` | Antifragile community design (soft lock-in, signal loops, governance) |
| `ditching-one-community-idea-per-month` | Community/DevRel ↔ product roadmap tension |
| `introducing-barazo-community-forums` | Portable antifragile community infrastructure (added as PPS — post already has a PS) |

## What I left alone

CRO / experimentation posts, AI posts, personal/tech posts (homelab, RPi, antifragile-tech-stack, etc.), Magento e-commerce posts, and pure psychology posts — none of those would feel natural with a retainer link, so they stay as-is.

## Test plan

- [ ] CI passes
- [ ] Deploy preview: each of the 4 posts shows the PS line at the bottom
- [ ] All `/retainer/` links resolve correctly