### PR TITLE
test: skip flaky external URL validation in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ Built with [Astro](https://astro.build/), [React](https://react.dev/), [MDX](htt
 [![Netlify Status](https://api.netlify.com/api/v1/badges/b6ca57ea-33ef-4185-a64e-a6b040a64805/deploy-status)](https://app.netlify.com/sites/gxjansen/deploys)
 [![CodeQL](https://github.com/gxjansen/gxjansen.github.io/workflows/CodeQL/badge.svg)](https://github.com/gxjansen/gxjansen.github.io/actions?query=workflow%3ACodeQL "Code quality workflow status")
 [![PageSpeed](https://img.shields.io/badge/PageSpeed-View%20Report-4285F4?logo=pagespeedinsights)](https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fgui.do)
+
+## Testing
+
+### URL Validation
+
+Blog post URL validation is skipped in CI to avoid 5-minute timeouts hitting external services. Run it locally before publishing new posts:
+
+```bash
+npm test -- validateUrls
+```
+
+(The recent-events URL check still runs in CI.)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ This is the website for [gui.do](https://gui.do), built with Astro and replacing
 See [this article](https://gui.do/post/website-moved-to-astro/) with more background info on why I made the switch.
 
 ## Stack
+
 Built with [Astro](https://astro.build/), [React](https://react.dev/), [MDX](https://mdxjs.com/), [Tailwind](https://tailwindcss.com/) and deployed on [Netlify](https://www.netlify.com/).
 
 ### Status
+
 [![Netlify Status](https://api.netlify.com/api/v1/badges/b6ca57ea-33ef-4185-a64e-a6b040a64805/deploy-status)](https://app.netlify.com/sites/gxjansen/deploys)
 [![CodeQL](https://github.com/gxjansen/gxjansen.github.io/workflows/CodeQL/badge.svg)](https://github.com/gxjansen/gxjansen.github.io/actions?query=workflow%3ACodeQL "Code quality workflow status")
 [![PageSpeed](https://img.shields.io/badge/PageSpeed-View%20Report-4285F4?logo=pagespeedinsights)](https://pagespeed.web.dev/analysis?url=https%3A%2F%2Fgui.do)

--- a/src/data/__tests__/validateUrls.test.ts
+++ b/src/data/__tests__/validateUrls.test.ts
@@ -408,7 +408,7 @@ describe("Data File URL Validation", () => {
     expect(errors).toEqual([]);
   }, 60000);
 
-  it("should have valid URLs in blog posts", async () => {
+  it.skipIf(process.env.CI)("should have valid URLs in blog posts", async () => {
     const urls = collectBlogPostUrls();
 
     console.log(`Validating ${urls.length} URLs from blog posts...`);

--- a/src/data/__tests__/validateUrls.test.ts
+++ b/src/data/__tests__/validateUrls.test.ts
@@ -408,20 +408,24 @@ describe("Data File URL Validation", () => {
     expect(errors).toEqual([]);
   }, 60000);
 
-  it.skipIf(process.env.CI)("should have valid URLs in blog posts", async () => {
-    const urls = collectBlogPostUrls();
+  it.skipIf(process.env.CI)(
+    "should have valid URLs in blog posts",
+    async () => {
+      const urls = collectBlogPostUrls();
 
-    console.log(`Validating ${urls.length} URLs from blog posts...`);
+      console.log(`Validating ${urls.length} URLs from blog posts...`);
 
-    const errors = await validateUrlsWithRateLimit(urls, 300);
+      const errors = await validateUrlsWithRateLimit(urls, 300);
 
-    if (errors.length > 0) {
-      console.error("\nBroken URLs found in blog posts:");
-      errors.forEach((err) => console.error(`  - ${err}`));
-    }
+      if (errors.length > 0) {
+        console.error("\nBroken URLs found in blog posts:");
+        errors.forEach((err) => console.error(`  - ${err}`));
+      }
 
-    expect(errors).toEqual([]);
-  }, 300000); // 5 min timeout for all blog posts
+      expect(errors).toEqual([]);
+    },
+    300000,
+  ); // 5 min timeout for all blog posts
 });
 
 // Export for potential use in CLI script


### PR DESCRIPTION
Closes #151

## Summary
The `should have valid URLs in blog posts` test in `src/data/__tests__/validateUrls.test.ts` validates every external URL in every blog post against the live internet at 300ms rate-limited intervals. With ~271 blog post URLs it consistently times out CI at the 5-minute (`300000ms`) cap. This blocked 5 PRs during the May 2026 modern-web-review batch.

Per issue #151 Option D: skip it in CI, keep it runnable locally on-demand before publishing new posts.

## Changes
- `src/data/__tests__/validateUrls.test.ts`: wrap the blog posts test with `it.skipIf(process.env.CI)`. The `recent events` URL test stays unchanged — it passes in CI (~6s, only 11 URLs).
- `README.md`: add a Testing section documenting how to run the URL validation locally.

## Verification
- `CI=true npm test -- validateUrls.test.ts` → 4 passed, 1 skipped, ~30s total. Blog posts test skipped as intended.
- Unset CI + run locally → blog posts test starts and begins validating 271 URLs (killed after ~30s; full run takes minutes).

## Out of scope
- Splitting URL validation into its own scheduled CI workflow (#151 Option A) — separate follow-up.
- Touching `validateUrlsWithRateLimit` or other utility functions.