### PR TITLE
perf: defer below-fold rendering with content-visibility

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,18 +28,32 @@ const siteData = getTranslatedData("siteData", currLocale);
 
 <BaseLayout title={siteData.title} description={siteData.description}>
   <HeroSideImage />
-  <SiteContent />
-  <FeatureCardsSmall />
-  <FeatureGalleryMarquee />
-  <ColleagueTestimonials />
+  <div class="defer-render"><SiteContent /></div>
+  <div class="defer-render"><FeatureCardsSmall /></div>
+  <div class="defer-render"><FeatureGalleryMarquee /></div>
+  <div class="defer-render"><ColleagueTestimonials /></div>
 
-  <UpcomingEvents events={eventIcons} />
+  <div class="defer-render"><UpcomingEvents events={eventIcons} /></div>
 
-  <FeatureFlagsMarquee />
+  <div class="defer-render"><FeatureFlagsMarquee /></div>
 
-  <CompanyLogos />
-  <NewsletterForm
-    variant="cta"
-    title="Subscribe to Guido's <span class='underline decoration-gold-light dark:decoration-gold decoration-2 underline-offset-4'>Golden</span> Nuggets"
-  />
+  <div class="defer-render"><CompanyLogos /></div>
+  <div class="defer-render">
+    <NewsletterForm
+      variant="cta"
+      title="Subscribe to Guido's <span class='underline decoration-gold-light dark:decoration-gold decoration-2 underline-offset-4'>Golden</span> Nuggets"
+    />
+  </div>
 </BaseLayout>
+
+<style>
+  /* Defer rendering of below-the-fold sections to reduce initial paint work.
+     content-visibility: auto skips rendering until the section approaches the
+     viewport. contain-intrinsic-size reserves a placeholder size so the
+     scrollbar doesn't jump; 'auto' lets the browser remember the real size
+     after the first render. See GitHub issue #125. */
+  .defer-render {
+    content-visibility: auto;
+    contain-intrinsic-size: auto 600px;
+  }
+</style>


### PR DESCRIPTION
Closes #125

## Summary
Wrap the 8 below-fold homepage sections in `.defer-render` divs and apply `content-visibility: auto` + `contain-intrinsic-size` to skip rendering work for content outside the viewport during initial paint.

`content-visibility` is Baseline since 2025-09-15, so no polyfill is needed.

## Implementation
- Hero (`HeroSideImage`) is NOT deferred — it's the critical above-the-fold render path.
- 8 below-fold sections each wrapped in `<div class="defer-render">`:
  - `SiteContent`, `FeatureCardsSmall`, `FeatureGalleryMarquee`, `ColleagueTestimonials`, `UpcomingEvents`, `FeatureFlagsMarquee`, `CompanyLogos`, `NewsletterForm`
- `contain-intrinsic-size: auto 600px` reserves a placeholder height so the scrollbar doesn't jump on first paint. The `auto` keyword lets the browser remember the actual size after the first real render.
- Scoped `<style>` block in `index.astro` only. No component, layout, or global style changes.

## Test plan
- [ ] Visual: load the homepage and confirm no layout shift on scroll.
- [ ] Keyboard: tab through the page and verify focus reaches every interactive element in all 8 deferred sections (search, links, newsletter form, etc.). `content-visibility: auto` is supposed to keep content focusable, but worth confirming.
- [ ] Find-in-page (Cmd+F) still finds text in deferred sections.
- [ ] Lighthouse/perf: confirm initial paint work decreases (LCP, TBT).
- [ ] If any section feels off when scrolling into view, tune the 600px intrinsic-size estimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)