### PR TITLE
fix(typography): use text-balance for headings

### DIFF
--- a/src/components/Cta/CtaCenter.astro
+++ b/src/components/Cta/CtaCenter.astro
@@ -15,7 +15,7 @@ import Button from "@components/Button/Button.astro";
     <div
       class="relative z-20 -m-3 mx-auto flex max-w-[760px] flex-col flex-wrap items-center gap-6 text-center"
     >
-      <h2 class="text-pretty text-4xl/tight font-bold dark:text-base-100">
+      <h2 class="text-balance text-4xl/tight font-bold dark:text-base-100">
         The fastest way to make a site.
       </h2>
       <p class="description text-pretty text-lg">

--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -36,7 +36,7 @@ const t = useTranslations(currLocale);
         <div class="flex flex-col gap-4">
           <h1
             id="hero-heading"
-            class="text-pretty text-3xl font-bold leading-normal tracking-normal text-base-900 lg:text-5xl lg:leading-normal dark:text-base-100"
+            class="text-balance text-3xl font-bold leading-normal tracking-normal text-base-900 lg:text-5xl lg:leading-normal dark:text-base-100"
           >
             {t("hero_text")}
           </h1>

--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -202,7 +202,7 @@ const testimonials = [
           <Badge>Retainer Advisory</Badge>
           <h1
             id="hero-heading"
-            class="text-pretty text-4xl font-bold leading-tight tracking-tight text-base-900 md:text-5xl lg:text-6xl lg:leading-[1.1] dark:text-base-100"
+            class="text-balance text-4xl font-bold leading-tight tracking-tight text-base-900 md:text-5xl lg:text-6xl lg:leading-[1.1] dark:text-base-100"
           >
             Senior community leadership for companies not yet ready to hire one.
           </h1>


### PR DESCRIPTION
Closes #122

## Summary

Per modern-web-guidance "improve-text-layout-and-legibility":
- `text-wrap: balance` is for short headings (distributes lines evenly)
- `text-wrap: pretty` is for paragraphs (prevents orphans)

The hero h1 was using the wrong utility (`text-pretty`). Fixed it and audited the rest of the codebase for the same mistake on heading elements.

## Files changed

| File | Line | Element | Change |
|------|------|---------|--------|
| `src/components/Hero/HeroSideImage.astro` | 39 | `<h1>` (homepage hero) | `text-pretty` → `text-balance` |
| `src/components/Cta/CtaCenter.astro` | 18 | `<h2>` (CTA section heading) | `text-pretty` → `text-balance` |
| `src/pages/retainer.astro` | 205 | `<h1>` (retainer hero) | `text-pretty` → `text-balance` |

## What was left alone

All other `text-pretty` usages are on body text (`<p>` tags, description `<div>`s) and are correct as-is:
- `src/components/Hero/HeroSideImage.astro:45` — description div (correctly uses `text-pretty`)
- `src/components/ServiceCard/ServiceCardIcon.astro:47` — `<p>`
- `src/components/Cta/CtaCenter.astro:21` — `<p>`
- `src/components/SiteContent/ContentCard.astro:46` — `<p>`
- `src/components/Feature/FeatureFlagsMarquee.astro:49` — `<p>`
- `src/components/Feature/FeatureCardsSmall.astro:51` — `<p>`
- `src/pages/retainer.astro:210, 217` — `<p>` tags
- `src/components/Feature/FeatureGalleryMarquee.astro:96`, `FeatureCardsMedium.astro:65` — commented out

The `<Image>` block in `HeroSideImage.astro` (lines 111-120) was deliberately untouched per #120.

## Test plan

- [x] `npx astro check` — 0 errors
- [ ] Visual verification on homepage hero (`/`)
- [ ] Visual verification on retainer page (`/retainer/`)
- [ ] Visual verification on any page using `CtaCenter` component