### PR TITLE
fix(retainer): positioning + testimonial alignment (lost in #112 squash)

### DIFF
--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -276,7 +276,8 @@ const testimonials = [
             burned a quarter on plays that should have been killed in week one.
           </p>
           <p class="font-medium text-base-900 dark:text-base-100">
-            The retainer covers the gap until you can hire well.
+            Two ways to use it: as a bridge to a senior hire, or as ongoing
+            senior leverage if you don't plan to make one.
           </p>
         </div>
       </div>
@@ -434,7 +435,7 @@ const testimonials = [
                 </dt>
                 <dd class="mt-1 font-medium text-base-900 dark:text-base-100">
                   A scorecard, a working system, and the decisions already made.
-                  So you hire well when you're ready.
+                  Whether or not a senior hire ends up making sense.
                 </dd>
               </div>
             </dl>
@@ -776,7 +777,7 @@ const testimonials = [
               <blockquote class="text-base leading-relaxed text-base-800 dark:text-base-200">
                 <p>“{t.quote}”</p>
               </blockquote>
-              <figcaption class="mt-auto flex items-start gap-4">
+              <figcaption class="mt-auto flex min-h-[7.5rem] items-start gap-4">
                 <Image
                   src={t.image}
                   alt={`Portrait of ${t.name}`}
@@ -786,11 +787,11 @@ const testimonials = [
                   format="webp"
                   class="h-12 w-12 flex-shrink-0 rounded-full object-cover ring-1 ring-base-200/70 dark:ring-base-700/70"
                 />
-                <div>
-                  <p class="font-semibold text-base-900 dark:text-base-100">
+                <div class="leading-tight">
+                  <p class="!my-0 font-semibold text-base-900 dark:text-base-100">
                     {t.name}
                   </p>
-                  <p class="text-sm text-base-600 dark:text-base-400">
+                  <p class="!mb-0 !mt-1 text-sm text-base-600 dark:text-base-400">
                     {t.role}, {t.company}
                   </p>
                 </div>


### PR DESCRIPTION
## Why this exists

Both the option-C positioning rewrite and the testimonial alignment fix were the second commit on the #112 branch. The squash-merge only captured the first commit, so neither change reached production. Same pattern as the missing bug-fix commit from #111 → #112.

This PR ships **only** the two missing changes.

## What's in

### 1. Positioning broadened to bridge-or-augment

Two specific lines now acknowledge both paths so the page stops implying the only successful outcome is "you eventually hire a senior community lead":

- **Why-this-offer closer** (was *"The retainer covers the gap until you can hire well."*) → now: *"Two ways to use it: as a bridge to a senior hire, or as ongoing senior leverage if you don't plan to make one."*

- **Compare panel, retainer-side "At month 6" row** (was *"...so you hire well when you're ready."*) → now: *"...whether or not a senior hire ends up making sense."*

Title and hero stay bridge-anchored. That framing is where acquisition urgency comes from — seat count, price anchor, hire-vs-retainer compare panel — and is what the buyer review confirmed pulls them in.

### 2. Testimonial alignment fix

Root cause: `<p>` tags inside the figure inherited 22.4px margin-top/bottom from a global rule, inflating each figcaption div to 159–187px tall. With grid-stretched figures + `mt-auto` figcaptions, Svitlana's longer role string pushed her name 28px above Boris/Chris.

Fix:
- `!my-0` / `!mb-0 !mt-1` on the `<p>` tags to zero the inherited margins
- `min-h-[7.5rem]` on the figcaption so all three render at the same height regardless of role wrap
- `leading-tight` on the inner div for compact line spacing
- `items-start` so name top + image top anchor to figcaption top across all three cards

Verified in dev: all three name+image tops render at exactly the same Y (was a 28px gap between Boris/Chris and Svitlana).

## Test plan

- [x] `astro check` clean
- [x] DOM measurement confirms all three testimonial name+image tops at identical Y
- [x] Both new positioning lines render in the deploy preview
- [ ] Visual review on Netlify deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)