### PR TITLE
chore: remove invalid viewTransitions config block

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,9 +17,6 @@ export default defineConfig({
   build: {
     inlineStylesheets: "auto", // Inline critical CSS automatically
   },
-  viewTransitions: {
-    fallback: true // Enable fallback animations for browsers that don't support view transitions
-  },
   // Prefetch destination HTML so View Transition swaps feel instant.
   // Without this, clicking a link on a slow connection sits on the old page
   // until the fetch completes — no native loading spinner under ClientRouter.


### PR DESCRIPTION
Partial fix for #131. Removes a 3-line block in `astro.config.mjs` that wasn't valid Astro 6 config (no-op behavior change). Defers SPA-vs-CSS-only decision to a separate PR.

## Why

The `viewTransitions: { fallback: true }` block is from the old Astro 4/5 API and isn't a valid Astro 6 config option — `defineConfig` was silently ignoring it.

The actual view transitions are wired via `<ClientRouter fallback="none" />` in `src/layouts/BaseHead.astro:214` and remain untouched here.

## What changed

- `astro.config.mjs`: removed the 3-line `viewTransitions: { fallback: true }` block.

## What did NOT change

- `<ClientRouter fallback="none" />` in `BaseHead.astro` — still wired the same way.
- No new `@view-transition` CSS rules.
- No animation/transition logic touched.

## Follow-up (separate PR)

Astro 6 supports native cross-document view transitions (CSS-only via `@view-transition`). Migrating from SPA `ClientRouter` to CSS-only is a meaningful UX decision worth its own PR:
- SPA `ClientRouter` = instant feel, preserves scroll position, JS-heavy
- CSS-only `@view-transition` = full reload per nav, simpler, no Firefox quirks

## Verification

- `grep -rn "viewTransitions:" astro.config.mjs` returns nothing.
- `grep -rn "viewTransitions" src/ astro.config.mjs` returns only `useViewTransitions` (the unrelated `siteSettings` flag).
- `<ClientRouter>` still present in `BaseHead.astro` at line 214.
- `npx astro check`: 0 errors, 0 warnings.
- `npm run build`: passes.