### PR TITLE
perf(typography): fluid clamp scaling for root + hero h1

### DIFF
--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -36,7 +36,8 @@ const t = useTranslations(currLocale);
         <div class="flex flex-col gap-4">
           <h1
             id="hero-heading"
-            class="text-balance text-3xl font-bold leading-normal tracking-normal text-base-900 lg:text-5xl lg:leading-normal dark:text-base-100"
+            class="text-balance font-bold leading-normal tracking-normal text-base-900 dark:text-base-100"
+            style="font-size: clamp(1.875rem, 1.25rem + 2.5vw, 3rem); line-height: 1.2;"
           >
             {t("hero_text")}
           </h1>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -15,18 +15,12 @@
 /* Base Typography */
 @layer base {
   html {
-    font-size: 16px;
+    /* Fluid root: 16px at 360px viewport → 22.4px at 1024px viewport.
+       Linear interpolation between those breakpoints; clamped at the edges. */
+    font-size: clamp(1rem, 0.65rem + 1.55vw, 1.4rem);
     /* Normalize fallback font x-height to Poppins to prevent CLS on font swap.
        Baseline since 2024-07-25. */
     font-size-adjust: from-font;
-
-    @screen sm {
-      font-size: 18px;
-    }
-
-    @screen md {
-      font-size: 22.4px; /* 1.4rem */
-    }
   }
 }
 


### PR DESCRIPTION
Closes #133

## Summary

Replaces breakpoint-switched font sizes with CSS `clamp()` for smooth, continuous typography across all viewport widths. No more visible jumps at `sm` (640px), `md` (1000px), or `lg` (1024px).

## Changes

- `src/styles/global.scss` — root `html` font-size: `clamp(1rem, 0.65rem + 1.55vw, 1.4rem)` (replaces 16px / 18px / 22.4px breakpoint ladder). `font-size-adjust: from-font` (#127) preserved.
- `src/components/Hero/HeroSideImage.astro` — hero `h1`: inline `style="font-size: clamp(1.875rem, 1.25rem + 2.5vw, 3rem); line-height: 1.2;"` (replaces `text-3xl lg:text-5xl`).

Inline style used because Tailwind v3 lacks a native fluid utility. After #128 (Tailwind v4) a cleaner utility-based approach will be possible.

## Verified font-sizes (live measurement via Playwright)

| Viewport | html (computed) | hero h1 (computed) | Old html | Old h1 |
|----------|----------------:|-------------------:|---------:|-------:|
| 360px    | 16.00 px        | 30.00 px           | 16px     | 30.00px |
| 640px    | 20.32 px        | 41.40 px           | 18px (jump) | 33.75px |
| 768px    | 22.30 px        | 47.08 px           | 18px     | 33.75px |
| 1024px   | 22.40 px        | 53.60 px           | 22.4px (jump) | 67.20px (jump) |
| 1280px   | 22.40 px        | 60.00 px           | 22.4px   | 67.20px |
| 1920px   | 22.40 px        | 67.20 px           | 22.4px   | 67.20px |

Note: the new clamp interpolates root smoothly from 16px → 22.4px between 360px and ~1024px viewport, then holds. The hero h1 reaches the previous `text-5xl` value (67.2px) at the high end without the abrupt jump at the `lg` breakpoint.

## Scope discipline

Only the root font-size declaration and the hero h1 are changed in this PR. Other headings deferred to a follow-up (per issue scope).

## Test plan

- [x] `npm run build` passes clean
- [x] Verified computed font-sizes at 360 / 640 / 768 / 1024 / 1280 / 1920 viewports — monotonic, no jumps
- [x] Hero h1 line-height locked to 1.2 (prevents leading drift from heading clamp interaction)
- [ ] Visual review on production preview
- [ ] Confirm `font-size-adjust: from-font` still in effect (CLS prevention from #127)

## Coordination

- #153 (a11y) touches different lines of HeroSideImage.astro (line 30 `role`). Trivial rebase.
- #144 (Bluesky wrapper) touches a far section of global.scss. Trivial rebase.
- #128 (Tailwind v4) and #151 (flaky test) — no overlap.

Generated with [Claude Code](https://claude.com/claude-code)