### PR TITLE
fix(a11y): remove misused aria-expanded from nav scroll handler

### DIFF
--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -199,12 +199,6 @@ const shouldReduceMotion =
 
         this.navbar?.classList.toggle("navbar--scrolled", shouldShowBackground);
         this.navbar?.classList.toggle("navbar--initial", !shouldShowBackground);
-
-        // Update ARIA attributes
-        this.navbar?.setAttribute(
-          "aria-expanded",
-          shouldShowBackground.toString(),
-        );
       });
     };
 


### PR DESCRIPTION
## Problem
After #157 landed, axe-core found a new **critical** violation: \`aria-allowed-attr\` on \`#nav__container\` because the scroll handler in \`Nav.astro\` was setting \`aria-expanded\` on the container \`<div>\`. That attribute is only valid on elements with an interactive role (button, combobox, link, etc.) — a plain div with aria-expanded fails ARIA validation.

This was the cause of Lighthouse mobile a11y dropping further to 92 after #157.

## Fix
Remove the \`setAttribute("aria-expanded", ...)\` call from the scroll handler. The visual scroll state is already driven by the \`.navbar--scrolled\` / \`.navbar--initial\` class toggle on the same line. The ARIA write was both:

1. **Semantically wrong** — \`aria-expanded\` means "is this expandable region open?", not "scroll position"
2. **Mechanically invalid** — applied to an element with no role that allows it

## Verification
- 6-line deletion, no behavioral change to visible UI
- Dropdown-button \`aria-expanded\` usages in \`Nav.test.ts\` (correct usage on \`<button>\` elements) are unchanged

## Expected impact
Lighthouse mobile a11y should return to ≥96. Combined with the brand-button contrast issues already filed as follow-ups, a return to 100 is possible once Rose Pine accent colors are darkened.

Followup to #157 / #153.