### PR TITLE
perf: strip permanent will-change + old GPU hacks

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -53,11 +53,10 @@ const currLocale = getLocaleFromUrl(Astro.url);
       noindex={noindex}
     />
     <style>
-      /* Performance optimizations for transitions */
-      .transition-ready {
+      /* will-change applied only during active transitions via JS.
+         Letting browser compositor decide layer promotion (no manual hacks). */
+      .transition-ready.is-transitioning {
         will-change: opacity, transform;
-        transform: translateZ(0);
-        backface-visibility: hidden;
       }
 
       /* Noise background animation */
@@ -144,14 +143,14 @@ const currLocale = getLocaleFromUrl(Astro.url);
       // Inform the browser about upcoming transitions
       document.addEventListener("astro:before-preparation", () => {
         document.querySelectorAll(".transition-ready").forEach((el) => {
-          (el as HTMLElement).style.willChange = "opacity, transform";
+          el.classList.add("is-transitioning");
         });
       });
 
       // Clean up after transition
       document.addEventListener("astro:after-swap", () => {
         document.querySelectorAll(".transition-ready").forEach((el) => {
-          (el as HTMLElement).style.willChange = "auto";
+          el.classList.remove("is-transitioning");
         });
       });
     </script>


### PR DESCRIPTION
Closes #129

The baseline `.transition-ready` rule in `BaseLayout.astro` was forcing `will-change: opacity, transform` on permanently and applying legacy `translateZ(0)` and `backface-visibility: hidden` hacks. Per MDN, `will-change` should be applied shortly before an animation and removed after — keeping it on continuously reserves GPU memory and undoes the optimization it's supposed to provide. The two GPU hacks are cargo-cult holdovers from 2012 (modern browsers handle layer promotion automatically; `backface-visibility` only matters for 3D transforms).

Switches to a semantic `.is-transitioning` class that JS adds in `astro:before-preparation` and removes in `astro:after-swap`. The browser now decides compositor layer promotion on its own. Also drops two `as HTMLElement` casts and the inline `style.willChange` mutation in favor of class toggling. No behavioral change to view-transitions, noise keyframes, or any other animation logic.