### PR TITLE
security: tighten CSP — remove unsafe-eval (#132)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -76,7 +76,16 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://u.a11y.nl https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://u.a11y.nl https://public.api.bsky.app; media-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://share.transistor.fm https://open.spotify.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://share.transistor.fm; object-src 'none'; worker-src 'self' blob:; upgrade-insecure-requests;"
+    # NOTE: 'unsafe-inline' is intentionally kept (for now). The site contains
+    # many inline event handlers (onload/onclick/onerror on iframes for lazy-loaded
+    # YouTube/Spotify/SlideShare embeds), inline scripts that vary per-page via
+    # Astro `define:vars` (carousel components on home/blog, slide embeds), and
+    # per-page JSON-LD blocks (author pages, retainer). Hash-based CSP for all of
+    # these is not feasible without significant refactor — see issue #132 for the
+    # full inventory. 'unsafe-eval' has been removed: a build-output audit
+    # (grep eval(/new Function( across dist/_astro/*.js) confirmed nothing in the
+    # shipped browser bundle relies on it.
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://u.a11y.nl https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://u.a11y.nl https://public.api.bsky.app; media-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://share.transistor.fm https://open.spotify.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://share.transistor.fm; object-src 'none'; worker-src 'self' blob:; upgrade-insecure-requests;"
     X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
Closes #132

## What changed

Removed `'unsafe-eval'` from the `script-src` directive in `netlify.toml`.

**Before:**
```
script-src 'self' 'unsafe-inline' 'unsafe-eval' https://u.a11y.nl https://cdn.jsdelivr.net;
```

**After:**
```
script-src 'self' 'unsafe-inline' https://u.a11y.nl https://cdn.jsdelivr.net;
```

A long explanatory comment was added above the directive so the next person (or future me) does not have to re-derive why `'unsafe-inline'` is still there.

## Why this is safe

A build-output audit of the shipped browser bundle confirmed nothing in client-side JS relies on dynamic code evaluation:

```
$ grep -l "eval(" dist/_astro/*.js          # no matches
$ grep -l "new Function(" dist/_astro/*.js  # no matches
```

Library check:
- `swiper` is in `package.json` but is not imported anywhere in `src/` (likely a leftover dep).
- `animejs` is imported only by `src/components/SiteLogo/logo-animation.ts` and bundles cleanly without runtime eval.
- Astro 6 runtime in the shipped bundle does not use `eval` or `new Function`.

A locally served `dist/` with the new header returned 200 and the headers carried correctly.

## What was kept and why

`'unsafe-inline'` stays. Dropping it requires either a refactor or `'unsafe-hashes'` with a per-deploy hash list, neither of which fits the scope of this PR. The site currently relies on inline execution in several places:

| Surface | Files | Notes |
|---|---|---|
| Inline event handlers on lazy-loaded iframes | `Embed/YouTubeEmbed.astro`, `Embed/SpotifyEmbed.astro`, `Press/LazyYouTube.astro`, `Press/VideoSection.astro`, `Presentations/VideoEmbed.astro`, `Presentations/SlideEmbed.astro`, `Button/Button.astro` | 22 inline handlers just on `/press/`. CSP doesn't separate inline scripts from inline handlers — both need `'unsafe-inline'` (or `'unsafe-hashes'`). |
| `<script is:inline define:vars={...}>` carousel scripts | `Feature/FeatureCardsSmall.astro`, `SiteContent/SiteContent.astro` | `totalItems` is baked into the script body, so the hash would vary per render. |
| Per-page JSON-LD `<script type="application/ld+json" is:inline>` | `pages/authors/[slug].astro`, `pages/retainer.astro` | Content varies per author/page. |
| Static inline scripts in layouts | `BaseHead.astro` (theme init), `BaseLayout.astro` (error tracking) | These could be hashed, but on their own they don't let us drop `'unsafe-inline'` while the inline event handlers above remain. |

## Deferred follow-ups

If we want to drop `'unsafe-inline'` in a future PR:

1. Replace inline event handlers in embed components with module-bundled JS using `addEventListener`. Largest cluster is the lazy-load iframe pattern in `Embed/` and `Presentations/`.
2. Refactor the two `define:vars` carousels (`FeatureCardsSmall.astro` and `SiteContent.astro`) to read their count from a `data-*` attribute instead of baking it into the script body, then move them to bundled module scripts.
3. Move JSON-LD into a server-rendered static partial whose hash doesn't change per page (or accept the per-page hash list).
4. Hash the BaseHead theme init and BaseLayout error tracking scripts (these are static).
5. `style-src 'unsafe-inline'` is still wide open because `BaseLayout.astro:55-99` and `BaseHead.astro:64-94` (font-face inline `<style>`) emit inline CSS. Similar tightening path: hash both static blocks.

## Test plan

- [x] `npm run build` succeeds locally.
- [x] `grep -l "eval(" dist/_astro/*.js` and `grep -l "new Function(" dist/_astro/*.js` both empty.
- [x] Served `dist/` locally with the new CSP header injected, homepage returned 200.
- [ ] After Netlify deploy preview is up: load homepage, `/press/`, `/retainer/`, an author page, a presentations page; check DevTools console for any CSP violation reports.
- [ ] Re-grade on `securityheaders.com` — should rise (any CSP without `unsafe-eval` scores better) and `csp-evaluator.withgoogle.com` should drop the "Eval in scripts: Allows the evaluation of strings as JavaScript" finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)