### PR TITLE
perf(typography): add font-size-adjust for stable Poppins fallback

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -15,6 +15,9 @@
 @layer base {
   html {
     font-size: 16px;
+    /* Normalize fallback font x-height to Poppins to prevent CLS on font swap.
+       Baseline since 2024-07-25. */
+    font-size-adjust: from-font;
 
     @screen sm {
       font-size: 18px;


### PR DESCRIPTION
Closes #127.

## What

Adds `font-size-adjust: from-font;` to the base `html` rule in `src/styles/global.scss`.

## Why

The site uses Poppins as the primary font with a system-ui/Segoe UI/Roboto/etc. fallback stack. Only Poppins 400 and 500 are preloaded — when weights 600 and 700 swap in from the fallback, glyph metrics differ enough to cause a brief CLS event.

`font-size-adjust: from-font` tells the browser to normalize the fallback's x-height to match Poppins, so the text stays visually stable during the font swap.

Per [modern-web-guidance "visually-stable-font-fallbacks"](https://web.dev/blog/css-size-adjust), this is the canonical fix and has been Baseline (cross-browser) since 2024-07-25 — safe without any polyfill.

## How to verify

1. Open DevTools → Network panel.
2. Add a block rule for `*/fonts/poppins/*`.
3. Reload the page — text now renders in the fallback stack with adjusted x-height.
4. Remove the block rule and reload — Poppins loads but text should NOT visibly shift in size.

Without this change, you'd see a subtle vertical reflow when Poppins arrives. With it, the swap is invisible.

## Scope

- Single line change + comment in `src/styles/global.scss`.
- No font-family changes, no `@font-face` changes, no preload changes.
- The `@screen sm` / `@screen md` font-size ladder is intentionally untouched (separate issue #133).

## Build verification

```
$ grep -oE "html\{[^}]*font-size-adjust:from-font[^}]*\}" dist/_astro/*.css
dist/_astro/Badge.BW1jA3iJ.css:html{font-size-adjust:from-font;font-size:16px}
dist/_astro/BaseLayout.BcWlFCQz.css:html{font-size-adjust:from-font;font-size:16px}
```

`npm run build` passes cleanly.