### PR TITLE
fix(perf): add fetchpriority="high" to hero LCP image

### DIFF
--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -113,6 +113,7 @@ const t = useTranslations(currLocale);
               class="h-auto min-w-full object-cover"
               alt="Guido Jansen, a CRO and UX specialist, sitting casually on a modern grey office couch with a laptop. He's wearing casual business attire and has a welcoming expression, representing his approachable consulting style."
               loading="eager"
+              fetchpriority="high"
               widths={[360, 600, 768, 1024, 1200]}
               sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 500px"
               quality={85}


### PR DESCRIPTION
Closes #120

## Summary

Adds `fetchpriority="high"` to the homepage hero image in `HeroSideImage.astro`, which is the Largest Contentful Paint (LCP) candidate. This signals the browser to prioritize fetching the hero image early, complementing the existing `loading="eager"` attribute and aligning with modern-web-guidance for LCP optimization.

## Test plan

- [ ] Verify `fetchpriority="high"` is present in the rendered HTML on the homepage
- [ ] Confirm Lighthouse LCP score is unchanged or improved
- [ ] Visual regression: hero image still renders correctly across breakpoints