### PR TITLE
refactor(build): remove redundant PostCSS PurgeCSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.7",
-        "@fullhuman/postcss-purgecss": "^7.0.2",
         "@testing-library/jest-dom": "^6.6.4",
         "@testing-library/react": "^16.3.2",
         "baseline-browser-mapping": "^2.10.29",
@@ -1755,19 +1754,6 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
-    },
-    "node_modules/@fullhuman/postcss-purgecss": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-7.0.2.tgz",
-      "integrity": "sha512-U4zAXNaVztbDxO9EdcLp51F3UxxYsb/7DN89rFxFJhfk2Wua2pvw2Kf3HdspbPhW/wpHjSjsxWYoIlbTgRSjbQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "purgecss": "^7.0.2"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
     },
     "node_modules/@humanwhocodes/momoa": {
       "version": "2.0.4",
@@ -14913,97 +14899,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/purgecss": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-7.0.2.tgz",
-      "integrity": "sha512-4Ku8KoxNhOWi9X1XJ73XY5fv+I+hhTRedKpGs/2gaBKU8ijUiIKF/uyyIyh7Wo713bELSICF5/NswjcuOqYouQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^12.1.0",
-        "glob": "^11.0.0",
-        "postcss": "^8.4.47",
-        "postcss-selector-parser": "^6.1.2"
-      },
-      "bin": {
-        "purgecss": "bin/purgecss.js"
-      }
-    },
-    "node_modules/purgecss/node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/purgecss/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/purgecss/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/purgecss/node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/purgecss/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/quansync": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.7",
-    "@fullhuman/postcss-purgecss": "^7.0.2",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.2",
     "baseline-browser-mapping": "^2.10.29",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,57 +1,9 @@
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
-import purgecssModule from '@fullhuman/postcss-purgecss';
-const purgecss = purgecssModule.default || purgecssModule;
 
 export default {
   plugins: [
     tailwindcss(),
     autoprefixer(),
-    purgecss({
-      content: [
-        './src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}',
-        './public/**/*.html'
-      ],
-      defaultExtractor: content => {
-        // Extract classes, IDs, and CSS-in-JS patterns
-        const broadMatches = content.match(/[^<>"'`\s]*[^<>"'`\s:]/g) || [];
-        const innerMatches = content.match(/[^<>"'`\s.()]*[^<>"'`\s.():]/g) || [];
-        return broadMatches.concat(innerMatches);
-      },
-      safelist: {
-        standard: [
-          // Astro and framework classes
-          /^astro-/, /^is-/, /^has-/, /^data-/, /^js-/,
-          // Animation classes
-          /^animate-/, /^transition-/, /^duration-/,
-          // State classes
-          'active', 'disabled', 'loading', 'error', 'success',
-          // Focus and hover states
-          /^focus:/, /^hover:/, /^group-hover:/,
-          // Prose typography class (needed to keep element-based selectors like .prose th)
-          'prose',
-        ],
-        deep: [
-          /dark$/, /light$/, /active$/, /open$/, /closed$/,
-          // Dynamic theme classes
-          /^bg-/, /^text-/, /^border-/,
-          // Prose element selectors (table, headings, etc.)
-          /^prose/,
-          // Bluesky comments library uses CSS modules with hashed class names
-          // that only exist at runtime -- preserve our attribute selectors
-          /bluesky-comments-wrapper/,
-        ],
-        greedy: [
-          /show$/, /hide$/, /sr-only$/, /visible$/, /invisible$/,
-          // Responsive classes
-          /^sm:/, /^md:/, /^lg:/, /^xl:/, /^2xl:/,
-        ]
-      },
-      // Keep keyframes - PurgeCSS can't detect usage inside @supports blocks
-      keyframes: false,
-      fontFace: true,
-      // More aggressive whitespace removal
-      rejected: false
-    })
-  ]
-}
+  ],
+};

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -206,6 +206,10 @@
   }
 }
 
+/* TODO: Audit for duplication with library CSS after PurgeCSS removal -- see #126 follow-up.
+   This wrapper was originally a PurgeCSS workaround. With PurgeCSS gone (#126),
+   the bluesky-comments library's own CSS modules should now load, which may
+   produce duplicate styling against the rules below. Trim once render is verified. */
 /* Bluesky Comments Styling
    =========================================================================
    The bluesky-comments library uses CSS Modules with hashed class names


### PR DESCRIPTION
## Summary
- Removes `@fullhuman/postcss-purgecss` from the build pipeline. Tailwind v3.4 JIT already only emits used classes, so PurgeCSS on top was redundant.
- Simplifies `postcss.config.mjs` from 57 lines (with a brittle 50-line safelist) to 9 lines.
- Drops `@fullhuman/postcss-purgecss` from `devDependencies` + `package-lock.json`.
- Leaves the Bluesky comments wrapper in `src/styles/global.scss` untouched, adds a TODO noting that duplication against the now-shipped library CSS should be audited in a follow-up.

Closes #126

## CSS bundle size: before vs after

| File | Before (with PurgeCSS) | After (no PurgeCSS) | Delta |
|---|---|---|---|
| `Badge.*.css` | 123,949 B (121 KB) | 154,882 B (151 KB) | +30,933 B |
| `BaseLayout.*.css` | 123,152 B (120 KB) | 154,085 B (150 KB) | +30,933 B |
| `index.*.css` | 10,166 B | 19,995 B | +9,829 B |
| `CompactingV2.*.css` | 6,174 B | 6,174 B | 0 |
| `GlobalStyles.*.css` | 251 B | 489 B | +238 B |

The two largest files grew by ~31 KB each. This is the bluesky-comments CSS-modules bundle that PurgeCSS was previously stripping (which is precisely why the `global.scss` wrapper existed as a workaround). With PurgeCSS removed the library's own styles now ship, and the wrapper duplicates them. Trimming the wrapper is a follow-up PR (see TODO comment).

The other CSS files only grew slightly, suggesting Tailwind JIT was already doing the bulk of the pruning work.

## Verification
- `npm run build` completes successfully (no errors; pre-existing unrelated `glob-loader` and `[id]`-collision warnings unchanged).
- Spot-checked `bg-base-50` Tailwind utility is present in built CSS:
  ```
  bg-base-50{--tw-bg-opacity:1;background-color:rgb(255 250 243/var(--tw-bg-opacity,1))}
  ```

## Test plan
- [ ] Deploy preview builds successfully on Netlify
- [ ] Site renders identically to master on key pages (`/`, `/retainer`, a blog post)
- [ ] Bluesky comments render correctly on a post with comments (this is the highest-risk surface)
- [ ] Visual diff or design review on dark + light themes
- [ ] Follow-up issue/PR: audit Bluesky wrapper in `src/styles/global.scss` (lines 213-482) against now-loading library CSS and trim duplication