### PR TITLE
perf: pause noise animation when tab is hidden

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -159,8 +159,9 @@ const currLocale = getLocaleFromUrl(Astro.url);
       const noiseEl = document.querySelector(".noise-background");
       if (noiseEl) {
         document.addEventListener("visibilitychange", () => {
-          (noiseEl as HTMLElement).style.animationPlayState =
-            document.hidden ? "paused" : "running";
+          (noiseEl as HTMLElement).style.animationPlayState = document.hidden
+            ? "paused"
+            : "running";
         });
       }
     </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -154,6 +154,15 @@ const currLocale = getLocaleFromUrl(Astro.url);
           (el as HTMLElement).style.willChange = "auto";
         });
       });
+
+      // Pause noise animation when tab is backgrounded to save CPU/battery
+      const noiseEl = document.querySelector(".noise-background");
+      if (noiseEl) {
+        document.addEventListener("visibilitychange", () => {
+          (noiseEl as HTMLElement).style.animationPlayState =
+            document.hidden ? "paused" : "running";
+        });
+      }
     </script>
 
     <!-- Error tracking with Umami -->


### PR DESCRIPTION
Closes #130

## Summary

The `.noise-background` overlay in `src/layouts/BaseLayout.astro` runs an 8s `noise` keyframe animation infinitely. Even when the tab is in the background, browsers continue to tick CSS animations, burning CPU/battery for an effect no one can see.

This PR adds a [Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API) listener that toggles `animationPlayState` between `paused` and `running` based on `document.hidden`.

## Why Page Visibility instead of `content-visibility`

The noise overlay is `position: fixed` (always visible relative to viewport), so `content-visibility: auto` won't trigger off-screen skipping. Page Visibility is the right tool here: tied to tab focus, not scroll position.

## What changed

- `src/layouts/BaseLayout.astro`: added a `visibilitychange` listener inside the existing transition `<script>` block. ~9 lines added.

## What did NOT change

- The `@keyframes noise` definition
- The `.noise-background` CSS or markup
- The global `prefers-reduced-motion` rules in `src/styles/global.scss` (those still take precedence; this layers on top)
- The `.transition-ready` / `is-transitioning` logic from issue #129

## Coordination with PR #146

PR #146 (issue #129) is open and touches the same file but different lines (CSS rule rename + classList toggles in the existing handlers). This PR only adds a new listener after the existing `astro:after-swap` handler. Rebase should be trivial.

## Verification

- `grep -n "visibilitychange\|animationPlayState" src/layouts/BaseLayout.astro` shows both
- `npx astro check` — 0 errors, 0 warnings (only pre-existing hints in unrelated files)
- `npm run build` — exit 0, all robots.txt / sitemap checks pass

## Manual test plan

- [ ] Open the homepage in Chrome
- [ ] Open DevTools, switch to the Performance tab, start recording
- [ ] Switch to another tab for ~3 seconds, then switch back
- [ ] Stop recording; confirm the timeline shows the noise frame paints stopped while the tab was hidden and resumed on return
- [ ] Optionally repeat in Firefox / Safari (Page Visibility API is broadly supported)
- [ ] Confirm the noise overlay still animates normally when the tab is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)