### PR TITLE
chore(deps): upgrade Tailwind v3.4 → v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,10 @@
         "@astrojs/sitemap": "^3.7.1",
         "@atproto/api": "^0.20.0",
         "@iconify-json/tabler": "^1.2.35",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
         "@tailwindcss/forms": "^0.5.11",
+        "@tailwindcss/postcss": "^4.3.0",
         "@tailwindcss/typography": "^0.5.16",
+        "@tailwindcss/vite": "^4.3.0",
         "@testing-library/dom": "^10.4.1",
         "@types/animejs": "^3.1.13",
         "@types/date-fns": "^2.6.3",
@@ -46,7 +47,7 @@
         "sass": "^1.97.3",
         "svg-country-flags": "^1.2.10",
         "swiper": "^12.1.2",
-        "tailwindcss": "^3.4.19",
+        "tailwindcss": "^4.3.0",
         "yaml": "^2.9.0"
       },
       "devDependencies": {
@@ -5205,6 +5206,274 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
+      }
+    },
     "node_modules/@tailwindcss/typography": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
@@ -5215,6 +5484,20 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6164,12 +6447,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -7405,15 +7682,6 @@
         "node": "*"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001791",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
@@ -8480,12 +8748,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -8494,12 +8756,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
@@ -8690,6 +8946,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -11788,7 +12057,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -12033,24 +12301,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
-    },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/listhen": {
       "version": "1.10.0",
@@ -13587,17 +13837,6 @@
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
-    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -13851,24 +14090,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -14517,24 +14738,6 @@
       "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
       "license": "MIT"
     },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/pkg-types": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
@@ -14581,149 +14784,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-import/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-nested/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -15063,15 +15123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
       }
     },
     "node_modules/read-package-up": {
@@ -16620,37 +16671,6 @@
         "inline-style-parser": "0.2.7"
       }
     },
-    "node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/suf-log": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
@@ -16854,155 +16874,22 @@
       "license": "MIT"
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "license": "MIT"
     },
-    "node_modules/tailwindcss/node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">=6"
       },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "license": "MIT",
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {
@@ -17093,27 +16980,6 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "license": "MIT"
-    },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -17329,12 +17195,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "license": "Apache-2.0"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "@atproto/api": "^0.20.0",
     "@iconify-json/tabler": "^1.2.35",
     "@tailwindcss/forms": "^0.5.11",
+    "@tailwindcss/postcss": "^4.3.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/vite": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@types/animejs": "^3.1.13",
     "@types/date-fns": "^2.6.3",
@@ -60,7 +62,7 @@
     "sass": "^1.97.3",
     "svg-country-flags": "^1.2.10",
     "swiper": "^12.1.2",
-    "tailwindcss": "^3.4.19",
+    "tailwindcss": "^4.3.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,6 +1,9 @@
-import tailwindcss from 'tailwindcss';
+import tailwindcss from '@tailwindcss/postcss';
 import autoprefixer from 'autoprefixer';
 
+// Tailwind v4 PostCSS pipeline.
+// Note: v4 ships its own vendor prefixing via lightningcss, but we keep
+// autoprefixer here for safety until we've fully verified browser coverage.
 export default {
   plugins: [
     tailwindcss(),

--- a/src/components/About/AboutHeader.astro
+++ b/src/components/About/AboutHeader.astro
@@ -96,7 +96,7 @@ const mobileImagePath = "/images/guido-up.png";
 
   /* Ensure proper focus visibility */
   :focus-visible {
-    outline: 2px solid var(--focus-ring-color, theme("colors.primary.500"));
+    outline: 2px solid var(--focus-ring-color, var(--color-primary-500));
     outline-offset: 2px;
   }
 </style>

--- a/src/components/About/AboutHeader.astro
+++ b/src/components/About/AboutHeader.astro
@@ -12,7 +12,7 @@ const mobileImagePath = "/images/guido-up.png";
 ---
 
 <section
-  class="overflow-hidden pb-0 pt-24 md:pb-0 md:pt-28"
+  class="overflow-hidden pt-24 pb-0 md:pt-28 md:pb-0"
   aria-labelledby="about-header-heading"
   role="region"
 >
@@ -32,13 +32,13 @@ const mobileImagePath = "/images/guido-up.png";
           aria-label="Professional introduction"
         >
           <p class="description">
-            I build <span class="font-semibold text-primary-500"
+            I build <span class="text-primary-500 font-semibold"
               >communities that matter to the business</span
             >, not just to the community itself.
           </p>
           <p class="description">
             Where many optimize for engagement metrics, I design systems that
-            translate <span class="font-semibold text-primary-500"
+            translate <span class="text-primary-500 font-semibold"
               >developer and customer intelligence</span
             > into product strategy, reduce support costs, and create competitive
             moats built on trust rather than lock-in.
@@ -46,7 +46,7 @@ const mobileImagePath = "/images/guido-up.png";
           <p class="description">
             I've done this from zero <a
               href="/communities/"
-              class="text-primary-500 underline underline-offset-2 transition-colors hover:text-primary-600 dark:hover:text-primary-400"
+              class="text-primary-500 hover:text-primary-600 dark:hover:text-primary-400 underline underline-offset-2 transition-colors"
               >multiple times</a
             >. My psychology background helps me understand why technical users
             behave the way they do and to design interventions that actually
@@ -58,7 +58,7 @@ const mobileImagePath = "/images/guido-up.png";
       <!-- Image Container -->
       <div class="md:w-1/3" role="complementary" aria-label="Profile images">
         <!-- Desktop Image -->
-        <figure class="hidden md:absolute md:bottom-0 md:right-4 md:block">
+        <figure class="hidden md:absolute md:right-4 md:bottom-0 md:block">
           <img
             src={desktopImagePath}
             alt="Guido X Jansen, community strategist and cognitive psychologist, standing confidently in a professional setting"

--- a/src/components/About/TheStory.astro
+++ b/src/components/About/TheStory.astro
@@ -60,7 +60,7 @@ Each role reinforced the same insight: understanding why people behave the way t
 
 <section
   id="the-story"
-  class="overflow-hidden bg-base-50 py-24 md:py-28 dark:bg-base-800/50"
+  class="bg-base-50 dark:bg-base-800/50 overflow-hidden py-24 md:py-28"
   aria-labelledby="story-heading"
 >
   <div class="site-container px-2 sm:px-4" role="presentation">
@@ -97,7 +97,7 @@ Each role reinforced the same insight: understanding why people behave the way t
             />
             <Icon
               name="tabler:letter-x"
-              class="-ml-3 h-14 w-14 text-base-100"
+              class="text-base-100 -ml-3 h-14 w-14"
               stroke-width="8"
               stroke="currentColor"
               fill="none"

--- a/src/components/About/WhatsNext.astro
+++ b/src/components/About/WhatsNext.astro
@@ -7,7 +7,7 @@ import Badge from "@components/Badge/Badge.astro";
 ---
 
 <section
-  class="bg-base-100 py-24 md:py-28 dark:bg-base-900"
+  class="bg-base-100 dark:bg-base-900 py-24 md:py-28"
   aria-labelledby="whats-next-heading"
 >
   <div class="site-container px-2 sm:px-4">
@@ -17,7 +17,7 @@ import Badge from "@components/Badge/Badge.astro";
         Need help and want to collaborate?
       </h2>
       <div
-        class="space-y-4 text-lg text-base-700 md:text-xl dark:text-base-300"
+        class="text-base-700 dark:text-base-300 space-y-4 text-lg md:text-xl"
       >
         <p class="description">
           I'm taking on community leadership opportunities at companies with
@@ -26,10 +26,10 @@ import Badge from "@components/Badge/Badge.astro";
         </p>
         <p class="description">
           Particularly interested in <span
-            class="font-semibold text-primary-500">open source</span
-          >, <span class="font-semibold text-primary-500">AI</span>, <span
-            class="font-semibold text-primary-500">automation</span
-          > and <span class="font-semibold text-primary-500"
+            class="text-primary-500 font-semibold">open source</span
+          >, <span class="text-primary-500 font-semibold">AI</span>, <span
+            class="text-primary-500 font-semibold">automation</span
+          > and <span class="text-primary-500 font-semibold"
             >privacy-focused</span
           > organizations.
         </p>
@@ -37,7 +37,7 @@ import Badge from "@components/Badge/Badge.astro";
       <div class="mt-8">
         <a
           href="/retainer/"
-          class="inline-flex items-center rounded-lg bg-primary-600 px-6 py-3 font-medium text-white transition-colors duration-200 hover:bg-primary-700"
+          class="bg-primary-600 hover:bg-primary-700 inline-flex items-center rounded-lg px-6 py-3 font-medium text-white transition-colors duration-200"
         >
           Work with me
           <svg

--- a/src/components/About/WhyItWorks.astro
+++ b/src/components/About/WhyItWorks.astro
@@ -70,7 +70,7 @@ const approaches: Approach[] = [
         <div class="space-y-4">
           {
             approaches.map((approach) => (
-              <div class="rounded-xl bg-base-50 p-4 shadow-sm transition-all duration-300 hover:shadow-md sm:p-5 dark:bg-base-800">
+              <div class="rounded-xl bg-base-50 p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-5 dark:bg-base-800">
                 <div class="flex flex-col gap-3 sm:flex-row sm:gap-4">
                   <div class="flex-shrink-0">
                     <div class="w-fit rounded-lg bg-primary-100 p-2 dark:bg-primary-900/30">

--- a/src/components/About/WhyItWorks.astro
+++ b/src/components/About/WhyItWorks.astro
@@ -48,18 +48,18 @@ const approaches: Approach[] = [
         <div>
           <Badge>The Psychology Edge</Badge>
           <h2 id="why-heading" class="h2 mb-6">Why This Approach Works</h2>
-          <div class="space-y-4 text-lg text-base-700 dark:text-base-300">
+          <div class="text-base-700 dark:text-base-300 space-y-4 text-lg">
             <p class="description">
               My cognitive psychology background shapes how I approach community
               building. I understand <span
-                class="font-semibold text-primary-500">why</span
+                class="text-primary-500 font-semibold">why</span
               > developers and technical users behave the way they do (or know how
               to figure it out), which lets me design interventions that actually
               work.
             </p>
             <p class="description">
               Where others ask "how do we get more people?" I ask "<span
-                class="font-semibold text-primary-500"
+                class="text-primary-500 font-semibold"
                 >why would someone stay, contribute, and advocate?</span
               >"
             </p>
@@ -70,21 +70,21 @@ const approaches: Approach[] = [
         <div class="space-y-4">
           {
             approaches.map((approach) => (
-              <div class="rounded-xl bg-base-50 p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-5 dark:bg-base-800">
+              <div class="bg-base-50 dark:bg-base-800 rounded-xl p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-5">
                 <div class="flex flex-col gap-3 sm:flex-row sm:gap-4">
                   <div class="flex-shrink-0">
-                    <div class="w-fit rounded-lg bg-primary-100 p-2 dark:bg-primary-900/30">
+                    <div class="bg-primary-100 dark:bg-primary-900/30 w-fit rounded-lg p-2">
                       <Icon
                         name={approach.icon}
-                        class="h-5 w-5 text-primary-600 dark:text-primary-400"
+                        class="text-primary-600 dark:text-primary-400 h-5 w-5"
                       />
                     </div>
                   </div>
                   <div>
-                    <h3 class="mb-1 font-semibold text-base-900 dark:text-base-100">
+                    <h3 class="text-base-900 dark:text-base-100 mb-1 font-semibold">
                       {approach.title}
                     </h3>
-                    <p class="text-sm text-base-600 dark:text-base-400">
+                    <p class="text-base-600 dark:text-base-400 text-sm">
                       {approach.description}
                     </p>
                   </div>
@@ -97,35 +97,35 @@ const approaches: Approach[] = [
 
       <!-- Experimentation background -->
       <div
-        class="mt-12 rounded-2xl bg-gradient-to-r from-primary-50 to-primary-100/50 p-5 sm:mt-16 sm:p-8 md:p-10 dark:from-primary-900/20 dark:to-primary-800/10"
+        class="from-primary-50 to-primary-100/50 dark:from-primary-900/20 dark:to-primary-800/10 mt-12 rounded-2xl bg-gradient-to-r p-5 sm:mt-16 sm:p-8 md:p-10"
       >
         <div class="flex flex-col items-start gap-4 sm:flex-row sm:gap-6">
           <div class="flex-shrink-0">
             <div
-              class="w-fit rounded-xl bg-primary-200 p-2 sm:p-3 dark:bg-primary-800/50"
+              class="bg-primary-200 dark:bg-primary-800/50 w-fit rounded-xl p-2 sm:p-3"
             >
               <Icon
                 name="tabler:flask"
-                class="h-6 w-6 text-primary-700 sm:h-8 sm:w-8 dark:text-primary-300"
+                class="text-primary-700 dark:text-primary-300 h-6 w-6 sm:h-8 sm:w-8"
               />
             </div>
           </div>
           <div>
             <h3
-              class="mb-2 text-lg font-bold text-base-900 sm:mb-3 sm:text-xl dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-2 text-lg font-bold sm:mb-3 sm:text-xl"
             >
               Data-Driven, Not Just Relational
             </h3>
             <p
-              class="text-base leading-relaxed text-base-700 sm:text-lg dark:text-base-300"
+              class="text-base-700 dark:text-base-300 text-base leading-relaxed sm:text-lg"
             >
               My experimentation background (running <span
-                class="font-semibold text-primary-600 dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 font-semibold"
                 >500+ A/B tests</span
               > at companies like Randstad and JDE) taught me to measure what matters
               and prove what's actually working. This makes me a different kind of
               community leader: one who thinks <span
-                class="font-semibold text-primary-600 dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 font-semibold"
                 >strategically and analytically</span
               >, not just relationally.
             </p>
@@ -137,7 +137,7 @@ const approaches: Approach[] = [
       <div class="mt-10 text-center">
         <a
           href="/authors/gxjansen/"
-          class="inline-flex items-center font-medium text-primary-600 transition-colors duration-200 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 inline-flex items-center font-medium transition-colors duration-200"
         >
           See my credentials, awards, and articles
           <svg

--- a/src/components/Accordion/Accordion.astro
+++ b/src/components/Accordion/Accordion.astro
@@ -18,17 +18,17 @@ const { title, details, group = "accordion" } = Astro.props;
 
 <details class="accordion group" name={group}>
   <summary
-    class="primary-focus flex cursor-pointer list-none items-center justify-between gap-2 py-3 text-lg font-bold text-base-900 transition hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-500"
+    class="primary-focus text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-500 flex cursor-pointer list-none items-center justify-between gap-2 py-3 text-lg font-bold transition"
   >
     {title}
     <Icon
       name="tabler/circle-arrow-up"
       aria-hidden="true"
-      class="accordion__chevron size-6 shrink-0 rotate-180 text-primary-500 transition-transform duration-[400ms] ease-[cubic-bezier(0.33,1,0.68,1)]"
+      class="accordion__chevron text-primary-500 size-6 shrink-0 rotate-180 transition-transform duration-[400ms] ease-[cubic-bezier(0.33,1,0.68,1)]"
     />
   </summary>
   <div class="accordion__content">
-    <p class="description prose mb-4 mr-auto mt-1 max-w-lg leading-snug">
+    <p class="description prose mt-1 mr-auto mb-4 max-w-lg leading-snug">
       <Fragment set:html={details} />
     </p>
   </div>

--- a/src/components/Admonition/Admonition.astro
+++ b/src/components/Admonition/Admonition.astro
@@ -35,14 +35,14 @@ const label =
 
 {
   variant === "terminal" ? (
-    <div class="admonition my-3 rounded-lg border-l-4 border-gold bg-gold/10 px-4 py-3 font-mono text-sm text-base-600 prose-code:bg-gold/20 dark:text-base-300 dark:prose-code:bg-gold/20">
+    <div class="admonition border-gold bg-gold/10 text-base-600 prose-code:bg-gold/20 dark:text-base-300 dark:prose-code:bg-gold/20 my-3 rounded-lg border-l-4 px-4 py-3 font-mono text-sm">
       <span
         class="mr-2 inline-flex items-center gap-1.5 align-middle"
         style="transform: translateY(-1px);"
       >
         <Icon
           name={icon}
-          class="inline size-5 text-base-600 dark:text-base-300"
+          class="text-base-600 dark:text-base-300 inline size-5"
           aria-hidden="true"
         />
         <span class="font-bold">{label}</span>
@@ -50,14 +50,14 @@ const label =
       <slot />
     </div>
   ) : variant === "prompt" ? (
-    <div class="admonition my-3 rounded-lg border-l-4 border-pine bg-pine/10 px-4 py-3 font-mono text-sm text-base-600 dark:text-base-300">
+    <div class="admonition border-pine bg-pine/10 text-base-600 dark:text-base-300 my-3 rounded-lg border-l-4 px-4 py-3 font-mono text-sm">
       <span
         class="mr-2 inline-flex items-center gap-1.5 align-middle"
         style="transform: translateY(-1px);"
       >
         <Icon
           name={icon}
-          class="inline size-5 text-base-600 dark:text-base-300"
+          class="text-base-600 dark:text-base-300 inline size-5"
           aria-hidden="true"
         />
         <span class="font-bold">{label}</span>
@@ -67,7 +67,7 @@ const label =
   ) : (
     <div
       class:list={[
-        "admonition my-3 rounded-lg border-l-4 px-4 py-3 text-base-600 dark:text-base-300",
+        "admonition text-base-600 dark:text-base-300 my-3 rounded-lg border-l-4 px-4 py-3",
         {
           "border-success bg-success/10 text-success-content prose-code:bg-success/20 dark:prose-code:bg-success/20":
             variant === "tip",
@@ -89,7 +89,7 @@ const label =
       <div class="flex items-center gap-2 pb-2">
         <Icon
           name={icon}
-          class="size-7 text-base-600 dark:text-base-300"
+          class="text-base-600 dark:text-base-300 size-7"
           aria-hidden="true"
         />
         <p class="text-sm font-bold">{label}</p>

--- a/src/components/Author/AuthorBioBox.astro
+++ b/src/components/Author/AuthorBioBox.astro
@@ -38,10 +38,10 @@ const hasWebsite = website && website.includes("gui.do");
 ---
 
 <aside
-  class="mt-12 rounded-xl border border-base-300 bg-base-50 p-6 dark:border-base-700 dark:bg-base-900"
+  class="border-base-300 bg-base-50 dark:border-base-700 dark:bg-base-900 mt-12 rounded-xl border p-6"
   aria-label={`About ${name}`}
 >
-  <h3 class="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+  <h3 class="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
     About the Author
   </h3>
 
@@ -56,7 +56,7 @@ const hasWebsite = website && website.includes("gui.do");
               width={120}
               height={120}
               quality="high"
-              class="md:h-30 md:w-30 h-24 w-24 rounded-full object-cover"
+              class="h-24 w-24 rounded-full object-cover md:h-30 md:w-30"
             />
           </a>
         </div>
@@ -66,14 +66,14 @@ const hasWebsite = website && website.includes("gui.do");
     <div class="flex-1">
       <a
         href={authorUrl}
-        class="text-xl font-semibold text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400"
+        class="text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400 text-xl font-semibold"
       >
         {name}
       </a>
 
       {
         (jobTitle || organization) && (
-          <div class="mt-1 text-base-600 dark:text-base-400">
+          <div class="text-base-600 dark:text-base-400 mt-1">
             {jobTitle}
             {jobTitle && organization && " at "}
             {organization}
@@ -83,7 +83,7 @@ const hasWebsite = website && website.includes("gui.do");
 
       {
         bio && (
-          <div class="prose prose-sm mt-3 max-w-none text-base-700 dark:prose-invert dark:text-base-300">
+          <div class="prose prose-sm text-base-700 dark:prose-invert dark:text-base-300 mt-3 max-w-none">
             <p>{bio}</p>
           </div>
         )
@@ -92,12 +92,12 @@ const hasWebsite = website && website.includes("gui.do");
       {
         expertise.length > 0 && (
           <div class="mt-4">
-            <h4 class="mb-2 text-sm font-semibold text-base-900 dark:text-base-100">
+            <h4 class="text-base-900 dark:text-base-100 mb-2 text-sm font-semibold">
               Areas of Expertise
             </h4>
             <div class="flex flex-wrap gap-2">
               {expertise.map((topic: string) => (
-                <span class="rounded-full bg-primary-100 px-3 py-1 text-xs text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+                <span class="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200 rounded-full px-3 py-1 text-xs">
                   {topic}
                 </span>
               ))}
@@ -109,10 +109,10 @@ const hasWebsite = website && website.includes("gui.do");
       {
         credentials.length > 0 && (
           <div class="mt-4">
-            <h4 class="mb-2 text-sm font-semibold text-base-900 dark:text-base-100">
+            <h4 class="text-base-900 dark:text-base-100 mb-2 text-sm font-semibold">
               Credentials
             </h4>
-            <ul class="list-inside list-disc space-y-1 text-sm text-base-700 dark:text-base-300">
+            <ul class="text-base-700 dark:text-base-300 list-inside list-disc space-y-1 text-sm">
               {credentials.map((credential: string) => (
                 <li>{credential}</li>
               ))}
@@ -137,7 +137,7 @@ const hasWebsite = website && website.includes("gui.do");
                 href={website}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="ml-2 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 ml-2 text-sm font-medium"
               >
                 gui.do →
               </a>
@@ -149,7 +149,7 @@ const hasWebsite = website && website.includes("gui.do");
       <div class="mt-4">
         <a
           href={authorUrl}
-          class="text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+          class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 text-sm font-medium"
         >
           View all posts by {name} →
         </a>

--- a/src/components/Author/AuthorByline.astro
+++ b/src/components/Author/AuthorByline.astro
@@ -40,7 +40,7 @@ const authorUrl = `/authors/${author.id}`;
     <div class="flex flex-wrap items-baseline gap-2">
       <a
         href={authorUrl}
-        class="font-semibold text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400"
+        class="text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400 font-semibold"
         itemprop="url"
       >
         <span itemprop="name">{name}</span>
@@ -50,7 +50,7 @@ const authorUrl = `/authors/${author.id}`;
     {
       showBio && bioShort && (
         <p
-          class="mt-1 text-sm text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 mt-1 text-sm"
           itemprop="description"
         >
           {bioShort}

--- a/src/components/Badge/Badge.astro
+++ b/src/components/Badge/Badge.astro
@@ -21,7 +21,7 @@ const classes = [
   "uppercase",
   "leading-5",
   "text-primary-500",
-  "shadow-sm",
+  "shadow-xs",
   "shadow-base-200/20",
   "dark:bg-primary-500",
   "dark:text-base-100",
@@ -41,10 +41,10 @@ const classes = [
 <style>
   /* Ensure proper color contrast in all themes */
   span {
-    --badge-bg-light: theme("colors.primary.100");
-    --badge-text-light: theme("colors.primary.700");
-    --badge-bg-dark: theme("colors.primary.500");
-    --badge-text-dark: theme("colors.base.100");
+    --badge-bg-light: var(--color-primary-100);
+    --badge-text-light: var(--color-primary-700);
+    --badge-bg-dark: var(--color-primary-500);
+    --badge-text-dark: var(--color-base-100);
   }
 
   /* Light theme */

--- a/src/components/Blog/BlogNav.astro
+++ b/src/components/Blog/BlogNav.astro
@@ -28,7 +28,7 @@ const nextPost =
   <div class="flex items-center justify-between">
     <a
       href={`/post/`}
-      class="flex items-center gap-2 rounded text-base-600 hover:text-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-primary-400"
+      class="flex items-center gap-2 rounded-sm text-base-600 hover:text-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-primary-400"
       aria-label="Return to article overview"
       data-umami-event="nav-click"
       data-umami-event-target="blog-overview"
@@ -54,7 +54,7 @@ const nextPost =
       prevPost && (
         <a
           href={`/post/${prevPost.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 hover:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
+          class="group flex-1 rounded-lg border border-base-200 p-4 hover:border-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
           aria-label={`Previous article: ${prevPost.data.title}`}
           data-umami-event="nav-click"
           data-umami-event-target="blog-prev"
@@ -85,7 +85,7 @@ const nextPost =
       nextPost && (
         <a
           href={`/post/${nextPost.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 text-right hover:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
+          class="group flex-1 rounded-lg border border-base-200 p-4 text-right hover:border-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
           aria-label={`Next article: ${nextPost.data.title}`}
           data-umami-event="nav-click"
           data-umami-event-target="blog-next"

--- a/src/components/Blog/BlogNav.astro
+++ b/src/components/Blog/BlogNav.astro
@@ -22,13 +22,13 @@ const nextPost =
 ---
 
 <nav
-  class="mt-12 border-t border-base-200 pt-8 dark:border-base-800"
+  class="border-base-200 dark:border-base-800 mt-12 border-t pt-8"
   aria-label="Blog post navigation"
 >
   <div class="flex items-center justify-between">
     <a
       href={`/post/`}
-      class="flex items-center gap-2 rounded-sm text-base-600 hover:text-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-primary-400"
+      class="text-base-600 hover:text-primary-500 focus:ring-primary-500 dark:text-base-400 dark:hover:text-primary-400 flex items-center gap-2 rounded-sm focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
       aria-label="Return to article overview"
       data-umami-event="nav-click"
       data-umami-event-target="blog-overview"
@@ -54,12 +54,12 @@ const nextPost =
       prevPost && (
         <a
           href={`/post/${prevPost.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 hover:border-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
+          class="group border-base-200 hover:border-primary-500 focus:ring-primary-500 dark:border-base-800 dark:hover:border-primary-400 flex-1 rounded-lg border p-4 focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
           aria-label={`Previous article: ${prevPost.data.title}`}
           data-umami-event="nav-click"
           data-umami-event-target="blog-prev"
         >
-          <span class="flex items-center gap-1 text-sm text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400">
+          <span class="text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400 flex items-center gap-1 text-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="h-4 w-4"
@@ -74,7 +74,7 @@ const nextPost =
             </svg>
             <span>Previous</span>
           </span>
-          <p class="mt-1 line-clamp-2 font-medium text-base-900 group-hover:text-primary-500 dark:text-white dark:group-hover:text-primary-400">
+          <p class="text-base-900 group-hover:text-primary-500 dark:group-hover:text-primary-400 mt-1 line-clamp-2 font-medium dark:text-white">
             {prevPost.data.title}
           </p>
         </a>
@@ -85,12 +85,12 @@ const nextPost =
       nextPost && (
         <a
           href={`/post/${nextPost.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 text-right hover:border-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-base-800 dark:hover:border-primary-400"
+          class="group border-base-200 hover:border-primary-500 focus:ring-primary-500 dark:border-base-800 dark:hover:border-primary-400 flex-1 rounded-lg border p-4 text-right focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
           aria-label={`Next article: ${nextPost.data.title}`}
           data-umami-event="nav-click"
           data-umami-event-target="blog-next"
         >
-          <span class="flex items-center justify-end gap-1 text-sm text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400">
+          <span class="text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400 flex items-center justify-end gap-1 text-sm">
             <span>Next</span>
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -105,7 +105,7 @@ const nextPost =
               <path d="M9 6l6 6l-6 6" />
             </svg>
           </span>
-          <p class="mt-1 line-clamp-2 font-medium text-base-900 group-hover:text-primary-500 dark:text-white dark:group-hover:text-primary-400">
+          <p class="text-base-900 group-hover:text-primary-500 dark:group-hover:text-primary-400 mt-1 line-clamp-2 font-medium dark:text-white">
             {nextPost.data.title}
           </p>
         </a>

--- a/src/components/Bluesky/BlueskyComments.tsx
+++ b/src/components/Bluesky/BlueskyComments.tsx
@@ -69,14 +69,14 @@ export default function BlueskyComments({ uri, postTitle, postUrl }: Props) {
     return (
       <section className="bluesky-comments-section mt-12">
         <aside
-          className="rounded-xl border border-base-300 bg-base-50 p-6 dark:border-base-700 dark:bg-base-900"
+          className="border-base-300 bg-base-50 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           aria-label="Comments"
         >
-          <h3 className="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 className="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
             Comments
           </h3>
           <div className="py-4 text-center">
-            <p className="mb-4 text-base-600 dark:text-base-400">
+            <p className="text-base-600 dark:text-base-400 mb-4">
               Want to discuss this post? Start a conversation on Bluesky.
             </p>
             <a
@@ -105,14 +105,14 @@ export default function BlueskyComments({ uri, postTitle, postUrl }: Props) {
     return (
       <section className="bluesky-comments-section mt-12">
         <aside
-          className="rounded-xl border border-base-300 bg-base-50 p-6 dark:border-base-700 dark:bg-base-900"
+          className="border-base-300 bg-base-50 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           aria-label="Comments"
         >
-          <h3 className="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 className="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
             Comments
           </h3>
           <div className="py-4 text-center">
-            <p className="mb-4 text-base-600 dark:text-base-400">
+            <p className="text-base-600 dark:text-base-400 mb-4">
               {isError
                 ? "Couldn't load comments. Join the conversation on Bluesky!"
                 : "No comments yet. Be the first to join the conversation!"}
@@ -136,7 +136,7 @@ export default function BlueskyComments({ uri, postTitle, postUrl }: Props) {
   return (
     <section className="bluesky-comments-section mt-12">
       <aside
-        className="rounded-xl border border-base-300 bg-base-50 p-6 dark:border-base-700 dark:bg-base-900"
+        className="border-base-300 bg-base-50 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         aria-label="Comments from Bluesky"
       >
         <div className="bluesky-comments-wrapper">
@@ -146,7 +146,7 @@ export default function BlueskyComments({ uri, postTitle, postUrl }: Props) {
             onEmpty={handleEmpty}
           />
         </div>
-        <div className="mt-6 border-t border-base-200 pt-4 text-center dark:border-base-700">
+        <div className="border-base-200 dark:border-base-700 mt-6 border-t pt-4 text-center">
           <a
             href={replyUrl}
             target="_blank"

--- a/src/components/Button/Button.astro
+++ b/src/components/Button/Button.astro
@@ -57,7 +57,7 @@ const baseClasses = [
   className,
   "button group",
   "inline-flex items-center justify-center",
-  "focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2",
+  "focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2",
   "disabled:opacity-50 disabled:cursor-not-allowed",
   {
     "button--primary": variant === "primary",
@@ -145,6 +145,7 @@ const baseClasses = [
 }
 
 <style>
+  @reference "../../styles/tailwind.css";
   .button {
     position: relative;
     padding: 0.75rem 1.5rem;

--- a/src/components/Button/Button.astro
+++ b/src/components/Button/Button.astro
@@ -162,11 +162,11 @@ const baseClasses = [
 
   /* Variant styles with improved contrast ratios */
   .button--primary {
-    @apply bg-primary-600 text-white hover:bg-primary-700;
+    @apply bg-primary-600 hover:bg-primary-700 text-white;
   }
 
   .button--secondary {
-    @apply bg-base-300 text-base-900 hover:bg-base-400 dark:bg-base-600 dark:text-white dark:hover:bg-base-700;
+    @apply bg-base-300 text-base-900 hover:bg-base-400 dark:bg-base-600 dark:hover:bg-base-700 dark:text-white;
   }
 
   .button--outline {
@@ -228,11 +228,11 @@ const baseClasses = [
   }
 
   .button--ghost {
-    @apply bg-transparent text-base-800 hover:bg-base-200 dark:text-base-100 dark:hover:bg-base-800;
+    @apply text-base-800 hover:bg-base-200 dark:text-base-100 dark:hover:bg-base-800 bg-transparent;
   }
 
   /* Special variant for buttons on colored backgrounds */
   .button--on-color {
-    @apply border-2 border-base-100 bg-transparent text-base-100 hover:bg-base-100 hover:text-primary-500 dark:border-base-900 dark:text-base-900 dark:hover:bg-base-900 dark:hover:text-primary-500;
+    @apply border-base-100 text-base-100 hover:bg-base-100 hover:text-primary-500 dark:border-base-900 dark:text-base-900 dark:hover:bg-base-900 dark:hover:text-primary-500 border-2 bg-transparent;
   }
 </style>

--- a/src/components/Button/VideoButton.astro
+++ b/src/components/Button/VideoButton.astro
@@ -116,6 +116,7 @@ import video from "@videos/placeholder-space.mp4";
 </script>
 
 <style lang="scss">
+  @reference "../../styles/tailwind.css";
   .video-button__backdrop-button--show {
     animation: fadeInAnimation ease-in-out 0.3s forwards;
   }

--- a/src/components/Button/VideoButton.astro
+++ b/src/components/Button/VideoButton.astro
@@ -32,7 +32,7 @@ import video from "@videos/placeholder-space.mp4";
     <!-- backdrop button to close video -->
     <button
       id="video-button__backdrop-button"
-      class="absolute inset-0 z-30 h-full w-full bg-base-900 transition-all"
+      class="bg-base-900 absolute inset-0 z-30 h-full w-full transition-all"
     >
     </button>
 
@@ -57,10 +57,10 @@ import video from "@videos/placeholder-space.mp4";
       <button
         id="video-button__close-button"
         aria-label="close video"
-        class="group absolute right-0 top-0 z-30 h-7 w-7 rounded-full border-2 border-base-50 transition-all hover:border-primary-500"
+        class="group border-base-50 hover:border-primary-500 absolute top-0 right-0 z-30 h-7 w-7 rounded-full border-2 transition-all"
       >
         <XIcon
-          class="m-auto aspect-square h-full max-h-14 w-full text-base-50 transition group-hover:text-primary-500 dark:text-base-950"
+          class="text-base-50 group-hover:text-primary-500 dark:text-base-950 m-auto aspect-square h-full max-h-14 w-full transition"
           aria-hidden="true"
         />
       </button>

--- a/src/components/Category/Category.astro
+++ b/src/components/Category/Category.astro
@@ -16,7 +16,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
 
 <div role="listitem">
   <a
-    class="inline-block rounded-full bg-primary-100/70 px-3 py-1 text-xs font-medium uppercase leading-5 text-primary-500 shadow-sm shadow-base-200/20 transition-colors hover:bg-primary-200/70 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-primary-500/90 dark:text-base-50 dark:shadow-none dark:hover:bg-primary-600"
+    class="inline-block rounded-full bg-primary-100/70 px-3 py-1 text-xs font-medium uppercase leading-5 text-primary-500 shadow-xs shadow-base-200/20 transition-colors hover:bg-primary-200/70 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-primary-500/90 dark:text-base-50 dark:shadow-none dark:hover:bg-primary-600"
     href={getRelativeLocaleUrl(currLocale, `/categories/${slugify(category)}`)}
     aria-label={`View all posts in category: ${humanize(category)}`}
     role="link"

--- a/src/components/Category/Category.astro
+++ b/src/components/Category/Category.astro
@@ -16,7 +16,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
 
 <div role="listitem">
   <a
-    class="inline-block rounded-full bg-primary-100/70 px-3 py-1 text-xs font-medium uppercase leading-5 text-primary-500 shadow-xs shadow-base-200/20 transition-colors hover:bg-primary-200/70 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-primary-500/90 dark:text-base-50 dark:shadow-none dark:hover:bg-primary-600"
+    class="bg-primary-100/70 text-primary-500 shadow-base-200/20 hover:bg-primary-200/70 focus:ring-primary-500 dark:bg-primary-500/90 dark:text-base-50 dark:hover:bg-primary-600 inline-block rounded-full px-3 py-1 text-xs leading-5 font-medium uppercase shadow-xs transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden dark:shadow-none"
     href={getRelativeLocaleUrl(currLocale, `/categories/${slugify(category)}`)}
     aria-label={`View all posts in category: ${humanize(category)}`}
     role="link"

--- a/src/components/Common/Skeleton.astro
+++ b/src/components/Common/Skeleton.astro
@@ -15,7 +15,7 @@ const typeClasses = {
 
 <div
   class:list={[
-    "animate-pulse bg-base-200 dark:bg-base-700",
+    "bg-base-200 dark:bg-base-700 animate-pulse",
     typeClasses[type],
     className,
   ]}

--- a/src/components/Common/Skeleton.astro
+++ b/src/components/Common/Skeleton.astro
@@ -9,7 +9,7 @@ const { type = "card", class: className } = Astro.props;
 const typeClasses = {
   card: "rounded-lg",
   image: "rounded-lg aspect-video",
-  text: "rounded h-4",
+  text: "rounded-sm h-4",
 };
 ---
 

--- a/src/components/Compacting/Compacting.astro
+++ b/src/components/Compacting/Compacting.astro
@@ -37,6 +37,7 @@ const { message = "Compacting our conversation so we can keep chatting..." } =
 </div>
 
 <style>
+  @reference "../../styles/tailwind.css";
   .compacting {
     padding: 1em 0;
     margin: 1em 0;

--- a/src/components/Compacting/CompactingV2.astro
+++ b/src/components/Compacting/CompactingV2.astro
@@ -31,6 +31,7 @@ const {
 </div>
 
 <style>
+  @reference "../../styles/tailwind.css";
   .compacting-v2 {
     @apply bg-base-950;
     padding: 3em 2em;

--- a/src/components/Companies/CompanyLogos.astro
+++ b/src/components/Companies/CompanyLogos.astro
@@ -20,7 +20,7 @@ const companies = [
 ---
 
 <section aria-label="Companies">
-  <div class="site-container mx-auto px-4 pb-20 pt-10 md:py-28">
+  <div class="site-container mx-auto px-4 pt-10 pb-20 md:py-28">
     <div class="relative">
       <div class="relative">
         <div class="mx-auto mb-16 text-center md:max-w-4xl">

--- a/src/components/CookieConsent/CookieConsent.astro
+++ b/src/components/CookieConsent/CookieConsent.astro
@@ -24,16 +24,16 @@ const currLocale = getLocaleFromUrl(Astro.url);
   class="fixed inset-x-6 bottom-6 z-50 hidden justify-center"
 >
   <div
-    class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 rounded-md border border-base-200 bg-base-50 p-4"
+    class="border-base-200 bg-base-50 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 rounded-md border p-4"
   >
     <div class="text-center">
       <p
-        class="text-sm font-medium text-base-500 lg:text-base dark:text-base-400"
+        class="text-base-500 dark:text-base-400 text-sm font-medium lg:text-base"
       >
         We use cookies to improve your experience on this site. To learn more,
         see our <a
           href={getRelativeLocaleUrl(currLocale, "/privacy-policy")}
-          class="text-base-700 underline decoration-primary-500 transition hover:text-primary-500 dark:text-base-200"
+          class="text-base-700 decoration-primary-500 hover:text-primary-500 dark:text-base-200 underline transition"
           >Privacy Policy</a
         >.
       </p>

--- a/src/components/Cta/CtaCardCenter.astro
+++ b/src/components/Cta/CtaCardCenter.astro
@@ -12,21 +12,21 @@ import Button from "@components/Button/Button.astro";
 <section class="py-10">
   <div class="site-container">
     <div
-      class="relative overflow-hidden rounded-md bg-base-900 px-16 py-11 md:py-20"
+      class="bg-base-900 relative overflow-hidden rounded-md px-16 py-11 md:py-20"
     >
       <Icon
         name="atlas/dots3"
-        class="absolute left-4 top-0 z-10 size-16 text-accent-3"
+        class="text-accent-3 absolute top-0 left-4 z-10 size-16"
         aria-hidden="true"
       />
       <Icon
         name="atlas/dots3"
-        class="absolute bottom-0 right-4 z-10 size-16 text-accent-1"
+        class="text-accent-1 absolute right-4 bottom-0 z-10 size-16"
         aria-hidden="true"
       />
       <Icon
         name="atlas/wave-bg-basic"
-        class="absolute left-1/2 top-1/2 h-full -translate-x-1/2 -translate-y-1/2 object-cover text-base-900 dark:text-base-100/5"
+        class="text-base-900 dark:text-base-100/5 absolute top-1/2 left-1/2 h-full -translate-x-1/2 -translate-y-1/2 object-cover"
         aria-hidden="true"
       />
 
@@ -34,7 +34,7 @@ import Button from "@components/Button/Button.astro";
         class="relative z-20 -m-3 mx-auto flex max-w-lg flex-col flex-wrap items-center gap-4 text-center"
       >
         <h2
-          class="mb-6 text-4xl/normal font-bold text-base-100 dark:text-base-900"
+          class="text-base-100 dark:text-base-900 mb-6 text-4xl/normal font-bold"
         >
           Ready to unlock the strategic value in your ecosystem?
         </h2>

--- a/src/components/Cta/CtaCardSplit.astro
+++ b/src/components/Cta/CtaCardSplit.astro
@@ -58,7 +58,7 @@ import Button from "@components/Button/Button.astro";
           <Button
             variant="on-color"
             href="/speaker/"
-            class="shadow-none focus:outline-none focus:ring-2 focus:ring-base-100 focus:ring-offset-2 focus:ring-offset-primary-500"
+            class="shadow-none focus:outline-hidden focus:ring-2 focus:ring-base-100 focus:ring-offset-2 focus:ring-offset-primary-500"
             aria-label="Invite Guido to speak at your event"
           >
             <span>Invite me to speak</span>

--- a/src/components/Cta/CtaCardSplit.astro
+++ b/src/components/Cta/CtaCardSplit.astro
@@ -12,25 +12,25 @@ import Button from "@components/Button/Button.astro";
 <section class="py-10" aria-labelledby="cta-heading">
   <div class="site-container">
     <div
-      class="relative overflow-hidden rounded-md bg-primary-500 px-4 py-8 sm:px-8 sm:py-11 md:px-16 md:py-20"
+      class="bg-primary-500 relative overflow-hidden rounded-md px-4 py-8 sm:px-8 sm:py-11 md:px-16 md:py-20"
       role="region"
       aria-label="Call to action"
     >
       <Icon
         name="atlas/dots3"
-        class="absolute left-4 top-0 z-10 size-16 text-accent-4"
+        class="text-accent-4 absolute top-0 left-4 z-10 size-16"
         aria-hidden="true"
         role="presentation"
       />
       <Icon
         name="atlas/dots3"
-        class="absolute bottom-0 right-4 z-10 size-16 text-accent-4"
+        class="text-accent-4 absolute right-4 bottom-0 z-10 size-16"
         aria-hidden="true"
         role="presentation"
       />
       <Icon
         name="atlas/wave-bg-basic"
-        class="absolute left-1/2 top-1/2 h-full w-full max-w-full -translate-x-1/2 -translate-y-1/2 object-cover text-base-100/5"
+        class="text-base-100/5 absolute top-1/2 left-1/2 h-full w-full max-w-full -translate-x-1/2 -translate-y-1/2 object-cover"
         aria-hidden="true"
         role="presentation"
       />
@@ -42,12 +42,12 @@ import Button from "@components/Button/Button.astro";
         <div class="w-full p-3 md:w-1/2">
           <h2
             id="cta-heading"
-            class="mb-4 text-2xl font-bold tracking-tighter text-base-100 sm:mb-6 sm:text-3xl md:text-4xl dark:text-base-900"
+            class="text-base-100 dark:text-base-900 mb-4 text-2xl font-bold tracking-tighter sm:mb-6 sm:text-3xl md:text-4xl"
           >
             Ready to discover what your ecosystem could become?
           </h2>
           <p
-            class="font-semibold text-base-100 dark:text-base-900"
+            class="text-base-100 dark:text-base-900 font-semibold"
             aria-describedby="cta-heading"
           >
             I speak at international conferences regularly and often get voted
@@ -58,7 +58,7 @@ import Button from "@components/Button/Button.astro";
           <Button
             variant="on-color"
             href="/speaker/"
-            class="shadow-none focus:outline-hidden focus:ring-2 focus:ring-base-100 focus:ring-offset-2 focus:ring-offset-primary-500"
+            class="focus:ring-base-100 focus:ring-offset-primary-500 shadow-none focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
             aria-label="Invite Guido to speak at your event"
           >
             <span>Invite me to speak</span>

--- a/src/components/Cta/CtaCenter.astro
+++ b/src/components/Cta/CtaCenter.astro
@@ -15,10 +15,10 @@ import Button from "@components/Button/Button.astro";
     <div
       class="relative z-20 -m-3 mx-auto flex max-w-[760px] flex-col flex-wrap items-center gap-6 text-center"
     >
-      <h2 class="text-balance text-4xl/tight font-bold dark:text-base-100">
+      <h2 class="dark:text-base-100 text-4xl/tight font-bold text-balance">
         The fastest way to make a site.
       </h2>
-      <p class="description text-pretty text-lg">
+      <p class="description text-lg text-pretty">
         Level up with this template. Multiple pages and sections, blog, i18n,
         animations, CMS - all ready to go.
       </p>

--- a/src/components/Embed/SpotifyEmbed.astro
+++ b/src/components/Embed/SpotifyEmbed.astro
@@ -21,11 +21,11 @@ const { episodeId, title } = Astro.props;
       style="opacity: 0; transition: opacity 0.3s ease-in-out"
       onload="this.style.opacity = 1"></iframe>
     <div
-      class="absolute inset-0 flex items-center justify-center rounded-lg bg-base-200"
+      class="bg-base-200 absolute inset-0 flex items-center justify-center rounded-lg"
       id={`spotify-load-button-${episodeId}`}
     >
       <button
-        class="rounded-sm bg-primary-500 px-4 py-2 text-white transition-colors hover:bg-primary-600"
+        class="bg-primary-500 hover:bg-primary-600 rounded-sm px-4 py-2 text-white transition-colors"
         onclick="document.getElementById(`spotify-embed-${episodeId}`).src = `https://open.spotify.com/embed/episode/${episodeId}`; this.parentElement.style.display = 'none';"
       >
         Load Spotify Player

--- a/src/components/Embed/SpotifyEmbed.astro
+++ b/src/components/Embed/SpotifyEmbed.astro
@@ -25,7 +25,7 @@ const { episodeId, title } = Astro.props;
       id={`spotify-load-button-${episodeId}`}
     >
       <button
-        class="rounded bg-primary-500 px-4 py-2 text-white transition-colors hover:bg-primary-600"
+        class="rounded-sm bg-primary-500 px-4 py-2 text-white transition-colors hover:bg-primary-600"
         onclick="document.getElementById(`spotify-embed-${episodeId}`).src = `https://open.spotify.com/embed/episode/${episodeId}`; this.parentElement.style.display = 'none';"
       >
         Load Spotify Player

--- a/src/components/Events/EventCard.astro
+++ b/src/components/Events/EventCard.astro
@@ -84,7 +84,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
             </span>
             {
               workshop && (
-                <span class="rounded bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400">
+                <span class="rounded-sm bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400">
                   Workshop
                 </span>
               )
@@ -120,7 +120,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
                   alt={`Flag of ${country}`}
                   width={16}
                   height={12}
-                  class="mb-0 inline-block rounded-sm mix-blend-multiply dark:mix-blend-screen"
+                  class="mb-0 inline-block rounded-xs mix-blend-multiply dark:mix-blend-screen"
                   loading="lazy"
                 />
               ) : (

--- a/src/components/Events/EventCard.astro
+++ b/src/components/Events/EventCard.astro
@@ -57,7 +57,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
   <WrapperTag {...wrapperProps} class={wrapperClasses}>
     <div class="mb-3 flex items-center">
       <div
-        class="mr-3 flex h-10 w-10 items-center justify-center rounded-lg bg-base-300 dark:bg-base-800"
+        class="bg-base-300 dark:bg-base-800 mr-3 flex h-10 w-10 items-center justify-center rounded-lg"
       >
         {
           loadedIcon ? (
@@ -78,20 +78,20 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
         <div class="flex flex-wrap items-center gap-2">
           <div class="flex items-center gap-2">
             <span
-              class="text-lg font-semibold text-primary-600 dark:text-primary-400"
+              class="text-primary-600 dark:text-primary-400 text-lg font-semibold"
             >
               {name}
             </span>
             {
               workshop && (
-                <span class="rounded-sm bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400">
+                <span class="bg-primary-50 text-primary-600 dark:bg-primary-400/10 dark:text-primary-400 rounded-sm px-2 py-1 text-xs">
                   Workshop
                 </span>
               )
             }
             {
               linkUrl && (
-                <span class="text-primary-600 transition-transform duration-200 group-hover:translate-x-1 dark:text-primary-400">
+                <span class="text-primary-600 dark:text-primary-400 transition-transform duration-200 group-hover:translate-x-1">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     class="h-4 w-4"
@@ -110,7 +110,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
           </div>
         </div>
         <div
-          class="flex flex-col text-sm text-base-600 sm:flex-row sm:items-center sm:gap-1 dark:text-base-300"
+          class="text-base-600 dark:text-base-300 flex flex-col text-sm sm:flex-row sm:items-center sm:gap-1"
         >
           <div class="flex items-center gap-1">
             {
@@ -137,7 +137,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
     <div class="mt-2 flex items-center gap-2">
       {
         !isOnPresentationPage && displayText && (
-          <em class="line-clamp-1 flex-1 text-sm text-base-600 dark:text-base-400">
+          <em class="text-base-600 dark:text-base-400 line-clamp-1 flex-1 text-sm">
             {displayText}
           </em>
         )
@@ -145,7 +145,7 @@ const eventDate = new Date(date).toLocaleDateString("en-US", {
 
       {
         linkUrl && !isOnPresentationPage && presentationUrl && (
-          <div class="flex items-center gap-1 text-xs text-base-500 transition-colors duration-200 group-hover:text-primary-600 dark:text-base-400 dark:group-hover:text-primary-400">
+          <div class="text-base-500 group-hover:text-primary-600 dark:text-base-400 dark:group-hover:text-primary-400 flex items-center gap-1 text-xs transition-colors duration-200">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="24"

--- a/src/components/Events/RecurringEventCard.astro
+++ b/src/components/Events/RecurringEventCard.astro
@@ -40,7 +40,7 @@ const wrapperProps = url
   <WrapperTag {...wrapperProps} class={url ? "cursor-pointer" : ""}>
     <div class="mb-3 flex items-center">
       <div
-        class="mr-3 flex h-10 w-10 items-center justify-center rounded-lg bg-base-300 dark:bg-base-800"
+        class="bg-base-300 dark:bg-base-800 mr-3 flex h-10 w-10 items-center justify-center rounded-lg"
       >
         {
           icon ? (
@@ -61,18 +61,18 @@ const wrapperProps = url
         <div class="flex flex-wrap items-center gap-2">
           <div class="flex items-center gap-2">
             <span
-              class="text-lg font-semibold text-primary-600 dark:text-primary-400"
+              class="text-primary-600 dark:text-primary-400 text-lg font-semibold"
             >
               {name}
             </span>
             <span
-              class="rounded-sm bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400"
+              class="bg-primary-50 text-primary-600 dark:bg-primary-400/10 dark:text-primary-400 rounded-sm px-2 py-1 text-xs"
             >
               {events.length}x
             </span>
             {
               url && (
-                <span class="text-primary-600 transition-transform duration-200 group-hover:translate-x-1 dark:text-primary-400">
+                <span class="text-primary-600 dark:text-primary-400 transition-transform duration-200 group-hover:translate-x-1">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     class="h-4 w-4"
@@ -91,7 +91,7 @@ const wrapperProps = url
           </div>
         </div>
         <div
-          class="flex flex-col text-sm text-base-600 sm:flex-row sm:items-center sm:gap-1 dark:text-base-300"
+          class="text-base-600 dark:text-base-300 flex flex-col text-sm sm:flex-row sm:items-center sm:gap-1"
         >
           <span>🌎</span>
           <span>Online event</span>
@@ -103,7 +103,7 @@ const wrapperProps = url
     <div class="mt-2">
       {
         role && (
-          <em class="line-clamp-1 text-sm text-base-600 dark:text-base-400">
+          <em class="text-base-600 dark:text-base-400 line-clamp-1 text-sm">
             {role}
           </em>
         )

--- a/src/components/Events/RecurringEventCard.astro
+++ b/src/components/Events/RecurringEventCard.astro
@@ -66,7 +66,7 @@ const wrapperProps = url
               {name}
             </span>
             <span
-              class="rounded bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400"
+              class="rounded-sm bg-primary-50 px-2 py-1 text-xs text-primary-600 dark:bg-primary-400/10 dark:text-primary-400"
             >
               {events.length}x
             </span>

--- a/src/components/Events/UpcomingEvents.astro
+++ b/src/components/Events/UpcomingEvents.astro
@@ -41,7 +41,7 @@ const secondColumnEvents = upcomingEvents.filter((_, i) => i % 2 === 1);
               {events.filter((event) => new Date(event.date) >= today).length >
                 maxEvents && (
                 <p
-                  class="mt-4 text-base-400 dark:text-base-500"
+                  class="text-base-400 dark:text-base-500 mt-4"
                   aria-live="polite"
                 >
                   Showing {maxEvents} of{" "}

--- a/src/components/Faq/FaqCard.astro
+++ b/src/components/Faq/FaqCard.astro
@@ -8,8 +8,8 @@ const { question, answer } = Astro.props as Props;
 ---
 
 <div class="flex flex-col gap-3">
-  <p class="text-lg font-bold dark:text-base-100">{question}</p>
-  <div class="description prose mb-4 mr-auto mt-1 max-w-full leading-snug">
+  <p class="dark:text-base-100 text-lg font-bold">{question}</p>
+  <div class="description prose mt-1 mr-auto mb-4 max-w-full leading-snug">
     <Fragment set:html={answer} />
   </div>
 </div>

--- a/src/components/Feature/FeatureCardsSmall.astro
+++ b/src/components/Feature/FeatureCardsSmall.astro
@@ -48,7 +48,7 @@ const featureData: FeatureData[] = [
       <Badge>Strategic Impact</Badge>
       <h2 id="features-heading" class="h2 mb-4">Strategic Impact Areas</h2>
       <p
-        class="description text-pretty text-lg md:text-xl"
+        class="description text-lg text-pretty md:text-xl"
         aria-describedby="features-heading"
       >
         Transform your ecosystem into a strategic growth engine

--- a/src/components/Feature/FeatureFlagsMarquee.astro
+++ b/src/components/Feature/FeatureFlagsMarquee.astro
@@ -46,7 +46,7 @@ const marqueeBottom = {
         <div class="mx-auto mb-16 text-center md:max-w-4xl">
           <Badge>Flags</Badge>
           <h2 class="h2">Countries where I presented</h2>
-          <p class="description mt-4 text-pretty text-lg md:text-xl">
+          <p class="description mt-4 text-lg text-pretty md:text-xl">
             {uniqueCountries.length} and counting!
           </p>
         </div>
@@ -65,12 +65,12 @@ const marqueeBottom = {
         {/* marquee top row */}
         <div class="marquee-top relative flex gap-3 overflow-hidden md:gap-5">
           <div
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 md:gap-5"
           >
             {
               marqueeTop.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}
@@ -90,12 +90,12 @@ const marqueeBottom = {
           </div>
           <div
             aria-hidden="true"
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 md:gap-5"
           >
             {
               marqueeTop.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}
@@ -119,12 +119,12 @@ const marqueeBottom = {
           class="marquee-middle relative flex gap-3 overflow-hidden md:gap-5"
         >
           <div
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 [animation-direction:reverse] md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 [animation-direction:reverse] md:gap-5"
           >
             {
               marqueeMiddle.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}
@@ -143,12 +143,12 @@ const marqueeBottom = {
           </div>
           <div
             aria-hidden="true"
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 [animation-direction:reverse] md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 [animation-direction:reverse] md:gap-5"
           >
             {
               marqueeMiddle.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}
@@ -172,12 +172,12 @@ const marqueeBottom = {
           class="marquee-bottom relative flex gap-3 overflow-hidden md:gap-5"
         >
           <div
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 md:gap-5"
           >
             {
               marqueeBottom.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}
@@ -196,12 +196,12 @@ const marqueeBottom = {
           </div>
           <div
             aria-hidden="true"
-            class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-3 md:gap-5"
+            class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-3 md:gap-5"
           >
             {
               marqueeBottom.flags.map((flag) => (
                 <div class="relative w-[clamp(3rem,28vmin,5rem)] overflow-hidden">
-                  <div class="absolute inset-0 rounded-md shadow-[inset_0_0_0_1px] shadow-base-200/10 dark:shadow-base-800/10" />
+                  <div class="shadow-base-200/10 dark:shadow-base-800/10 absolute inset-0 rounded-md shadow-[inset_0_0_0_1px]" />
                   <Image
                     src={flag.image}
                     alt={`${flag.countryName} flag`}

--- a/src/components/Feature/FeatureGalleryMarquee.astro
+++ b/src/components/Feature/FeatureGalleryMarquee.astro
@@ -112,7 +112,7 @@ const marqueeBottom: MarqueeImages = {
             class="marquee-top relative flex gap-6 overflow-hidden md:gap-10"
           >
             <div
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 md:gap-10"
             >
               {
                 marqueeTop.images.map((item) => (
@@ -132,7 +132,7 @@ const marqueeBottom: MarqueeImages = {
             </div>
             <div
               aria-hidden="true"
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 md:gap-10"
             >
               {
                 marqueeTop.images.map((item) => (
@@ -157,7 +157,7 @@ const marqueeBottom: MarqueeImages = {
             class="marquee-middle relative flex gap-6 overflow-hidden md:gap-10"
           >
             <div
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 [animation-direction:reverse] md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 [animation-direction:reverse] md:gap-10"
             >
               {
                 marqueeMiddle.images.map((item) => (
@@ -177,7 +177,7 @@ const marqueeBottom: MarqueeImages = {
             </div>
             <div
               aria-hidden="true"
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 [animation-direction:reverse] md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 [animation-direction:reverse] md:gap-10"
             >
               {
                 marqueeMiddle.images.map((item) => (
@@ -202,7 +202,7 @@ const marqueeBottom: MarqueeImages = {
             class="marquee-bottom relative flex gap-6 overflow-hidden md:gap-10"
           >
             <div
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 md:gap-10"
             >
               {
                 marqueeBottom.images.map((item) => (
@@ -222,7 +222,7 @@ const marqueeBottom: MarqueeImages = {
             </div>
             <div
               aria-hidden="true"
-              class="flex min-w-full shrink-0 animate-marquee items-center justify-around gap-6 md:gap-10"
+              class="animate-marquee flex min-w-full shrink-0 items-center justify-around gap-6 md:gap-10"
             >
               {
                 marqueeBottom.images.map((item) => (

--- a/src/components/Feature/FeatureVideo.astro
+++ b/src/components/Feature/FeatureVideo.astro
@@ -39,21 +39,21 @@ import video from "@videos/placeholder-space.mp4";
           />
 
           <div
-            class="absolute left-0 top-0 m-auto flex h-full w-full items-center justify-center"
+            class="absolute top-0 left-0 m-auto flex h-full w-full items-center justify-center"
           >
             <div class="relative m-auto aspect-square h-[20%] max-h-16">
               <!-- background glow of play button -->
               <div
-                class="absolute inset-2 z-10 rounded-full bg-primary-500/70 motion-safe:animate-ping"
+                class="bg-primary-500/70 absolute inset-2 z-10 rounded-full motion-safe:animate-ping"
               >
               </div>
               <!-- play button -->
               <div
-                class="relative z-20 h-full w-full rounded-full bg-primary-500 p-2 transition-all duration-300 group-hover:bg-primary-600 xs:p-4"
+                class="bg-primary-500 group-hover:bg-primary-600 xs:p-4 relative z-20 h-full w-full rounded-full p-2 transition-all duration-300"
               >
                 <Icon
                   name="tabler/player-play"
-                  class="m-auto aspect-square h-full w-full text-base-50 dark:text-base-950"
+                  class="text-base-50 dark:text-base-950 m-auto aspect-square h-full w-full"
                   aria-hidden="true"
                 />
               </div>
@@ -62,12 +62,12 @@ import video from "@videos/placeholder-space.mp4";
 
           <Icon
             name="atlas/wave"
-            class="absolute -left-8 -top-8 z-10 w-40 text-primary-500"
+            class="text-primary-500 absolute -top-8 -left-8 z-10 w-40"
             aria-hidden="true"
           />
           <Icon
             name="atlas/wave"
-            class="absolute -bottom-8 -right-8 -z-10 w-40 text-accent-1"
+            class="text-accent-1 absolute -right-8 -bottom-8 -z-10 w-40"
             aria-hidden="true"
           />
         </button>
@@ -81,7 +81,7 @@ import video from "@videos/placeholder-space.mp4";
             <!-- backdrop button to close video -->
             <button
               id="feature-video__backdrop-button"
-              class="absolute inset-0 z-30 h-full w-full bg-base-900 transition-all"
+              class="bg-base-900 absolute inset-0 z-30 h-full w-full transition-all"
             >
             </button>
 
@@ -106,11 +106,11 @@ import video from "@videos/placeholder-space.mp4";
               <button
                 id="feature-video__close-button"
                 aria-label="close video"
-                class="group absolute right-0 top-0 z-30 h-7 w-7 rounded-full border-2 border-base-50 transition-all hover:border-primary-400"
+                class="group border-base-50 hover:border-primary-400 absolute top-0 right-0 z-30 h-7 w-7 rounded-full border-2 transition-all"
               >
                 <Icon
                   name="tabler/x"
-                  class="m-auto aspect-square h-full max-h-14 w-full text-base-50 transition group-hover:text-primary-400 dark:text-base-950"
+                  class="text-base-50 group-hover:text-primary-400 dark:text-base-950 m-auto aspect-square h-full max-h-14 w-full transition"
                   aria-hidden="true"
                 />
               </button>

--- a/src/components/Feature/FeatureVideo.astro
+++ b/src/components/Feature/FeatureVideo.astro
@@ -170,6 +170,7 @@ import video from "@videos/placeholder-space.mp4";
 </script>
 
 <style lang="scss">
+  @reference "../../styles/tailwind.css";
   .feature-video__backdrop-button--show {
     animation: fadeInAnimation ease-in-out 0.3s forwards;
   }

--- a/src/components/FeatureCard/FeatureCardMedium.astro
+++ b/src/components/FeatureCard/FeatureCardMedium.astro
@@ -19,22 +19,22 @@ const { icon, title, text, ...rest } = Astro.props as Props;
 ---
 
 <div
-  class="h-full rounded-md p-8 text-center transition duration-200 hover:bg-white hover:shadow-xl dark:hover:bg-base-900"
+  class="dark:hover:bg-base-900 h-full rounded-md p-8 text-center transition duration-200 hover:bg-white hover:shadow-xl"
   {...rest}
 >
   <div class="flex h-full flex-col">
     <div
-      class="mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg bg-primary-500 text-base-100 dark:text-base-900"
+      class="bg-primary-500 text-base-100 dark:text-base-900 mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg"
     >
       <Icon
         name={icon}
-        class="size-6 text-base-100 dark:text-base-900"
+        class="text-base-100 dark:text-base-900 size-6"
         aria-hidden="true"
       />
     </div>
     <div class="flex flex-col items-center">
       <div
-        class="heading-card mb-3 text-base-900 dark:text-base-100"
+        class="heading-card text-base-900 dark:text-base-100 mb-3"
         role="heading"
         aria-level="4"
       >

--- a/src/components/FeatureCard/FeatureCardSideImage.astro
+++ b/src/components/FeatureCard/FeatureCardSideImage.astro
@@ -48,7 +48,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
             <li class="description mt-4 flex items-center">
               <Icon
                 name="tabler/circle-check"
-                class="mr-2 size-6 text-primary-500"
+                class="text-primary-500 mr-2 size-6"
                 aria-hidden="true"
               />
               <span>{item}</span>

--- a/src/components/FeatureCard/FeatureCardSmall.astro
+++ b/src/components/FeatureCard/FeatureCardSmall.astro
@@ -61,8 +61,8 @@ const cardId = `feature-${title.toLowerCase().replace(/\s+/g, "-")}${suffix}`;
   .focus-within\:ring-2:focus-within {
     outline: none;
     box-shadow:
-      0 0 0 2px var(--ring-color, theme("colors.primary.500")),
-      0 0 0 4px var(--ring-offset-color, theme("colors.white"));
+      0 0 0 2px var(--ring-color, var(--color-primary-500)),
+      0 0 0 4px var(--ring-offset-color, #fff);
   }
 
   /* Enhance hover state for better visibility */

--- a/src/components/FeatureCard/FeatureCardSmall.astro
+++ b/src/components/FeatureCard/FeatureCardSmall.astro
@@ -26,7 +26,7 @@ const cardId = `feature-${title.toLowerCase().replace(/\s+/g, "-")}${suffix}`;
 
 <article {...rest} class="group">
   <div
-    class="h-full rounded-md p-6 transition duration-200 focus-within:ring-2 focus-within:ring-primary-500 focus-within:ring-offset-2 hover:bg-white hover:shadow-xl dark:hover:bg-base-900"
+    class="focus-within:ring-primary-500 dark:hover:bg-base-900 h-full rounded-md p-6 transition duration-200 focus-within:ring-2 focus-within:ring-offset-2 hover:bg-white hover:shadow-xl"
     tabindex="0"
     aria-labelledby={`${cardId}-title`}
     aria-describedby={`${cardId}-description`}
@@ -36,7 +36,7 @@ const cardId = `feature-${title.toLowerCase().replace(/\s+/g, "-")}${suffix}`;
         <div class="mt-1 flex-shrink-0" aria-hidden="true">
           <Icon
             name={icon}
-            class="h-5 w-5 text-primary-500 transition-transform group-focus-within:rotate-3 group-focus-within:scale-110 group-hover:rotate-3 group-hover:scale-110"
+            class="text-primary-500 h-5 w-5 transition-transform group-focus-within:scale-110 group-focus-within:rotate-3 group-hover:scale-110 group-hover:rotate-3"
             role="presentation"
           />
         </div>

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -18,7 +18,7 @@ const today = new Date();
 ---
 
 <footer
-  class="relative z-10 overflow-x-clip pb-16 pt-20 font-medium text-base-600 dark:text-base-400"
+  class="text-base-600 dark:text-base-400 relative z-10 overflow-x-clip pt-20 pb-16 font-medium"
   role="contentinfo"
   aria-label="Site footer"
 >
@@ -76,7 +76,7 @@ const today = new Date();
   </div>
 
   <div
-    class="mt-2 border-t border-t-base-200/50 text-sm text-base-600 dark:text-base-500"
+    class="border-t-base-200/50 text-base-600 dark:text-base-500 mt-2 border-t text-sm"
   >
     <div class="site-container px-2 sm:px-4">
       <div class="mt-2">

--- a/src/components/Footer/FooterLink.astro
+++ b/src/components/Footer/FooterLink.astro
@@ -10,7 +10,7 @@ const { href, newTab = false, ...rest } = Astro.props as Props;
 
 <a
   href={href}
-  class="rounded px-4 py-2 text-base-600 transition hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
+  class="rounded-sm px-4 py-2 text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
   target={newTab ? "_blank" : undefined}
   rel={newTab ? "noopener noreferrer" : undefined}
   {...rest}

--- a/src/components/Footer/FooterLink.astro
+++ b/src/components/Footer/FooterLink.astro
@@ -10,7 +10,7 @@ const { href, newTab = false, ...rest } = Astro.props as Props;
 
 <a
   href={href}
-  class="rounded-sm px-4 py-2 text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
+  class="text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-400 dark:hover:text-base-300 rounded-sm px-4 py-2 transition focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
   target={newTab ? "_blank" : undefined}
   rel={newTab ? "noopener noreferrer" : undefined}
   {...rest}

--- a/src/components/Forms/ContactForm.astro
+++ b/src/components/Forms/ContactForm.astro
@@ -13,7 +13,7 @@ import Button from "@components/Button/Button.astro";
 
 <section
   id="contact"
-  class="mx-auto min-w-fit max-w-3xl rounded-lg"
+  class="mx-auto max-w-3xl min-w-fit rounded-lg"
   aria-labelledby="contact-form-heading"
 >
   <h2 id="contact-form-heading" class="sr-only">Contact Form</h2>
@@ -278,7 +278,7 @@ import Button from "@components/Button/Button.astro";
   @reference "../../styles/tailwind.css";
   /* Focus styles */
   .form__input:focus-visible {
-    @apply outline-hidden ring-2 ring-primary-500 ring-offset-2;
+    @apply ring-primary-500 ring-2 ring-offset-2 outline-hidden;
   }
 
   /* Invalid state styles */

--- a/src/components/Forms/ContactForm.astro
+++ b/src/components/Forms/ContactForm.astro
@@ -275,9 +275,10 @@ import Button from "@components/Button/Button.astro";
 </script>
 
 <style>
+  @reference "../../styles/tailwind.css";
   /* Focus styles */
   .form__input:focus-visible {
-    @apply outline-none ring-2 ring-primary-500 ring-offset-2;
+    @apply outline-hidden ring-2 ring-primary-500 ring-offset-2;
   }
 
   /* Invalid state styles */

--- a/src/components/GameUI/GameUI.astro
+++ b/src/components/GameUI/GameUI.astro
@@ -4,23 +4,23 @@
 
 <!-- Mobile version -->
 <div
-  class="game-ui-mobile my-4 rounded-lg border border-base-700 bg-base-950 p-3 font-mono text-xs"
+  class="game-ui-mobile border-base-700 bg-base-950 my-4 rounded-lg border p-3 font-mono text-xs"
 >
   <div
-    class="mb-2 flex items-center justify-between border-b border-base-700 pb-2"
+    class="border-base-700 mb-2 flex items-center justify-between border-b pb-2"
   >
-    <span class="font-bold text-foam">REALMS ONLINE</span>
+    <span class="text-foam font-bold">REALMS ONLINE</span>
     <span class="text-foam">████████░░ 80%</span>
   </div>
-  <div class="grid grid-cols-2 gap-1 text-[11px] text-base-400">
+  <div class="text-base-400 grid grid-cols-2 gap-1 text-[11px]">
     <div>CLASS: <span class="text-foam">Viber 42</span></div>
     <div>REALM: <span class="text-foam">Sisyphean Max</span></div>
     <div>STAMINA: <span class="text-foam">████░░░░</span></div>
     <div>SESSION: <span class="text-foam">4h 32m</span></div>
   </div>
-  <div class="mt-2 border-t border-base-700 pt-2 text-[11px]">
+  <div class="border-base-700 mt-2 border-t pt-2 text-[11px]">
     <div class="text-gold">QUEST: "Reinforce the Eastern Ward"</div>
-    <div class="mt-1 text-base-500">
+    <div class="text-base-500 mt-1">
       > Sysopus is waiting for your command...
     </div>
   </div>

--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -28,21 +28,21 @@ const t = useTranslations(currLocale);
   aria-labelledby="hero-heading"
   class="mt-20 overflow-clip"
 >
-  <div class="relative pb-20 pt-10 md:py-28" role="presentation">
+  <div class="relative pt-10 pb-20 md:py-28" role="presentation">
     <div class="relative z-10 flex flex-wrap xl:items-center">
       <div class="mb-16 w-full md:mb-0 md:w-1/2">
         <Badge>Community Builder</Badge>
         <div class="flex flex-col gap-4">
           <h1
             id="hero-heading"
-            class="text-balance font-bold leading-normal tracking-normal text-base-900 dark:text-base-100"
+            class="text-base-900 dark:text-base-100 leading-normal font-bold tracking-normal text-balance"
             style="font-size: clamp(1.875rem, 1.25rem + 2.5vw, 3rem); line-height: 1.2;"
           >
             {t("hero_text")}
           </h1>
         </div>
         <div
-          class="description mb-8 text-pretty text-lg leading-relaxed text-base-700 lg:text-xl dark:text-base-300 [&>br+br]:mb-4 [&>br+br]:block"
+          class="description text-base-700 dark:text-base-300 mb-8 text-lg leading-relaxed text-pretty lg:text-xl [&>br+br]:mb-4 [&>br+br]:block"
         >
           <Fragment
             set:html={t("hero_description")
@@ -60,7 +60,7 @@ const t = useTranslations(currLocale);
             variant="primary"
             href="/retainer/"
             aria-label="Work with Guido on a community advisory engagement"
-            class="min-h-[44px] min-w-[44px] focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+            class="focus:ring-primary-500 min-h-[44px] min-w-[44px] focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
             umamiEvent="cta-click"
             umamiEventTarget="work-with-me-hero"
           >
@@ -70,7 +70,7 @@ const t = useTranslations(currLocale);
             variant="outline"
             href="/speaker/"
             aria-label="Invite Guido to speak at your event"
-            class="min-h-[44px] min-w-[44px] focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+            class="focus:ring-primary-500 min-h-[44px] min-w-[44px] focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
             umamiEvent="cta-click"
             umamiEventTarget="invite-to-speak-hero"
           >
@@ -88,13 +88,13 @@ const t = useTranslations(currLocale);
         <div class="relative mx-auto max-w-max md:mr-0">
           <Icon
             name="atlas/circle3"
-            class="absolute -left-14 -top-12 z-10 w-28 text-accent-4"
+            class="text-accent-4 absolute -top-12 -left-14 z-10 w-28"
             aria-hidden="true"
             role="presentation"
           />
           <Icon
             name="atlas/dots3"
-            class="absolute -bottom-8 -right-7 z-10 w-28 text-accent-2"
+            class="text-accent-2 absolute -right-7 -bottom-8 z-10 w-28"
             aria-hidden="true"
             role="presentation"
           />

--- a/src/components/Hero/HeroSideImage.astro
+++ b/src/components/Hero/HeroSideImage.astro
@@ -60,7 +60,7 @@ const t = useTranslations(currLocale);
             variant="primary"
             href="/retainer/"
             aria-label="Work with Guido on a community advisory engagement"
-            class="min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+            class="min-h-[44px] min-w-[44px] focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
             umamiEvent="cta-click"
             umamiEventTarget="work-with-me-hero"
           >
@@ -70,7 +70,7 @@ const t = useTranslations(currLocale);
             variant="outline"
             href="/speaker/"
             aria-label="Invite Guido to speak at your event"
-            class="min-h-[44px] min-w-[44px] focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+            class="min-h-[44px] min-w-[44px] focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
             umamiEvent="cta-click"
             umamiEventTarget="invite-to-speak-hero"
           >

--- a/src/components/LanguageSelect/LanguageSelect.astro
+++ b/src/components/LanguageSelect/LanguageSelect.astro
@@ -34,7 +34,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
   {...rest}
 >
   <button
-    class="primary-focus lang-select__dropdown-button flex items-center gap-0.5 whitespace-nowrap rounded py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:flex dark:text-base-300 dark:hover:text-base-200"
+    class="primary-focus lang-select__dropdown-button flex items-center gap-0.5 whitespace-nowrap rounded-sm py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:flex dark:text-base-300 dark:hover:text-base-200"
     type="button"
     aria-expanded="false"
     aria-haspopup="true"
@@ -57,14 +57,14 @@ const currLocale = getLocaleFromUrl(Astro.url);
     class="lang-select__dropdown-content invisible absolute top-full z-10 mt-2 w-full opacity-0 transition-all"
   >
     <ul
-      class="mx-auto mt-3 w-fit max-w-xs whitespace-nowrap rounded-md border border-solid border-base-200 bg-base-50 px-3 py-1.5 drop-shadow-sm dark:border-base-800 dark:bg-base-900"
+      class="mx-auto mt-3 w-fit max-w-xs whitespace-nowrap rounded-md border border-solid border-base-200 bg-base-50 px-3 py-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
       role="menu"
     >
       {
         locales.map((lang) => (
           <li class="flex w-full justify-center" role="menuitem">
             <a
-              class="primary-focus relative block w-full whitespace-nowrap rounded py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200"
+              class="primary-focus relative block w-full whitespace-nowrap rounded-sm py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200"
               href={getLocalizedPathname(lang, Astro.url)}
               aria-label={`Change language to ${languageSwitcherMap[lang]}`}
               lang={lang}
@@ -218,6 +218,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
 </script>
 
 <style lang="scss">
+  @reference "../../styles/tailwind.css";
   .dropdown--fade-in {
     animation: dropdownFadeInAnimation ease-out 0.15s forwards;
     @apply visible opacity-100;
@@ -225,10 +226,10 @@ const currLocale = getLocaleFromUrl(Astro.url);
 
   @keyframes dropdownFadeInAnimation {
     0% {
-      @apply top-[80%];
+      top: 80%;
     }
     100% {
-      @apply top-full;
+      top: 100%;
     }
   }
 </style>

--- a/src/components/LanguageSelect/LanguageSelect.astro
+++ b/src/components/LanguageSelect/LanguageSelect.astro
@@ -34,7 +34,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
   {...rest}
 >
   <button
-    class="primary-focus lang-select__dropdown-button flex items-center gap-0.5 whitespace-nowrap rounded-sm py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:flex dark:text-base-300 dark:hover:text-base-200"
+    class="primary-focus lang-select__dropdown-button text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-300 dark:hover:text-base-200 flex items-center gap-0.5 rounded-sm py-1 leading-tight font-medium whitespace-nowrap transition focus:ring-2 focus:ring-offset-2 focus:outline-hidden md:flex"
     type="button"
     aria-expanded="false"
     aria-haspopup="true"
@@ -57,14 +57,14 @@ const currLocale = getLocaleFromUrl(Astro.url);
     class="lang-select__dropdown-content invisible absolute top-full z-10 mt-2 w-full opacity-0 transition-all"
   >
     <ul
-      class="mx-auto mt-3 w-fit max-w-xs whitespace-nowrap rounded-md border border-solid border-base-200 bg-base-50 px-3 py-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
+      class="border-base-200 bg-base-50 dark:border-base-800 dark:bg-base-900 mx-auto mt-3 w-fit max-w-xs rounded-md border border-solid px-3 py-1.5 whitespace-nowrap drop-shadow-xs"
       role="menu"
     >
       {
         locales.map((lang) => (
           <li class="flex w-full justify-center" role="menuitem">
             <a
-              class="primary-focus relative block w-full whitespace-nowrap rounded-sm py-1 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200"
+              class="primary-focus text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-300 dark:hover:text-base-200 relative block w-full rounded-sm py-1 leading-tight font-medium whitespace-nowrap transition focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
               href={getLocalizedPathname(lang, Astro.url)}
               aria-label={`Change language to ${languageSwitcherMap[lang]}`}
               lang={lang}

--- a/src/components/LanguageSelect/MobileLanguageSelect.astro
+++ b/src/components/LanguageSelect/MobileLanguageSelect.astro
@@ -32,7 +32,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
   {...rest}
 >
   <button
-    class="primary-focus mobile-lang__dropdown-button flex w-full flex-1 items-center justify-between gap-0.5 rounded-md px-4 py-2 text-left font-medium text-base-500 transition duration-300 hover:text-base-600 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus mobile-lang__dropdown-button text-base-500 hover:text-base-600 dark:text-base-400 dark:hover:text-base-300 flex w-full flex-1 items-center justify-between gap-0.5 rounded-md px-4 py-2 text-left font-medium transition duration-300"
     type="button"
     aria-expanded="false"
     aria-haspopup="true"
@@ -58,7 +58,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
         locales.map((lang) => (
           <li class="flex w-full">
             <a
-              class="primary-focus relative block w-full whitespace-nowrap py-1 pl-8 font-medium leading-tight text-base-500 transition hover:text-base-600 dark:text-base-400 dark:hover:text-base-300"
+              class="primary-focus text-base-500 hover:text-base-600 dark:text-base-400 dark:hover:text-base-300 relative block w-full py-1 pl-8 leading-tight font-medium whitespace-nowrap transition"
               href={getLocalizedPathname(lang, Astro.url)}
               aria-label={`Change language to ${lang.toUpperCase()}`}
             >

--- a/src/components/ManaBar/ManaBar.astro
+++ b/src/components/ManaBar/ManaBar.astro
@@ -24,19 +24,19 @@ const bar = "█".repeat(filled) + "░".repeat(empty);
 ---
 
 <div
-  class="mana-bar my-4 rounded-lg border border-base-700 bg-base-950 p-3 font-mono text-sm"
+  class="mana-bar border-base-700 bg-base-950 my-4 rounded-lg border p-3 font-mono text-sm"
 >
   <div class="flex flex-wrap gap-x-4 gap-y-1">
-    <span class="whitespace-nowrap text-foam">{bar} {percent}%</span>
-    <span class="whitespace-nowrap text-foam">⏱ {time}</span>
+    <span class="text-foam whitespace-nowrap">{bar} {percent}%</span>
+    <span class="text-foam whitespace-nowrap">⏱ {time}</span>
     {
       attunementLow && !attunementCritical && (
-        <span class="whitespace-nowrap text-gold">⚠ ATTUNEMENT LOW</span>
+        <span class="text-gold whitespace-nowrap">⚠ ATTUNEMENT LOW</span>
       )
     }
     {
       attunementCritical && (
-        <span class="animate-pulse whitespace-nowrap text-love">
+        <span class="text-love animate-pulse whitespace-nowrap">
           ⚠ ATTUNEMENT CRITICAL
         </span>
       )
@@ -44,8 +44,8 @@ const bar = "█".repeat(filled) + "░".repeat(empty);
   </div>
   {
     depleted && message && (
-      <div class="mt-2 border-t border-base-700 pt-2 text-center">
-        <div class="font-bold text-love">SESSION MANA DEPLETED</div>
+      <div class="border-base-700 mt-2 border-t pt-2 text-center">
+        <div class="text-love font-bold">SESSION MANA DEPLETED</div>
         <div class="text-base-500">{message}</div>
       </div>
     )

--- a/src/components/Nav/MobileNav/MobileNav.astro
+++ b/src/components/Nav/MobileNav/MobileNav.astro
@@ -34,28 +34,28 @@ import { locales } from "@config/siteSettings.json";
   >
     <!-- hamburger icon to open menu -->
     <MenuIcon
-      class="m-auto inline-block h-8 w-8 stroke-current text-base-600 dark:text-base-300"
+      class="text-base-600 dark:text-base-300 m-auto inline-block h-8 w-8 stroke-current"
       aria-hidden="true"
     />
   </button>
   <div
     id="mobile-nav__content"
-    class="whitepace-nowrap fixed -right-72 top-0 z-20 hidden h-screen w-72 items-center overflow-x-hidden bg-base-50 text-lg font-normal transition-all duration-300 dark:bg-base-950"
+    class="whitepace-nowrap bg-base-50 dark:bg-base-950 fixed top-0 -right-72 z-20 hidden h-screen w-72 items-center overflow-x-hidden text-lg font-normal transition-all duration-300"
   >
     <div class="w-full px-2 pb-6">
-      <div class="mx-1 my-2 flex w-full justify-end pl-6 pr-4">
+      <div class="mx-1 my-2 flex w-full justify-end pr-4 pl-6">
         <button
           id="mobile-nav__close"
           class="primary-focus p-2"
           aria-label="close navigation menu"
         >
           <!-- "X" icon to close menu -->
-          <CloseIcon class="h-8 w-8 text-base-600 dark:text-base-300" />
+          <CloseIcon class="text-base-600 dark:text-base-300 h-8 w-8" />
         </button>
       </div>
 
       <!-- nav items -->
-      <hr class="mx-1 border-base-400 dark:border-base-600" />
+      <hr class="border-base-400 dark:border-base-600 mx-1" />
       <nav aria-label="Mobile navigation">
         <ul class="mx-1 mt-2 text-xl">
           {
@@ -99,7 +99,7 @@ import { locales } from "@config/siteSettings.json";
         </Button>
       </div>
 
-      <div class="mt-4 flex items-start justify-between pl-4 pr-2">
+      <div class="mt-4 flex items-start justify-between pr-2 pl-4">
         <ThemeToggle />
 
         {
@@ -116,7 +116,7 @@ import { locales } from "@config/siteSettings.json";
   <!-- backdrop button to also close menu -->
   <button
     id="mobile-nav__backdrop"
-    class="mobile-nav__backdrop--fade-out fixed left-0 top-0 z-10 h-screen bg-black"
+    class="mobile-nav__backdrop--fade-out fixed top-0 left-0 z-10 h-screen bg-black"
     aria-label="close navigation menu"></button>
 </div>
 

--- a/src/components/Nav/MobileNav/MobileNav.astro
+++ b/src/components/Nav/MobileNav/MobileNav.astro
@@ -231,6 +231,7 @@ import { locales } from "@config/siteSettings.json";
 </script>
 
 <style lang="scss">
+  @reference "../../../styles/tailwind.css";
   // backdrop button to close mobile nav
   .mobile-nav__backdrop--fade-in {
     animation: MobileNavFadeInAnimation ease-in-out 0.3s forwards;
@@ -243,10 +244,10 @@ import { locales } from "@config/siteSettings.json";
 
   @keyframes MobileNavFadeInAnimation {
     0% {
-      @apply opacity-0;
+      opacity: 0;
     }
     100% {
-      @apply opacity-40;
+      opacity: 0.4;
     }
   }
 
@@ -262,19 +263,19 @@ import { locales } from "@config/siteSettings.json";
 
   @keyframes mobileNavSlideInAnimation {
     0% {
-      @apply -right-72;
+      right: -18rem;
     }
     100% {
-      @apply right-0;
+      right: 0;
     }
   }
 
   @keyframes mobileNavSlideOutAnimation {
     0% {
-      @apply right-0;
+      right: 0;
     }
     100% {
-      @apply -right-72;
+      right: -18rem;
     }
   }
 </style>

--- a/src/components/Nav/MobileNav/MobileNavDropdown.astro
+++ b/src/components/Nav/MobileNav/MobileNavDropdown.astro
@@ -33,7 +33,7 @@ if ("dropdown" in navItem) {
 
 <li class="mobile-nav__dropdown group relative">
   <button
-    class="primary-focus mobile-nav__dropdown-button flex w-full flex-1 items-center justify-between rounded-md px-4 py-2 text-left font-medium text-base-600 transition duration-300 hover:text-base-700 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus mobile-nav__dropdown-button text-base-600 hover:text-base-700 dark:text-base-400 dark:hover:text-base-300 flex w-full flex-1 items-center justify-between rounded-md px-4 py-2 text-left font-medium transition duration-300"
     type="button"
     aria-label={`${dropdownItem.text} dropdown menu`}
     aria-expanded="false"

--- a/src/components/Nav/MobileNav/__tests__/MobileNav.test.ts
+++ b/src/components/Nav/MobileNav/__tests__/MobileNav.test.ts
@@ -53,7 +53,7 @@ describe("MobileNav", () => {
         aria-modal="true"
         aria-label="Mobile navigation menu"
       >
-        <div class="fixed inset-0 z-40 bg-base-900/50 backdrop-blur-sm dark:bg-base-900/80">
+        <div class="fixed inset-0 z-40 bg-base-900/50 backdrop-blur-xs dark:bg-base-900/80">
           <div class="fixed inset-y-0 right-0 z-40 w-full max-w-sm bg-base-50 px-6 py-6 dark:bg-base-900">
             <nav class="flex h-full flex-col">
               <ul class="space-y-4" role="menu">

--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -35,7 +35,7 @@ const shouldReduceMotion =
 <!-- Skip to main content link -->
 <a
   href="#main-content"
-  class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2"
+  class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-white focus:outline-hidden focus:ring-2 focus:ring-white focus:ring-offset-2"
 >
   Skip to main content
 </a>
@@ -89,7 +89,7 @@ const shouldReduceMotion =
           <!-- CTA Button -->
           <Button
             variant="secondary"
-            class="my-auto hidden px-4 py-1.5 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:block"
+            class="my-auto hidden px-4 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:block"
             href="/retainer/"
             aria-label="Work with Guido on a community advisory engagement"
             umamiEvent="cta-click"
@@ -119,6 +119,7 @@ const shouldReduceMotion =
 </div>
 
 <style>
+  @reference "../../styles/tailwind.css";
   /* Navigation states */
   .navbar--scrolled {
     @apply border-b-base-200 bg-base-50 dark:border-b-base-800 dark:bg-base-950;
@@ -150,7 +151,7 @@ const shouldReduceMotion =
 
   /* Focus styles */
   :focus-visible {
-    outline: 2px solid var(--focus-ring-color, theme("colors.primary.500"));
+    outline: 2px solid var(--focus-ring-color, var(--color-primary-500));
     outline-offset: 2px;
   }
 </style>

--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -35,7 +35,7 @@ const shouldReduceMotion =
 <!-- Skip to main content link -->
 <a
   href="#main-content"
-  class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-white focus:outline-hidden focus:ring-2 focus:ring-white focus:ring-offset-2"
+  class="focus:bg-primary-500 sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:block focus:rounded-md focus:px-4 focus:py-2 focus:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:outline-hidden"
 >
   Skip to main content
 </a>
@@ -89,7 +89,7 @@ const shouldReduceMotion =
           <!-- CTA Button -->
           <Button
             variant="secondary"
-            class="my-auto hidden px-4 py-1.5 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 md:block"
+            class="focus:ring-primary-500 my-auto hidden px-4 py-1.5 focus:ring-2 focus:ring-offset-2 focus:outline-hidden md:block"
             href="/retainer/"
             aria-label="Work with Guido on a community advisory engagement"
             umamiEvent="cta-click"

--- a/src/components/Nav/NavDropdown/MegaMenuDropdownToggle.astro
+++ b/src/components/Nav/NavDropdown/MegaMenuDropdownToggle.astro
@@ -58,7 +58,7 @@ if (cols >= 5) {
   >
     <ul
       class:list={[
-        "mt-[.9rem] grid w-full min-w-[150px] max-w-full gap-3 rounded-md border border-solid border-base-200 bg-base-50 px-1.5 py-3 drop-shadow-sm dark:border-base-800 dark:bg-base-900",
+        "mt-[.9rem] grid w-full min-w-[150px] max-w-full gap-3 rounded-md border border-solid border-base-200 bg-base-50 px-1.5 py-3 drop-shadow-xs dark:border-base-800 dark:bg-base-900",
         gridClass,
       ]}
     >
@@ -134,6 +134,7 @@ if (cols >= 5) {
 </script>
 
 <style lang="scss">
+  @reference "../../../styles/tailwind.css";
   .mega-menu--fade-in {
     animation: navDropdownFadeInAnimation ease-out 0.15s forwards;
     @apply visible opacity-100;
@@ -141,10 +142,10 @@ if (cols >= 5) {
 
   @keyframes navDropdownFadeInAnimation {
     0% {
-      @apply top-[80%];
+      top: 80%;
     }
     100% {
-      @apply top-full;
+      top: 100%;
     }
   }
 </style>

--- a/src/components/Nav/NavDropdown/MegaMenuDropdownToggle.astro
+++ b/src/components/Nav/NavDropdown/MegaMenuDropdownToggle.astro
@@ -34,7 +34,7 @@ if (cols >= 5) {
 <!-- non-mobile mega menu menu -->
 <li class="mega-menu__dropdown group">
   <button
-    class="primary-focus mega-menu__dropdown-button flex w-full items-center gap-0.5 whitespace-nowrap px-3 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus mega-menu__dropdown-button text-base-600 hover:text-base-700 dark:text-base-400 dark:hover:text-base-300 flex w-full items-center gap-0.5 px-3 py-2 leading-tight font-medium whitespace-nowrap transition"
     type="button"
     id={`${navItem.text} mega menu menu`}
     aria-expanded="false"
@@ -58,14 +58,14 @@ if (cols >= 5) {
   >
     <ul
       class:list={[
-        "mt-[.9rem] grid w-full min-w-[150px] max-w-full gap-3 rounded-md border border-solid border-base-200 bg-base-50 px-1.5 py-3 drop-shadow-xs dark:border-base-800 dark:bg-base-900",
+        "border-base-200 bg-base-50 dark:border-base-800 dark:bg-base-900 mt-[.9rem] grid w-full max-w-full min-w-[150px] gap-3 rounded-md border border-solid px-1.5 py-3 drop-shadow-xs",
         gridClass,
       ]}
     >
       {
         navItem.megaMenuColumns.map((col) => (
           <div>
-            <p class="mx-4 mb-2 border-b border-base-200 pb-1 text-lg font-medium text-base-600 dark:border-base-800 dark:text-base-400">
+            <p class="border-base-200 text-base-600 dark:border-base-800 dark:text-base-400 mx-4 mb-2 border-b pb-1 text-lg font-medium">
               {col.title}
             </p>
             {col.items.map((navItem) => (

--- a/src/components/Nav/NavDropdown/NavDropdown.astro
+++ b/src/components/Nav/NavDropdown/NavDropdown.astro
@@ -28,7 +28,7 @@ const shouldReduceMotion =
 
 <li class="dropdown group relative" role="none">
   <button
-    class="primary-focus flex items-center gap-0.5 rounded-md px-3 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-400 dark:hover:text-base-300 flex items-center gap-0.5 rounded-md px-3 py-2 leading-tight font-medium transition focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
     type="button"
     aria-expanded="false"
     aria-controls={dropdownId}
@@ -54,7 +54,7 @@ const shouldReduceMotion =
     data-dropdown-content
   >
     <ul
-      class="mt-4 w-[14rem] min-w-[12rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
+      class="border-base-200 bg-base-50 dark:border-base-800 dark:bg-base-900 mt-4 w-[14rem] max-w-[20rem] min-w-[12rem] rounded-md border border-solid p-1.5 drop-shadow-xs"
       role="none"
     >
       {

--- a/src/components/Nav/NavDropdown/NavDropdown.astro
+++ b/src/components/Nav/NavDropdown/NavDropdown.astro
@@ -28,7 +28,7 @@ const shouldReduceMotion =
 
 <li class="dropdown group relative" role="none">
   <button
-    class="primary-focus flex items-center gap-0.5 rounded-md px-3 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus flex items-center gap-0.5 rounded-md px-3 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300"
     type="button"
     aria-expanded="false"
     aria-controls={dropdownId}
@@ -54,7 +54,7 @@ const shouldReduceMotion =
     data-dropdown-content
   >
     <ul
-      class="mt-4 w-[14rem] min-w-[12rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-sm dark:border-base-800 dark:bg-base-900"
+      class="mt-4 w-[14rem] min-w-[12rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
       role="none"
     >
       {
@@ -115,7 +115,7 @@ const shouldReduceMotion =
 
   /* Focus styles */
   .primary-focus:focus-visible {
-    outline: 2px solid var(--focus-ring-color, theme("colors.primary.500"));
+    outline: 2px solid var(--focus-ring-color, var(--color-primary-500));
     outline-offset: 2px;
   }
 </style>

--- a/src/components/Nav/NavDropdown/NavDropdownToggle.astro
+++ b/src/components/Nav/NavDropdown/NavDropdownToggle.astro
@@ -19,7 +19,7 @@ const { navItem } = Astro.props as Props;
 <!-- non-mobile dropdown menu -->
 <li class="nav__dropdown group relative">
   <button
-    class="primary-focus nav__dropdown-button flex w-full items-center gap-0.5 whitespace-nowrap px-3 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 dark:text-base-400 dark:hover:text-base-300"
+    class="primary-focus nav__dropdown-button text-base-600 hover:text-base-700 dark:text-base-400 dark:hover:text-base-300 flex w-full items-center gap-0.5 px-3 py-2 leading-tight font-medium whitespace-nowrap transition"
     type="button"
     id={`${navItem.text} dropdown menu`}
     aria-expanded="false"
@@ -39,7 +39,7 @@ const { navItem } = Astro.props as Props;
     class="nav__dropdown-content invisible absolute left-0 z-10 opacity-0 transition-all"
   >
     <ul
-      class="mt-4 w-[12rem] min-w-[9rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
+      class="border-base-200 bg-base-50 dark:border-base-800 dark:bg-base-900 mt-4 w-[12rem] max-w-[20rem] min-w-[9rem] rounded-md border border-solid p-1.5 drop-shadow-xs"
     >
       {
         navItem.dropdown.map((dropdownItem) => (

--- a/src/components/Nav/NavDropdown/NavDropdownToggle.astro
+++ b/src/components/Nav/NavDropdown/NavDropdownToggle.astro
@@ -39,7 +39,7 @@ const { navItem } = Astro.props as Props;
     class="nav__dropdown-content invisible absolute left-0 z-10 opacity-0 transition-all"
   >
     <ul
-      class="mt-4 w-[12rem] min-w-[9rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-sm dark:border-base-800 dark:bg-base-900"
+      class="mt-4 w-[12rem] min-w-[9rem] max-w-[20rem] rounded-md border border-solid border-base-200 bg-base-50 p-1.5 drop-shadow-xs dark:border-base-800 dark:bg-base-900"
     >
       {
         navItem.dropdown.map((dropdownItem) => (
@@ -106,6 +106,7 @@ const { navItem } = Astro.props as Props;
 </script>
 
 <style lang="scss">
+  @reference "../../../styles/tailwind.css";
   .dropdown--fade-in {
     animation: navDropdownFadeInAnimation ease-out 0.15s forwards;
     @apply visible opacity-100;
@@ -113,10 +114,10 @@ const { navItem } = Astro.props as Props;
 
   @keyframes navDropdownFadeInAnimation {
     0% {
-      @apply top-[80%];
+      top: 80%;
     }
     100% {
-      @apply top-full;
+      top: 100%;
     }
   }
 </style>

--- a/src/components/Nav/NavLink.astro
+++ b/src/components/Nav/NavLink.astro
@@ -33,7 +33,7 @@ const isCurrentPage = Astro.url.pathname === actualLink;
 <li role="none">
   <a
     class:list={[
-      `primary-focus relative block flex w-full items-center gap-1.5 rounded-md px-4 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300 ${className}`,
+      `primary-focus relative block flex w-full items-center gap-1.5 rounded-md px-4 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300 ${className}`,
       {
         "aria-current": isCurrentPage,
         "font-semibold text-primary-600 dark:text-primary-400": isCurrentPage,
@@ -70,7 +70,7 @@ const isCurrentPage = Astro.url.pathname === actualLink;
 
   /* Focus styles */
   .primary-focus:focus-visible {
-    outline: 2px solid var(--focus-ring-color, theme("colors.primary.500"));
+    outline: 2px solid var(--focus-ring-color, var(--color-primary-500));
     outline-offset: 2px;
   }
 </style>

--- a/src/components/Nav/NavLink.astro
+++ b/src/components/Nav/NavLink.astro
@@ -33,10 +33,10 @@ const isCurrentPage = Astro.url.pathname === actualLink;
 <li role="none">
   <a
     class:list={[
-      `primary-focus relative block flex w-full items-center gap-1.5 rounded-md px-4 py-2 font-medium leading-tight text-base-600 transition hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:text-base-300 ${className}`,
+      `primary-focus text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-400 dark:hover:text-base-300 relative block flex w-full items-center gap-1.5 rounded-md px-4 py-2 leading-tight font-medium transition focus:ring-2 focus:ring-offset-2 focus:outline-hidden ${className}`,
       {
         "aria-current": isCurrentPage,
-        "font-semibold text-primary-600 dark:text-primary-400": isCurrentPage,
+        "text-primary-600 dark:text-primary-400 font-semibold": isCurrentPage,
       },
     ]}
     href={actualLink}

--- a/src/components/Nav/__tests__/Nav.test.ts
+++ b/src/components/Nav/__tests__/Nav.test.ts
@@ -12,7 +12,7 @@ describe("Nav", () => {
           <div class="site-container flex h-14 w-full items-center px-4">
             <header class="relative flex w-full items-center justify-between gap-4">
               <!-- Skip link -->
-              <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2">
+              <a href="#main-content" class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:block focus:rounded-md focus:bg-primary-500 focus:px-4 focus:py-2 focus:text-white focus:outline-hidden focus:ring-2 focus:ring-white focus:ring-offset-2">
                 Skip to main content
               </a>
 

--- a/src/components/Newsletter/NewsletterForm.astro
+++ b/src/components/Newsletter/NewsletterForm.astro
@@ -735,12 +735,13 @@ const signupPage = Astro.url.pathname;
 </script>
 
 <style>
+  @reference "../../styles/tailwind.css";
   .newsletter-form input[aria-invalid="true"] {
     @apply border-red-500 dark:border-red-400;
   }
 
   .newsletter-form input:focus-visible {
-    @apply outline-none ring-2 ring-primary-500 ring-offset-2;
+    @apply outline-hidden ring-2 ring-primary-500 ring-offset-2;
   }
 
   .newsletter-status:empty {

--- a/src/components/Newsletter/NewsletterForm.astro
+++ b/src/components/Newsletter/NewsletterForm.astro
@@ -72,26 +72,26 @@ const signupPage = Astro.url.pathname;
   variant === "card" && (
     <div
       class:list={[
-        "newsletter-card rounded-lg bg-base-200 p-6 md:p-8 dark:bg-base-800",
+        "newsletter-card bg-base-200 dark:bg-base-800 rounded-lg p-6 md:p-8",
         className,
       ]}
     >
       {title && (
         <h3
-          class="mb-2 text-xl font-bold text-base-900 md:text-2xl dark:text-base-100"
+          class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold md:text-2xl"
           set:html={title}
         />
       )}
       {showSubscriberCount && (
         <p
-          class="subscriber-count mb-2 hidden text-base-600 dark:text-base-400"
+          class="subscriber-count text-base-600 dark:text-base-400 mb-2 hidden"
           data-subscriber-count
         >
           Join <span class="subscriber-number" /> newsletter subscribers
         </p>
       )}
       {description && (
-        <p class="mb-6 text-base-600 dark:text-base-400">{description}</p>
+        <p class="text-base-600 dark:text-base-400 mb-6">{description}</p>
       )}
       <form
         id={formId}
@@ -172,7 +172,7 @@ const signupPage = Astro.url.pathname;
         />
 
         {note && (
-          <p class="mt-2 text-xs text-base-500 dark:text-base-400">{note}</p>
+          <p class="text-base-500 dark:text-base-400 mt-2 text-xs">{note}</p>
         )}
       </form>
     </div>
@@ -185,7 +185,7 @@ const signupPage = Astro.url.pathname;
       <div class="site-container">
         <div
           class:list={[
-            "relative overflow-hidden rounded-md bg-primary-500 px-4 py-8 sm:px-8 sm:py-11 md:px-16 md:py-14",
+            "bg-primary-500 relative overflow-hidden rounded-md px-4 py-8 sm:px-8 sm:py-11 md:px-16 md:py-14",
             className,
           ]}
           role="region"
@@ -193,19 +193,19 @@ const signupPage = Astro.url.pathname;
         >
           <Icon
             name="atlas/dots3"
-            class="absolute left-4 top-0 z-10 size-16 text-accent-4"
+            class="text-accent-4 absolute top-0 left-4 z-10 size-16"
             aria-hidden="true"
             role="presentation"
           />
           <Icon
             name="atlas/dots3"
-            class="absolute bottom-0 right-4 z-10 size-16 text-accent-4"
+            class="text-accent-4 absolute right-4 bottom-0 z-10 size-16"
             aria-hidden="true"
             role="presentation"
           />
           <Icon
             name="atlas/wave-bg-basic"
-            class="absolute left-1/2 top-1/2 h-full w-full max-w-full -translate-x-1/2 -translate-y-1/2 object-cover text-base-100/5"
+            class="text-base-100/5 absolute top-1/2 left-1/2 h-full w-full max-w-full -translate-x-1/2 -translate-y-1/2 object-cover"
             aria-hidden="true"
             role="presentation"
           />
@@ -214,20 +214,20 @@ const signupPage = Astro.url.pathname;
             {title && (
               <h2
                 id={`${formId}-heading`}
-                class="text-2xl font-bold tracking-tighter text-base-100 sm:text-3xl md:text-4xl dark:text-base-900"
+                class="text-base-100 dark:text-base-900 text-2xl font-bold tracking-tighter sm:text-3xl md:text-4xl"
                 set:html={title}
               />
             )}
             {showSubscriberCount && (
               <p
-                class="subscriber-count hidden font-medium text-base-100/90 dark:text-base-900/90"
+                class="subscriber-count text-base-100/90 dark:text-base-900/90 hidden font-medium"
                 data-subscriber-count
               >
                 Join <span class="subscriber-number" /> newsletter subscribers
               </p>
             )}
             {description && (
-              <p class="max-w-lg font-medium text-base-100/90 dark:text-base-900/90">
+              <p class="text-base-100/90 dark:text-base-900/90 max-w-lg font-medium">
                 {description}
               </p>
             )}
@@ -254,7 +254,7 @@ const signupPage = Astro.url.pathname;
                     id={`${formId}-email`}
                     required
                     placeholder={emailPlaceholder}
-                    class="form__input h-[46px] w-full border-transparent bg-base-100 text-base-900 placeholder:text-base-500 dark:bg-base-900 dark:text-base-100"
+                    class="form__input bg-base-100 text-base-900 placeholder:text-base-500 dark:bg-base-900 dark:text-base-100 h-[46px] w-full border-transparent"
                     aria-required="true"
                     aria-describedby={`${formId}-status`}
                   />
@@ -270,7 +270,7 @@ const signupPage = Astro.url.pathname;
                       name="name"
                       id={`${formId}-name`}
                       placeholder={namePlaceholder}
-                      class="form__input h-[46px] w-full border-transparent bg-base-100 text-base-900 placeholder:text-base-500 dark:bg-base-900 dark:text-base-100"
+                      class="form__input bg-base-100 text-base-900 placeholder:text-base-500 dark:bg-base-900 dark:text-base-100 h-[46px] w-full border-transparent"
                       aria-required="false"
                     />
                   </div>
@@ -311,7 +311,7 @@ const signupPage = Astro.url.pathname;
               />
 
               {note && (
-                <p class="mt-3 text-xs text-base-100/80 dark:text-base-900/80">
+                <p class="text-base-100/80 dark:text-base-900/80 mt-3 text-xs">
                   {note}
                 </p>
               )}
@@ -741,7 +741,7 @@ const signupPage = Astro.url.pathname;
   }
 
   .newsletter-form input:focus-visible {
-    @apply outline-hidden ring-2 ring-primary-500 ring-offset-2;
+    @apply ring-primary-500 ring-2 ring-offset-2 outline-hidden;
   }
 
   .newsletter-status:empty {

--- a/src/components/Podcasts/PodcastCard.astro
+++ b/src/components/Podcasts/PodcastCard.astro
@@ -44,7 +44,7 @@ const cardClasses =
             class="rounded-lg object-cover"
           />
         ) : (
-          <div class="flex h-20 w-20 items-center justify-center rounded-lg bg-base-200 dark:bg-base-700">
+          <div class="bg-base-200 dark:bg-base-700 flex h-20 w-20 items-center justify-center rounded-lg">
             <span class="text-2xl">🎙️</span>
           </div>
         )
@@ -56,34 +56,34 @@ const cardClasses =
       {/* Podcast Name and Date */}
       <div class="mb-1 flex items-center justify-between">
         <span
-          class="text-sm font-medium text-primary-600 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 text-sm font-medium"
         >
           {episode.podcastName}
         </span>
-        <span class="text-sm text-base-500 dark:text-base-400">
+        <span class="text-base-500 dark:text-base-400 text-sm">
           {formattedDate}
         </span>
       </div>
 
       {/* Episode Title */}
       <h3
-        class="mb-2 text-xl font-semibold text-primary-600 transition-colors duration-200 group-hover:text-primary-700 dark:text-primary-400 dark:group-hover:text-primary-300"
+        class="text-primary-600 group-hover:text-primary-700 dark:text-primary-400 dark:group-hover:text-primary-300 mb-2 text-xl font-semibold transition-colors duration-200"
       >
         {episode.title}
       </h3>
 
       {/* Description */}
-      <p class="mb-3 text-sm text-base-600 dark:text-base-300">
+      <p class="text-base-600 dark:text-base-300 mb-3 text-sm">
         {truncatedDescription}
       </p>
 
       {/* Duration and Listen Button */}
       <div class="flex items-center justify-between">
-        <span class="text-sm text-base-500 dark:text-base-400">
+        <span class="text-base-500 dark:text-base-400 text-sm">
           {episode.duration}
         </span>
         <span
-          class="inline-flex items-center gap-1 text-sm text-primary-600 transition-transform duration-200 group-hover:translate-x-1 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 inline-flex items-center gap-1 text-sm transition-transform duration-200 group-hover:translate-x-1"
         >
           Listen Now
           <svg

--- a/src/components/Podcasts/PodcastFeed.astro
+++ b/src/components/Podcasts/PodcastFeed.astro
@@ -12,10 +12,10 @@ const { episodes } = Astro.props;
 <div class="mx-auto max-w-4xl space-y-6">
   {/* Header */}
   <div class="mb-8">
-    <h1 class="mb-4 text-4xl font-bold text-base-900 dark:text-base-100">
+    <h1 class="text-base-900 dark:text-base-100 mb-4 text-4xl font-bold">
       Latest Podcast Episodes
     </h1>
-    <p class="text-xl text-base-500 dark:text-base-400">
+    <p class="text-base-500 dark:text-base-400 text-xl">
       Listen to the latest episodes from podcasts that I host. <br /> For podcasts
       I'm a guest in, check out the <a
         href="/press/#podcasts"
@@ -28,7 +28,7 @@ const { episodes } = Astro.props;
   <div class="space-y-6">
     {
       episodes.map((episode) => (
-        <div class="w-full overflow-hidden rounded-lg bg-base-800">
+        <div class="bg-base-800 w-full overflow-hidden rounded-lg">
           <iframe
             width="100%"
             height="180"
@@ -49,7 +49,7 @@ const { episodes } = Astro.props;
     episodes.length === 0 && (
       <div class="py-12 text-center">
         <div class="mb-4 text-4xl">🎙️</div>
-        <h3 class="mb-2 text-xl font-semibold text-base-900 dark:text-base-100">
+        <h3 class="text-base-900 dark:text-base-100 mb-2 text-xl font-semibold">
           No Episodes Available
         </h3>
         <p class="text-base-500 dark:text-base-400">

--- a/src/components/Podcasts/__tests__/PodcastFeed.test.ts
+++ b/src/components/Podcasts/__tests__/PodcastFeed.test.ts
@@ -48,7 +48,7 @@ describe("PodcastFeed", () => {
       <div class="flex justify-center mt-8">
         <button 
           type="button" 
-          class="button button--primary inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
+          class="button button--primary inline-flex items-center justify-center focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
           aria-label="View my appearances in 3rd party podcasts"
         >
           <a href="/press/#podcasts" class="text-white hover:text-white">
@@ -111,7 +111,7 @@ describe("PodcastFeed", () => {
       <div class="flex justify-center mt-8">
         <button 
           type="button" 
-          class="button button--primary inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
+          class="button button--primary inline-flex items-center justify-center focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
           aria-label="View my appearances in 3rd party podcasts"
         >
           <a href="/press/#podcasts" class="text-white hover:text-white">
@@ -161,7 +161,7 @@ describe("PodcastFeed", () => {
       <div class="flex justify-center mt-8">
         <button 
           type="button" 
-          class="button button--primary inline-flex items-center justify-center focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
+          class="button button--primary inline-flex items-center justify-center focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2" 
           aria-label="View my appearances in 3rd party podcasts"
         >
           <a href="/press/#podcasts" class="text-white hover:text-white">

--- a/src/components/PostCard/PostCardAtlas.astro
+++ b/src/components/PostCard/PostCardAtlas.astro
@@ -58,7 +58,7 @@ const filteredCategories = filterCategoriesByCount(categories, allPosts);
       </div>
       <time
         datetime={new Date(pubDate).toISOString()}
-        class="text-sm text-base-600 dark:text-base-300"
+        class="text-base-600 dark:text-base-300 text-sm"
       >
         {formatDate(pubDate, currLocale)}
       </time>

--- a/src/components/Presentations/PresentationCard.astro
+++ b/src/components/Presentations/PresentationCard.astro
@@ -32,14 +32,14 @@ const { title, duration, intendedAudience, isWorkshop, image } =
     <div class="card-meta">
       {
         duration && (
-          <span class="inline-flex rounded-full bg-base-200 px-3 py-1 text-sm font-medium text-base-900 dark:bg-base-800 dark:text-base-100">
+          <span class="bg-base-200 text-base-900 dark:bg-base-800 dark:text-base-100 inline-flex rounded-full px-3 py-1 text-sm font-medium">
             {duration}
           </span>
         )
       }
       {
         isWorkshop && (
-          <span class="inline-flex rounded-full bg-primary-100 px-3 py-1 text-sm font-medium text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+          <span class="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200 inline-flex rounded-full px-3 py-1 text-sm font-medium">
             Workshop
           </span>
         )

--- a/src/components/Presentations/PresentationNav.astro
+++ b/src/components/Presentations/PresentationNav.astro
@@ -23,11 +23,11 @@ const nextPresentation =
     : null;
 ---
 
-<nav class="mt-12 border-t border-base-200 pt-8 dark:border-base-800">
+<nav class="border-base-200 dark:border-base-800 mt-12 border-t pt-8">
   <div class="flex items-center justify-between">
     <a
       href="/presentations/"
-      class="flex items-center gap-2 text-base-600 hover:text-primary-500 dark:text-base-400 dark:hover:text-primary-400"
+      class="text-base-600 hover:text-primary-500 dark:text-base-400 dark:hover:text-primary-400 flex items-center gap-2"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -48,9 +48,9 @@ const nextPresentation =
       prevPresentation && (
         <a
           href={`/presentations/${prevPresentation.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 hover:border-primary-500 dark:border-base-800 dark:hover:border-primary-400"
+          class="group border-base-200 hover:border-primary-500 dark:border-base-800 dark:hover:border-primary-400 flex-1 rounded-lg border p-4"
         >
-          <span class="flex items-center gap-1 text-sm text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400">
+          <span class="text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400 flex items-center gap-1 text-sm">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               class="h-4 w-4"
@@ -63,7 +63,7 @@ const nextPresentation =
             </svg>
             Previous
           </span>
-          <p class="mt-1 line-clamp-2 font-medium text-base-900 group-hover:text-primary-500 dark:text-white dark:group-hover:text-primary-400">
+          <p class="text-base-900 group-hover:text-primary-500 dark:group-hover:text-primary-400 mt-1 line-clamp-2 font-medium dark:text-white">
             {prevPresentation.data.title}
           </p>
         </a>
@@ -74,9 +74,9 @@ const nextPresentation =
       nextPresentation && (
         <a
           href={`/presentations/${nextPresentation.id}/`}
-          class="group flex-1 rounded-lg border border-base-200 p-4 text-right hover:border-primary-500 dark:border-base-800 dark:hover:border-primary-400"
+          class="group border-base-200 hover:border-primary-500 dark:border-base-800 dark:hover:border-primary-400 flex-1 rounded-lg border p-4 text-right"
         >
-          <span class="flex items-center justify-end gap-1 text-sm text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400">
+          <span class="text-base-500 group-hover:text-primary-500 dark:text-base-400 dark:group-hover:text-primary-400 flex items-center justify-end gap-1 text-sm">
             Next
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -89,7 +89,7 @@ const nextPresentation =
               <path d="M9 6l6 6l-6 6" />
             </svg>
           </span>
-          <p class="mt-1 line-clamp-2 font-medium text-base-900 group-hover:text-primary-500 dark:text-white dark:group-hover:text-primary-400">
+          <p class="text-base-900 group-hover:text-primary-500 dark:group-hover:text-primary-400 mt-1 line-clamp-2 font-medium dark:text-white">
             {nextPresentation.data.title}
           </p>
         </a>

--- a/src/components/Presentations/SlideEmbed.astro
+++ b/src/components/Presentations/SlideEmbed.astro
@@ -9,12 +9,12 @@ const { slideshareKey } = Astro.props;
 <div class="mb-12">
   <h2 class="h3 mb-4">Slides</h2>
   <div
-    class="relative rounded-lg bg-base-200 pb-[56.25%] dark:bg-base-800"
+    class="bg-base-200 dark:bg-base-800 relative rounded-lg pb-[56.25%]"
     id={`slide-container-${slideshareKey}`}
   >
     <iframe
       src={`https://www.slideshare.net/slideshow/embed_code/key/${slideshareKey}?hostedIn=slideshare&page=upload`}
-      class="absolute left-0 top-0 h-full w-full rounded-lg border-none"
+      class="absolute top-0 left-0 h-full w-full rounded-lg border-none"
       allowfullscreen
       loading="lazy"
       onload="this.parentElement.classList.remove('bg-base-200', 'dark:bg-base-800')"

--- a/src/components/Presentations/VideoEmbed.astro
+++ b/src/components/Presentations/VideoEmbed.astro
@@ -8,10 +8,10 @@ const { youtubeId } = Astro.props;
 
 <div class="mb-12">
   <h2 class="h3 mb-4">Video Recording</h2>
-  <div class="relative rounded-lg bg-base-200 pb-[56.25%] dark:bg-base-800">
+  <div class="bg-base-200 dark:bg-base-800 relative rounded-lg pb-[56.25%]">
     <iframe
       src={`https://www.youtube.com/embed/${youtubeId}`}
-      class="absolute left-0 top-0 h-full w-full rounded-lg border-none"
+      class="absolute top-0 left-0 h-full w-full rounded-lg border-none"
       allowfullscreen
       loading="lazy"
       onload="this.parentElement.classList.remove('bg-base-200', 'dark:bg-base-800')"

--- a/src/components/Press/ArticleSection.astro
+++ b/src/components/Press/ArticleSection.astro
@@ -35,12 +35,12 @@ const getBrandIcon = (org: string | undefined): string | null => {
 
         return (
           <article
-            class="article-card rounded-xl border border-base-200 bg-gradient-to-br from-base-50 to-base-100 p-6 transition-shadow hover:shadow-lg dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50"
+            class="article-card border-base-200 from-base-50 to-base-100 dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50 rounded-xl border bg-gradient-to-br p-6 transition-shadow hover:shadow-lg"
             role="listitem"
             aria-labelledby={articleId}
           >
             <div class="flex items-start gap-4">
-              <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200 dark:bg-base-700">
+              <div class="bg-base-200 dark:bg-base-700 flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg">
                 {brandIcon === "spryker" ? (
                   <svg class="h-8 w-8" viewBox="0 0 100 100" aria-hidden="true">
                     <path
@@ -62,7 +62,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                   />
                 ) : (
                   <svg
-                    class="h-7 w-7 text-base-500 dark:text-base-400"
+                    class="text-base-500 dark:text-base-400 h-7 w-7"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -80,12 +80,12 @@ const getBrandIcon = (org: string | undefined): string | null => {
               <div class="min-w-0 flex-1">
                 <h3
                   id={articleId}
-                  class="mb-2 text-lg font-semibold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-lg font-semibold"
                 >
                   {article.title}
                 </h3>
                 <div
-                  class="flex flex-wrap items-center gap-2 text-sm text-base-600 dark:text-base-400"
+                  class="text-base-600 dark:text-base-400 flex flex-wrap items-center gap-2 text-sm"
                   aria-label="Article details"
                 >
                   <time
@@ -118,7 +118,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                     href={article.articleUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                    class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 mt-3 inline-flex items-center gap-1 text-sm font-medium"
                     aria-label={`View article about ${article.title} (opens in new tab)`}
                   >
                     View article <span aria-hidden="true">→</span>

--- a/src/components/Press/AudioPlayer.astro
+++ b/src/components/Press/AudioPlayer.astro
@@ -9,7 +9,7 @@ const { src, title, coverImage } = Astro.props;
 ---
 
 <div
-  class="audio-player w-full rounded-xl bg-base-200 p-4 transition-colors dark:bg-base-800"
+  class="audio-player bg-base-200 dark:bg-base-800 w-full rounded-xl p-4 transition-colors"
 >
   {
     coverImage && (
@@ -31,7 +31,7 @@ const { src, title, coverImage } = Astro.props;
       <a
         href={src}
         download
-        class="text-primary-600 underline dark:text-primary-400"
+        class="text-primary-600 dark:text-primary-400 underline"
         >Download the audio</a
       >
     </p>

--- a/src/components/Press/AwardsSection.astro
+++ b/src/components/Press/AwardsSection.astro
@@ -43,8 +43,8 @@ const getBrandIcon = (org: string | undefined): string | null => {
           <article
             class={`award-card rounded-xl p-6 transition-shadow hover:shadow-lg ${
               isNomination
-                ? "border border-base-200 bg-gradient-to-br from-base-50 to-base-100 dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50"
-                : "border border-primary-200 bg-gradient-to-br from-primary-50 to-primary-100 dark:border-primary-700 dark:from-primary-900/20 dark:to-primary-800/20"
+                ? "border-base-200 from-base-50 to-base-100 dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50 border bg-gradient-to-br"
+                : "border-primary-200 from-primary-50 to-primary-100 dark:border-primary-700 dark:from-primary-900/20 dark:to-primary-800/20 border bg-gradient-to-br"
             }`}
             role="listitem"
             aria-labelledby={awardId}
@@ -54,7 +54,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                 class={`flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg ${
                   isNomination
                     ? "bg-base-200 dark:bg-base-700"
-                    : "border border-base-200 bg-base-100 dark:border-base-600 dark:bg-base-800"
+                    : "border-base-200 bg-base-100 dark:border-base-600 dark:bg-base-800 border"
                 }`}
               >
                 {brandIcon === "elevenlabs" ? (
@@ -95,7 +95,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                   />
                 ) : brandIcon === "trophy" ? (
                   <svg
-                    class="h-7 w-7 text-base-700 dark:text-base-300"
+                    class="text-base-700 dark:text-base-300 h-7 w-7"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -110,7 +110,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                   </svg>
                 ) : (
                   <svg
-                    class="h-7 w-7 text-base-700 dark:text-base-300"
+                    class="text-base-700 dark:text-base-300 h-7 w-7"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -128,12 +128,12 @@ const getBrandIcon = (org: string | undefined): string | null => {
               <div class="min-w-0 flex-1">
                 <h3
                   id={awardId}
-                  class="mb-2 text-lg font-semibold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-lg font-semibold"
                 >
                   {award.title}
                 </h3>
                 <div
-                  class="flex flex-wrap items-center gap-2 text-sm text-base-600 dark:text-base-400"
+                  class="text-base-600 dark:text-base-400 flex flex-wrap items-center gap-2 text-sm"
                   aria-label={
                     isNomination ? "Nomination details" : "Award details"
                   }
@@ -163,7 +163,7 @@ const getBrandIcon = (org: string | undefined): string | null => {
                     href={award.articleUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                    class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 mt-3 inline-flex items-center gap-1 text-sm font-medium"
                     aria-label={`View details about ${award.title} (opens in new tab)`}
                     title={`View details about ${award.title}`}
                   >

--- a/src/components/Press/ContentTypeSelector.astro
+++ b/src/components/Press/ContentTypeSelector.astro
@@ -36,7 +36,7 @@ const contentTypes = [
       contentTypes.map((type) => (
         <a
           href={`#${type.id}`}
-          class="flex w-full items-center justify-center gap-2 rounded-lg bg-primary-500 px-4 py-3 text-base-100 transition hover:bg-primary-600 sm:w-auto sm:px-6 dark:text-base-900"
+          class="bg-primary-500 text-base-100 hover:bg-primary-600 dark:text-base-900 flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 transition sm:w-auto sm:px-6"
         >
           <svg
             class="h-5 w-5"

--- a/src/components/Press/LazySpotify.astro
+++ b/src/components/Press/LazySpotify.astro
@@ -11,7 +11,7 @@ const { episodeId, title } = Astro.props;
   role="application"
   tabindex="0"
   aria-label={`Podcast player for episode: ${title}`}
-  class="w-full focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+  class="focus:ring-primary-500 w-full focus:ring-2 focus:ring-offset-2 focus:outline-hidden"
 >
   <iframe
     style="border-radius:12px"

--- a/src/components/Press/LazySpotify.astro
+++ b/src/components/Press/LazySpotify.astro
@@ -11,7 +11,7 @@ const { episodeId, title } = Astro.props;
   role="application"
   tabindex="0"
   aria-label={`Podcast player for episode: ${title}`}
-  class="w-full focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
+  class="w-full focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
 >
   <iframe
     style="border-radius:12px"

--- a/src/components/Press/LazyYouTube.astro
+++ b/src/components/Press/LazyYouTube.astro
@@ -11,7 +11,7 @@ const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
 ---
 
 <div
-  class="lazy-youtube relative aspect-video overflow-hidden rounded-lg bg-base-200 dark:bg-white/[.075]"
+  class="lazy-youtube bg-base-200 relative aspect-video overflow-hidden rounded-lg dark:bg-white/[.075]"
   data-video-id={videoId}
   data-title={title}
 >

--- a/src/components/Press/LazyYouTube.astro
+++ b/src/components/Press/LazyYouTube.astro
@@ -63,7 +63,7 @@ const thumbnailUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
 
 <style>
   .lazy-youtube button:focus {
-    outline: 2px solid theme("colors.primary.500");
+    outline: 2px solid var(--color-primary-500);
     outline-offset: 2px;
   }
 

--- a/src/components/Press/ListingsSection.astro
+++ b/src/components/Press/ListingsSection.astro
@@ -11,7 +11,7 @@ const { listings } = Astro.props;
 
 <section id="listings" class="mb-16" aria-labelledby="listings-heading">
   <h2 id="listings-heading" class="h2 mb-4">Featured In</h2>
-  <p class="mb-6 text-base-600 dark:text-base-400">
+  <p class="text-base-600 dark:text-base-400 mb-6">
     Mentioned in "best of" lists and expert compilations.
   </p>
   <div
@@ -26,12 +26,12 @@ const { listings } = Astro.props;
 
         return (
           <article
-            class="listing-card rounded-xl border border-base-200 bg-gradient-to-br from-base-50 to-base-100 p-6 transition-shadow hover:shadow-lg dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50"
+            class="listing-card border-base-200 from-base-50 to-base-100 dark:border-base-600 dark:from-base-800/50 dark:to-base-700/50 rounded-xl border bg-gradient-to-br p-6 transition-shadow hover:shadow-lg"
             role="listitem"
             aria-labelledby={listingId}
           >
             <div class="flex items-start gap-4">
-              <div class="flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg bg-base-200 dark:bg-base-700">
+              <div class="bg-base-200 dark:bg-base-700 flex h-12 w-12 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg">
                 {listing.articleUrl ? (
                   <img
                     src={getFaviconUrl(listing.articleUrl)}
@@ -46,7 +46,7 @@ const { listings } = Astro.props;
                   />
                 ) : (
                   <svg
-                    class="h-7 w-7 text-base-500 dark:text-base-400"
+                    class="text-base-500 dark:text-base-400 h-7 w-7"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -64,12 +64,12 @@ const { listings } = Astro.props;
               <div class="min-w-0 flex-1">
                 <h3
                   id={listingId}
-                  class="mb-2 text-lg font-semibold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-lg font-semibold"
                 >
                   {listing.title}
                 </h3>
                 <div
-                  class="flex flex-wrap items-center gap-2 text-sm text-base-600 dark:text-base-400"
+                  class="text-base-600 dark:text-base-400 flex flex-wrap items-center gap-2 text-sm"
                   aria-label="Listing details"
                 >
                   <time
@@ -89,7 +89,7 @@ const { listings } = Astro.props;
                     href={listing.articleUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="mt-3 inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                    class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 mt-3 inline-flex items-center gap-1 text-sm font-medium"
                     aria-label={`View ${listing.title} (opens in new tab)`}
                   >
                     View details <span aria-hidden="true">→</span>

--- a/src/components/Press/PodcastLinks.astro
+++ b/src/components/Press/PodcastLinks.astro
@@ -17,9 +17,9 @@ const spotifyUrl = spotifyId
 ---
 
 <div
-  class="podcast-links w-full rounded-xl bg-base-200 p-4 transition-colors dark:bg-base-800"
+  class="podcast-links bg-base-200 dark:bg-base-800 w-full rounded-xl p-4 transition-colors"
 >
-  <p class="mb-3 text-sm text-base-600 dark:text-base-400">
+  <p class="text-base-600 dark:text-base-400 mb-3 text-sm">
     Listen on your preferred platform:
   </p>
   <div class="flex flex-wrap gap-2">

--- a/src/components/Press/SifaCTA.astro
+++ b/src/components/Press/SifaCTA.astro
@@ -3,16 +3,16 @@
 ---
 
 <section class="container mx-auto mb-16 px-4">
-  <div class="rounded-xl bg-primary-50 p-8 text-center dark:bg-primary-900/20">
+  <div class="bg-primary-50 dark:bg-primary-900/20 rounded-xl p-8 text-center">
     <h2 class="h2 mb-4">More like this? Follow me on Sifa ID!</h2>
-    <p class="description mb-6 text-base-600 dark:text-base-400">
+    <p class="description text-base-600 dark:text-base-400 mb-6">
       Most of my content is published on Sifa, so make sure to follow me there!
     </p>
     <a
       href="https://sifa.id/p/gui.do"
       target="_blank"
       rel="noopener noreferrer"
-      class="inline-flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-base-100 transition hover:bg-primary-600 dark:text-base-900"
+      class="bg-primary-500 text-base-100 hover:bg-primary-600 dark:text-base-900 inline-flex items-center gap-2 rounded-lg px-6 py-3 transition"
     >
       <svg
         class="h-5 w-5"

--- a/src/components/Press/VideoSection.astro
+++ b/src/components/Press/VideoSection.astro
@@ -111,7 +111,7 @@ function getYouTubeId(url: string): string {
 
 <style>
   .lazy-youtube button:focus {
-    outline: 2px solid theme("colors.primary.500");
+    outline: 2px solid var(--color-primary-500);
     outline-offset: 2px;
   }
 

--- a/src/components/Projects/ProjectCard.astro
+++ b/src/components/Projects/ProjectCard.astro
@@ -44,7 +44,7 @@ const {
           ) : (
             <Icon
               name={mainImage}
-              class="h-12 w-12 text-base-50"
+              class="text-base-50 h-12 w-12"
               aria-hidden="true"
             />
           )
@@ -70,7 +70,7 @@ const {
       </h2>
       {
         (tagline || license) && (
-          <p class="mb-2 text-sm text-base-400">
+          <p class="text-base-400 mb-2 text-sm">
             {tagline || `License: ${license}`}
           </p>
         )

--- a/src/components/Regenerating/Regenerating.astro
+++ b/src/components/Regenerating/Regenerating.astro
@@ -12,6 +12,7 @@
 </div>
 
 <style>
+  @reference "../../styles/tailwind.css";
   .regenerating {
     @apply bg-base-950;
     padding: 3em 2em;

--- a/src/components/RelatedEvents/RelatedEvents.astro
+++ b/src/components/RelatedEvents/RelatedEvents.astro
@@ -32,8 +32,8 @@ const secondColumnEvents = sortedEvents.filter((_, i) => i % 2 === 1);
 
 {
   sortedEvents.length > 0 && (
-    <div class="mt-12 border-t border-base-200 pt-12 dark:border-base-800">
-      <h2 class="mb-8 text-2xl font-bold text-base-900 dark:text-base-100">
+    <div class="border-base-200 dark:border-base-800 mt-12 border-t pt-12">
+      <h2 class="text-base-900 dark:text-base-100 mb-8 text-2xl font-bold">
         I've given the above session at the following events:
       </h2>
       <div class="grid grid-cols-1 gap-6 md:grid-cols-2 md:gap-8">

--- a/src/components/RelatedPresentations/RelatedPresentations.astro
+++ b/src/components/RelatedPresentations/RelatedPresentations.astro
@@ -23,7 +23,7 @@ const relatedPresentations = getRelatedPresentations(eventId, allPresentations);
         {relatedPresentations.map((presentation) => (
           <a
             href={`/presentations/${presentation.id}/`}
-            class="block rounded-lg bg-white shadow-md transition-shadow hover:shadow-lg dark:bg-base-900"
+            class="dark:bg-base-900 block rounded-lg bg-white shadow-md transition-shadow hover:shadow-lg"
           >
             <div class="relative">
               {presentation.data.image && (
@@ -34,7 +34,7 @@ const relatedPresentations = getRelatedPresentations(eventId, allPresentations);
                 />
               )}
               {presentation.data.isWorkshop && (
-                <span class="absolute right-2 top-2 rounded-sm bg-primary-600 px-2 py-1 text-sm text-base-100 dark:text-base-900">
+                <span class="bg-primary-600 text-base-100 dark:text-base-900 absolute top-2 right-2 rounded-sm px-2 py-1 text-sm">
                   Workshop
                 </span>
               )}
@@ -44,12 +44,12 @@ const relatedPresentations = getRelatedPresentations(eventId, allPresentations);
                 {presentation.data.title}
               </h3>
               {presentation.data.duration && (
-                <p class="text-sm text-base-600 dark:text-base-400">
+                <p class="text-base-600 dark:text-base-400 text-sm">
                   Duration: {presentation.data.duration}
                 </p>
               )}
               {presentation.data.intendedAudience && (
-                <p class="mt-1 text-sm text-base-600 dark:text-base-400">
+                <p class="text-base-600 dark:text-base-400 mt-1 text-sm">
                   For: {presentation.data.intendedAudience}
                 </p>
               )}

--- a/src/components/RelatedPresentations/RelatedPresentations.astro
+++ b/src/components/RelatedPresentations/RelatedPresentations.astro
@@ -34,7 +34,7 @@ const relatedPresentations = getRelatedPresentations(eventId, allPresentations);
                 />
               )}
               {presentation.data.isWorkshop && (
-                <span class="absolute right-2 top-2 rounded bg-primary-600 px-2 py-1 text-sm text-base-100 dark:text-base-900">
+                <span class="absolute right-2 top-2 rounded-sm bg-primary-600 px-2 py-1 text-sm text-base-100 dark:text-base-900">
                   Workshop
                 </span>
               )}

--- a/src/components/ServiceCard/ServiceCardIcon.astro
+++ b/src/components/ServiceCard/ServiceCardIcon.astro
@@ -28,23 +28,23 @@ const { icon, title, text, href, idx, ...rest } = Astro.props as Props;
 <div {...rest} class="h-full">
   <a
     href={href}
-    class="group flex h-full flex-col justify-between overflow-hidden rounded-xl px-4 py-8 text-center transition-all duration-300 hover:bg-white hover:shadow-xl dark:hover:bg-base-900"
+    class="group dark:hover:bg-base-900 flex h-full flex-col justify-between overflow-hidden rounded-xl px-4 py-8 text-center transition-all duration-300 hover:bg-white hover:shadow-xl"
   >
     <div>
       <div
-        class="mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg bg-primary-500 text-base-100 dark:text-base-900"
+        class="bg-primary-500 text-base-100 dark:text-base-900 mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg"
       >
         <Icon
           name={icon}
-          class="size-7 text-base-100 dark:text-base-900"
+          class="text-base-100 dark:text-base-900 size-7"
           aria-hidden="true"
         />
       </div>
 
-      <h4 class="heading-card mb-3 text-base-900 dark:text-base-100">
+      <h4 class="heading-card text-base-900 dark:text-base-100 mb-3">
         {title}
       </h4>
-      <p class="description text-pretty text-base-400">{text}</p>
+      <p class="description text-base-400 text-pretty">{text}</p>
     </div>
     <div class="mt-6 flex justify-center">
       <Button variant="outline" arrow="right">

--- a/src/components/ServiceCard/ServiceCardSideImage.astro
+++ b/src/components/ServiceCard/ServiceCardSideImage.astro
@@ -164,7 +164,7 @@ const cardId = `biography-${title.toLowerCase().replace(/\s+/g, "-")}`;
 
   /* Focus styles for interactive elements */
   :focus-visible {
-    outline: 2px solid var(--focus-ring-color, theme("colors.primary.500"));
+    outline: 2px solid var(--focus-ring-color, var(--color-primary-500));
     outline-offset: 2px;
   }
 </style>

--- a/src/components/Services/ServicesIconPress.astro
+++ b/src/components/Services/ServicesIconPress.astro
@@ -24,7 +24,7 @@ const pageTitle = "Press / Media";
       <div class="flex space-x-4">
         <a
           href="#videos"
-          class="flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-base-100 transition hover:bg-primary-600 dark:text-base-900"
+          class="bg-primary-500 text-base-100 hover:bg-primary-600 dark:text-base-900 flex items-center gap-2 rounded-lg px-6 py-3 transition"
         >
           <svg
             class="h-5 w-5"
@@ -48,7 +48,7 @@ const pageTitle = "Press / Media";
         </a>
         <a
           href="#podcasts"
-          class="flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-base-100 transition hover:bg-primary-600 dark:text-base-900"
+          class="bg-primary-500 text-base-100 hover:bg-primary-600 dark:text-base-900 flex items-center gap-2 rounded-lg px-6 py-3 transition"
         >
           <svg
             class="h-5 w-5"
@@ -67,7 +67,7 @@ const pageTitle = "Press / Media";
         </a>
         <a
           href="#articles"
-          class="flex items-center gap-2 rounded-lg bg-primary-500 px-6 py-3 text-base-100 transition hover:bg-primary-600 dark:text-base-900"
+          class="bg-primary-500 text-base-100 hover:bg-primary-600 dark:text-base-900 flex items-center gap-2 rounded-lg px-6 py-3 transition"
         >
           <svg
             class="h-5 w-5"

--- a/src/components/Services/ServicesSideImage.astro
+++ b/src/components/Services/ServicesSideImage.astro
@@ -102,7 +102,7 @@ In 2021 it was time to focus on something new and I became the Global Business &
             />
             <Icon
               name="tabler:letter-x"
-              class="-ml-3 h-14 w-14 text-base-100"
+              class="text-base-100 -ml-3 h-14 w-14"
               stroke-width="8"
               stroke="currentColor"
               fill="none"

--- a/src/components/SiteContent/ContentCard.astro
+++ b/src/components/SiteContent/ContentCard.astro
@@ -29,15 +29,15 @@ const { icon, title, text, href, ctaText, idx, ...rest } = Astro.props as Props;
 <div {...rest} class="h-full">
   <a
     href={href}
-    class="group flex h-full flex-col justify-between overflow-hidden rounded-xl px-4 py-8 text-center transition-all duration-300 hover:bg-white hover:shadow-xl dark:hover:bg-base-900"
+    class="group dark:hover:bg-base-900 flex h-full flex-col justify-between overflow-hidden rounded-xl px-4 py-8 text-center transition-all duration-300 hover:bg-white hover:shadow-xl"
   >
     <div>
       <div
-        class="mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg bg-primary-500 text-base-100 dark:text-base-900"
+        class="bg-primary-500 text-base-100 dark:text-base-900 mx-auto mb-7 inline-flex size-16 items-center justify-center rounded-lg"
       >
         <Icon
           name={icon}
-          class="size-7 text-base-100 dark:text-base-900"
+          class="text-base-100 dark:text-base-900 size-7"
           aria-hidden="true"
         />
       </div>

--- a/src/components/SiteLogo/SiteLogo.astro
+++ b/src/components/SiteLogo/SiteLogo.astro
@@ -55,10 +55,10 @@ const currLocale = getLocaleFromUrl(Astro.url);
 
 <a
   transition:persist
-  class="site-logo primary-focus flex items-center gap-2 align-middle text-xl font-bold text-base-600 dark:text-base-200"
+  class="site-logo primary-focus text-base-600 dark:text-base-200 flex items-center gap-2 align-middle text-xl font-bold"
   href={getRelativeLocaleUrl(currLocale)}
 >
   <p class="site-logo-text">Guido</p>
-  <LogoIcon class="site-logo-icon size-7 text-primary-500" aria-hidden="true" />
+  <LogoIcon class="site-logo-icon text-primary-500 size-7" aria-hidden="true" />
   <p class="site-logo-text">Jansen</p>
 </a>

--- a/src/components/SocialIcon/SocialIcon.astro
+++ b/src/components/SocialIcon/SocialIcon.astro
@@ -44,7 +44,7 @@ const IconComponent = iconMap[icon] || null;
   target="_blank"
   rel="noopener noreferrer"
   class:list={[
-    "relative inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md p-2 text-base-600 transition-colors hover:bg-base-100 hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:bg-base-800 dark:hover:text-base-300",
+    "text-base-600 hover:bg-base-100 hover:text-base-700 focus:ring-primary-500 dark:text-base-400 dark:hover:bg-base-800 dark:hover:text-base-300 relative inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md p-2 transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden",
     className,
   ]}
   data-umami-event="social-click"

--- a/src/components/SocialIcon/SocialIcon.astro
+++ b/src/components/SocialIcon/SocialIcon.astro
@@ -44,7 +44,7 @@ const IconComponent = iconMap[icon] || null;
   target="_blank"
   rel="noopener noreferrer"
   class:list={[
-    "relative inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md p-2 text-base-600 transition-colors hover:bg-base-100 hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:bg-base-800 dark:hover:text-base-300",
+    "relative inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded-md p-2 text-base-600 transition-colors hover:bg-base-100 hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-400 dark:hover:bg-base-800 dark:hover:text-base-300",
     className,
   ]}
   data-umami-event="social-click"

--- a/src/components/SocialLinks/SocialLinks.astro
+++ b/src/components/SocialLinks/SocialLinks.astro
@@ -43,10 +43,10 @@ const navLabel = labelMap[location] ?? "Social media links";
     {
       visibleLinks.map(({ name, href, icon }) => (
         <li role="listitem" class="group relative pt-8">
-          <div class="pointer-events-none absolute left-1/2 top-0 z-[100] -translate-x-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 [.group:first-child_&]:left-0 [.group:first-child_&]:translate-x-0 [.group:last-child_&]:left-auto [.group:last-child_&]:right-0 [.group:last-child_&]:translate-x-0">
-            <div class="mb-6 whitespace-nowrap rounded-md border border-base-700/20 bg-base-900/90 px-2.5 py-1.5 text-xs text-base-50 shadow-lg backdrop-blur-xs">
+          <div class="pointer-events-none absolute top-0 left-1/2 z-[100] -translate-x-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 [.group:first-child_&]:left-0 [.group:first-child_&]:translate-x-0 [.group:last-child_&]:right-0 [.group:last-child_&]:left-auto [.group:last-child_&]:translate-x-0">
+            <div class="border-base-700/20 bg-base-900/90 text-base-50 mb-6 rounded-md border px-2.5 py-1.5 text-xs whitespace-nowrap shadow-lg backdrop-blur-xs">
               {name}
-              <div class="absolute left-1/2 top-full -mt-px -translate-x-1/2 border-4 border-transparent border-t-base-900/90" />
+              <div class="border-t-base-900/90 absolute top-full left-1/2 -mt-px -translate-x-1/2 border-4 border-transparent" />
             </div>
           </div>
           <SocialIcon

--- a/src/components/SocialLinks/SocialLinks.astro
+++ b/src/components/SocialLinks/SocialLinks.astro
@@ -44,7 +44,7 @@ const navLabel = labelMap[location] ?? "Social media links";
       visibleLinks.map(({ name, href, icon }) => (
         <li role="listitem" class="group relative pt-8">
           <div class="pointer-events-none absolute left-1/2 top-0 z-[100] -translate-x-1/2 opacity-0 transition-opacity duration-200 group-hover:opacity-100 [.group:first-child_&]:left-0 [.group:first-child_&]:translate-x-0 [.group:last-child_&]:left-auto [.group:last-child_&]:right-0 [.group:last-child_&]:translate-x-0">
-            <div class="mb-6 whitespace-nowrap rounded-md border border-base-700/20 bg-base-900/90 px-2.5 py-1.5 text-xs text-base-50 shadow-lg backdrop-blur-sm">
+            <div class="mb-6 whitespace-nowrap rounded-md border border-base-700/20 bg-base-900/90 px-2.5 py-1.5 text-xs text-base-50 shadow-lg backdrop-blur-xs">
               {name}
               <div class="absolute left-1/2 top-full -mt-px -translate-x-1/2 border-4 border-transparent border-t-base-900/90" />
             </div>

--- a/src/components/Testimonials/ColleagueTestimonialCard.astro
+++ b/src/components/Testimonials/ColleagueTestimonialCard.astro
@@ -11,7 +11,7 @@ const { name, role, company, workRelationship, quote } =
 ---
 
 <article
-  class="bg-base-0 flex h-full flex-col rounded-xl border border-base-200 p-4 shadow-sm transition-all duration-300 hover:shadow-md sm:p-6 md:p-8 dark:border-base-700 dark:bg-base-800"
+  class="bg-base-0 flex h-full flex-col rounded-xl border border-base-200 p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-6 md:p-8 dark:border-base-700 dark:bg-base-800"
 >
   <!-- Quote section -->
   <div class="flex-1">

--- a/src/components/Testimonials/ColleagueTestimonialCard.astro
+++ b/src/components/Testimonials/ColleagueTestimonialCard.astro
@@ -11,18 +11,18 @@ const { name, role, company, workRelationship, quote } =
 ---
 
 <article
-  class="bg-base-0 flex h-full flex-col rounded-xl border border-base-200 p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-6 md:p-8 dark:border-base-700 dark:bg-base-800"
+  class="bg-base-0 border-base-200 dark:border-base-700 dark:bg-base-800 flex h-full flex-col rounded-xl border p-4 shadow-xs transition-all duration-300 hover:shadow-md sm:p-6 md:p-8"
 >
   <!-- Quote section -->
   <div class="flex-1">
     <div class="relative">
       <Icon
         name="atlas/quotes-top"
-        class="absolute -left-2 -top-2 h-8 w-8 text-primary-200 opacity-60 dark:text-primary-700"
+        class="text-primary-200 dark:text-primary-700 absolute -top-2 -left-2 h-8 w-8 opacity-60"
         aria-hidden="true"
       />
       <blockquote
-        class="mb-4 pl-4 text-lg leading-relaxed text-base-700 dark:text-base-200"
+        class="text-base-700 dark:text-base-200 mb-4 pl-4 text-lg leading-relaxed"
       >
         "{quote}"
       </blockquote>
@@ -31,12 +31,12 @@ const { name, role, company, workRelationship, quote } =
 
   <!-- Attribution section -->
   <footer class="mt-auto">
-    <div class="border-t border-base-200 pt-4 dark:border-base-600">
+    <div class="border-base-200 dark:border-base-600 border-t pt-4">
       <cite class="not-italic">
-        <div class="text-lg font-semibold text-base-900 dark:text-base-100">
+        <div class="text-base-900 dark:text-base-100 text-lg font-semibold">
           {name}
         </div>
-        <div class="mt-1 text-base-600 dark:text-base-300">
+        <div class="text-base-600 dark:text-base-300 mt-1">
           {role}
           {
             company && (
@@ -44,7 +44,7 @@ const { name, role, company, workRelationship, quote } =
             )
           }
         </div>
-        <div class="mt-1 text-sm text-base-600 dark:text-base-400">
+        <div class="text-base-600 dark:text-base-400 mt-1 text-sm">
           {workRelationship}
         </div>
       </cite>

--- a/src/components/Testimonials/ColleagueTestimonials.astro
+++ b/src/components/Testimonials/ColleagueTestimonials.astro
@@ -25,7 +25,7 @@ const initialTestimonials = getRandomTestimonials(4);
           href="https://www.linkedin.com/in/gxjansen/details/recommendations/"
           target="_blank"
           rel="noopener noreferrer"
-          class="transition-colors duration-200 hover:text-primary-600"
+          class="hover:text-primary-600 transition-colors duration-200"
         >
           What my colleagues say
         </a>
@@ -56,7 +56,7 @@ const initialTestimonials = getRandomTestimonials(4);
         href="https://www.linkedin.com/in/gxjansen/details/recommendations/"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center font-medium text-primary-600 transition-colors duration-200 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+        class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 inline-flex items-center font-medium transition-colors duration-200"
       >
         View the full, 80+ recommendations on my LinkedIn profile (login
         required)

--- a/src/components/ThemeToggle/ThemeToggle.astro
+++ b/src/components/ThemeToggle/ThemeToggle.astro
@@ -14,7 +14,7 @@ const { class: className } = Astro.props as Props;
 <button
   class:list={[
     className,
-    "theme-toggle primary-focus rounded-full p-2 text-base-600 transition-colors hover:text-base-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200",
+    "theme-toggle primary-focus rounded-full p-2 text-base-600 transition-colors hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200",
   ]}
   aria-label="Toggle color theme"
   aria-pressed="false"

--- a/src/components/ThemeToggle/ThemeToggle.astro
+++ b/src/components/ThemeToggle/ThemeToggle.astro
@@ -14,7 +14,7 @@ const { class: className } = Astro.props as Props;
 <button
   class:list={[
     className,
-    "theme-toggle primary-focus rounded-full p-2 text-base-600 transition-colors hover:text-base-700 focus:outline-hidden focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:text-base-300 dark:hover:text-base-200",
+    "theme-toggle primary-focus text-base-600 hover:text-base-700 focus:ring-primary-500 dark:text-base-300 dark:hover:text-base-200 rounded-full p-2 transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-hidden",
   ]}
   aria-label="Toggle color theme"
   aria-pressed="false"

--- a/src/components/Throbber/Throbber.astro
+++ b/src/components/Throbber/Throbber.astro
@@ -19,7 +19,7 @@ const shimmerDelay = (Math.random() * 2).toFixed(2);
 ---
 
 <div
-  class="throbber my-4 flex select-none items-center gap-2 font-mono text-sm"
+  class="throbber my-4 flex items-center gap-2 font-mono text-sm select-none"
 >
   <span
     class:list={["throbber-icon", variant === "game" ? "game" : "claude"]}

--- a/src/layouts/BlogLayoutCenter.astro
+++ b/src/layouts/BlogLayoutCenter.astro
@@ -104,7 +104,7 @@ const newsletterDescription =
             </h1>
 
             <div
-              class="mt-6 flex w-full flex-wrap items-center justify-center gap-4 font-medium text-base-500 dark:text-base-400"
+              class="text-base-500 dark:text-base-400 mt-6 flex w-full flex-wrap items-center justify-center gap-4 font-medium"
             >
               <!-- Author info -->
               <div class="flex flex-wrap items-center gap-4">
@@ -126,7 +126,7 @@ const newsletterDescription =
 
               {
                 authorsData.length > 0 && pubDate && (
-                  <span class="hidden text-base-400 sm:inline">&bull;</span>
+                  <span class="text-base-400 hidden sm:inline">&bull;</span>
                 )
               }
 
@@ -158,7 +158,7 @@ const newsletterDescription =
                       href={blueskyUri}
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="inline-flex items-center gap-1.5 text-foam-light hover:underline dark:text-foam"
+                      class="text-foam-light dark:text-foam inline-flex items-center gap-1.5 hover:underline"
                     >
                       <svg
                         class="h-4 w-4"
@@ -220,7 +220,7 @@ const newsletterDescription =
   <!-- article content -->
   <div class="mt-10 w-full px-4">
     <div class="mx-auto max-w-2xl">
-      <div class="text-base text-base-900 dark:text-base-100">
+      <div class="text-base-900 dark:text-base-100 text-base">
         {
           updatedDate && (
             <div class="mb-6 italic">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -59,7 +59,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
         <div class="w-full px-4 md:w-1/2">
           <div class="text-center md:max-w-xl md:text-left">
             <span
-              class="mb-4 inline-block rounded-full bg-primary-100 px-2 py-px text-xs font-medium leading-5 text-primary-500 shadow-sm dark:bg-primary-500 dark:text-white"
+              class="mb-4 inline-block rounded-full bg-primary-100 px-2 py-px text-xs font-medium leading-5 text-primary-500 shadow-xs dark:bg-primary-500 dark:text-white"
               >Error 404</span
             >
             <h2

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -37,37 +37,37 @@ const currLocale = getLocaleFromUrl(Astro.url);
           <!-- corner icons -->
           <Icon
             name="atlas/dots1"
-            class="absolute -left-6 -top-6 z-10 w-28 text-accent-1"
+            class="text-accent-1 absolute -top-6 -left-6 z-10 w-28"
             aria-hidden="true"
           />
           <Icon
             name="atlas/dots3"
-            class="absolute -right-6 -top-6 z-10 w-28 text-primary-500"
+            class="text-primary-500 absolute -top-6 -right-6 z-10 w-28"
             aria-hidden="true"
           />
           <Icon
             name="atlas/dots1"
-            class="absolute -bottom-6 -right-6 w-28 text-accent-4"
+            class="text-accent-4 absolute -right-6 -bottom-6 w-28"
             aria-hidden="true"
           />
           <Icon
             name="atlas/dots3"
-            class="absolute -bottom-6 -left-6 w-28 text-accent-3"
+            class="text-accent-3 absolute -bottom-6 -left-6 w-28"
             aria-hidden="true"
           />
         </div>
         <div class="w-full px-4 md:w-1/2">
           <div class="text-center md:max-w-xl md:text-left">
             <span
-              class="mb-4 inline-block rounded-full bg-primary-100 px-2 py-px text-xs font-medium leading-5 text-primary-500 shadow-xs dark:bg-primary-500 dark:text-white"
+              class="bg-primary-100 text-primary-500 dark:bg-primary-500 mb-4 inline-block rounded-full px-2 py-px text-xs leading-5 font-medium shadow-xs dark:text-white"
               >Error 404</span
             >
             <h2
-              class="mb-4 text-4xl font-bold leading-tight tracking-tighter text-base-900 md:text-5xl dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-4xl leading-tight font-bold tracking-tighter md:text-5xl"
             >
               Oh no! Error 404
             </h2>
-            <p class="mb-6 text-lg text-base-500 md:text-xl dark:text-base-400">
+            <p class="text-base-500 dark:text-base-400 mb-6 text-lg md:text-xl">
               Something went wrong, so this page is broken.
             </p>
             <div class="flex flex-wrap justify-center md:justify-start">

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -47,7 +47,7 @@ const { Content } = await render(page);
     </div>
     <div class="mx-auto max-w-3xl">
       <div
-        class="prose mt-10 max-w-none text-sm text-base-900 md:text-base dark:text-base-100"
+        class="prose text-base-900 dark:text-base-100 mt-10 max-w-none text-sm md:text-base"
       >
         <Content components={{ a: ExternalLink }} />
       </div>

--- a/src/pages/authors/[slug].astro
+++ b/src/pages/authors/[slug].astro
@@ -126,14 +126,14 @@ const personSchema = {
 
         <div class="flex-1">
           <h1
-            class="text-4xl font-bold text-base-900 md:text-5xl dark:text-base-100"
+            class="text-base-900 dark:text-base-100 text-4xl font-bold md:text-5xl"
           >
             {name}
           </h1>
 
           {
             (jobTitle || organization) && (
-              <div class="mt-2 text-xl text-base-600 dark:text-base-400">
+              <div class="text-base-600 dark:text-base-400 mt-2 text-xl">
                 {jobTitle}
                 {jobTitle && organization && " at "}
                 {organization}
@@ -143,7 +143,7 @@ const personSchema = {
 
           {
             yearsOfExperience && (
-              <div class="mt-2 text-base-600 dark:text-base-400">
+              <div class="text-base-600 dark:text-base-400 mt-2">
                 {yearsOfExperience}+ years of experience
               </div>
             )
@@ -151,7 +151,7 @@ const personSchema = {
 
           {
             bio && (
-              <div class="prose mt-4 max-w-none text-lg text-base-700 dark:prose-invert dark:text-base-300">
+              <div class="prose text-base-700 dark:prose-invert dark:text-base-300 mt-4 max-w-none text-lg">
                 <p>{bio}</p>
               </div>
             )
@@ -163,7 +163,7 @@ const personSchema = {
               <div class="mt-6">
                 <a
                   href="/about/"
-                  class="inline-flex items-center rounded-lg border-2 border-primary-600 px-5 py-2.5 font-medium text-primary-600 transition-colors duration-200 hover:bg-primary-600 hover:text-white dark:border-primary-400 dark:text-primary-400 dark:hover:bg-primary-400 dark:hover:text-base-900"
+                  class="border-primary-600 text-primary-600 hover:bg-primary-600 dark:border-primary-400 dark:text-primary-400 dark:hover:bg-primary-400 dark:hover:text-base-900 inline-flex items-center rounded-lg border-2 px-5 py-2.5 font-medium transition-colors duration-200 hover:text-white"
                 >
                   Read the Full Story
                   <svg
@@ -199,7 +199,7 @@ const personSchema = {
                     href={website}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="ml-2 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                    class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 ml-2 text-sm font-medium"
                   >
                     gui.do →
                   </a>
@@ -214,12 +214,12 @@ const personSchema = {
       {
         expertise.length > 0 && (
           <section class="mt-12">
-            <h2 class="mb-4 text-2xl font-bold text-base-900 dark:text-base-100">
+            <h2 class="text-base-900 dark:text-base-100 mb-4 text-2xl font-bold">
               Areas of Expertise
             </h2>
             <div class="flex flex-wrap gap-3">
               {expertise.map((topic: string) => (
-                <span class="rounded-full bg-primary-100 px-4 py-2 font-medium text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+                <span class="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200 rounded-full px-4 py-2 font-medium">
                   {topic}
                 </span>
               ))}
@@ -232,10 +232,10 @@ const personSchema = {
       {
         credentials.length > 0 && (
           <section class="mt-12">
-            <h2 class="mb-4 text-2xl font-bold text-base-900 dark:text-base-100">
+            <h2 class="text-base-900 dark:text-base-100 mb-4 text-2xl font-bold">
               Credentials & Qualifications
             </h2>
-            <ul class="list-inside list-disc space-y-2 text-base-700 dark:text-base-300">
+            <ul class="text-base-700 dark:text-base-300 list-inside list-disc space-y-2">
               {credentials.map((credential: string) => (
                 <li>{credential}</li>
               ))}
@@ -248,10 +248,10 @@ const personSchema = {
       {
         awards.length > 0 && (
           <section class="mt-12">
-            <h2 class="mb-4 text-2xl font-bold text-base-900 dark:text-base-100">
+            <h2 class="text-base-900 dark:text-base-100 mb-4 text-2xl font-bold">
               Awards & Recognition
             </h2>
-            <ul class="list-inside list-disc space-y-2 text-base-700 dark:text-base-300">
+            <ul class="text-base-700 dark:text-base-300 list-inside list-disc space-y-2">
               {awards.map((award: string) => (
                 <li>{award}</li>
               ))}
@@ -264,7 +264,7 @@ const personSchema = {
       {
         publications.length > 0 && (
           <section class="mt-12">
-            <h2 class="mb-4 text-2xl font-bold text-base-900 dark:text-base-100">
+            <h2 class="text-base-900 dark:text-base-100 mb-4 text-2xl font-bold">
               Notable Publications
             </h2>
             <ul class="space-y-3">
@@ -272,12 +272,12 @@ const personSchema = {
                 <li>
                   <a
                     href={pub.url}
-                    class="font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                    class="text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
                   >
                     {pub.title}
                   </a>
                   {(pub.publication || pub.date) && (
-                    <span class="ml-2 text-sm text-base-600 dark:text-base-400">
+                    <span class="text-base-600 dark:text-base-400 ml-2 text-sm">
                       {pub.publication && `— ${pub.publication}`}
                       {pub.date && ` (${pub.date})`}
                     </span>
@@ -290,7 +290,7 @@ const personSchema = {
       }
 
       <!-- MDX Content (if any) -->
-      <div class="prose mt-12 max-w-none dark:prose-invert">
+      <div class="prose dark:prose-invert mt-12 max-w-none">
         <Content />
       </div>
 
@@ -298,7 +298,7 @@ const personSchema = {
       {
         sortedPosts.length > 0 && (
           <section class="mt-16">
-            <h2 class="mb-8 text-3xl font-bold text-base-900 dark:text-base-100">
+            <h2 class="text-base-900 dark:text-base-100 mb-8 text-3xl font-bold">
               Articles by {name} ({sortedPosts.length})
             </h2>
             <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/authors/index.astro
+++ b/src/pages/authors/index.astro
@@ -23,18 +23,18 @@ const authorPostCounts = authors
 >
   <div class="mx-auto mt-24 max-w-5xl px-4">
     <h1
-      class="mb-4 text-4xl font-bold text-base-900 md:text-5xl dark:text-base-100"
+      class="text-base-900 dark:text-base-100 mb-4 text-4xl font-bold md:text-5xl"
     >
       About the Author
     </h1>
-    <p class="mb-12 text-xl text-base-600 dark:text-base-400">
+    <p class="text-base-600 dark:text-base-400 mb-12 text-xl">
       Meet the expert behind this content
     </p>
 
     <div class="grid grid-cols-1 gap-8 md:grid-cols-2">
       {
         authorPostCounts.map(({ author, postCount }) => (
-          <article class="rounded-xl border border-base-300 p-6 transition-shadow hover:shadow-lg dark:border-base-700">
+          <article class="border-base-300 dark:border-base-700 rounded-xl border p-6 transition-shadow hover:shadow-lg">
             <a href={`/authors/${author.id}/`} class="flex gap-6">
               {author.data.avatar && (
                 <div class="flex-shrink-0">
@@ -50,12 +50,12 @@ const authorPostCounts = authors
               )}
 
               <div class="flex-1">
-                <h2 class="text-xl font-bold text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400">
+                <h2 class="text-base-900 hover:text-primary-500 dark:text-base-100 dark:hover:text-primary-400 text-xl font-bold">
                   {author.data.name}
                 </h2>
 
                 {(author.data.jobTitle || author.data.organization) && (
-                  <div class="mt-1 text-sm text-base-600 dark:text-base-400">
+                  <div class="text-base-600 dark:text-base-400 mt-1 text-sm">
                     {author.data.jobTitle}
                     {author.data.jobTitle && author.data.organization && " at "}
                     {author.data.organization}
@@ -63,12 +63,12 @@ const authorPostCounts = authors
                 )}
 
                 {author.data.bioShort && (
-                  <p class="mt-2 line-clamp-2 text-sm text-base-700 dark:text-base-300">
+                  <p class="text-base-700 dark:text-base-300 mt-2 line-clamp-2 text-sm">
                     {author.data.bioShort}
                   </p>
                 )}
 
-                <div class="mt-3 text-sm text-primary-600 dark:text-primary-400">
+                <div class="text-primary-600 dark:text-primary-400 mt-3 text-sm">
                   {postCount} {postCount === 1 ? "article" : "articles"}
                 </div>
               </div>

--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -133,10 +133,10 @@ const communities = [
               >
                 <div class="space-y-4">
                   <div class="-ml-0.5 flex flex-wrap items-center gap-3">
-                    <span class="bg-primary/10 rounded-full px-3 py-1 text-sm font-medium text-primary-600 dark:text-primary-400">
+                    <span class="bg-primary/10 text-primary-600 dark:text-primary-400 rounded-full px-3 py-1 text-sm font-medium">
                       {community.period}
                     </span>
-                    <span class="text-sm text-base-600 dark:text-base-400">
+                    <span class="text-base-600 dark:text-base-400 text-sm">
                       {community.context}
                     </span>
                   </div>
@@ -151,7 +151,7 @@ const communities = [
                   </p>
 
                   <div class="pt-4">
-                    <h3 class="text-primary mb-3 text-sm font-semibold uppercase tracking-wider">
+                    <h3 class="text-primary mb-3 text-sm font-semibold tracking-wider uppercase">
                       Key Achievements
                     </h3>
                     <ul class="space-y-2">

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -59,17 +59,17 @@ const metaDescription = descriptionParts.filter(Boolean).join(" ");
       <div class="mx-auto max-w-4xl">
         <div class="mb-8">
           <Badge>Event</Badge>
-          <h1 class="h2 mb-4 text-base-100 dark:text-base-900">{event.name}</h1>
+          <h1 class="h2 text-base-100 dark:text-base-900 mb-4">{event.name}</h1>
 
           <div class="mb-6 flex flex-wrap gap-3">
             <span
-              class="rounded-full bg-base-100 px-3 py-1 text-sm text-base-700 dark:bg-base-800 dark:text-base-300"
+              class="bg-base-100 text-base-700 dark:bg-base-800 dark:text-base-300 rounded-full px-3 py-1 text-sm"
             >
               {eventDate}
             </span>
             {
               event.workshop && (
-                <span class="rounded-full bg-primary-100 px-3 py-1 text-sm text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+                <span class="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200 rounded-full px-3 py-1 text-sm">
                   Workshop
                 </span>
               )
@@ -78,19 +78,19 @@ const metaDescription = descriptionParts.filter(Boolean).join(" ");
 
           <div class="flex items-start gap-6">
             <div>
-              <p class="text-lg text-base-600 dark:text-base-300">
+              <p class="text-base-600 dark:text-base-300 text-lg">
                 {event.city}{event.country && `, ${event.country}`}
               </p>
               {
                 event.role && (
-                  <p class="mt-1 text-base text-base-600 dark:text-base-300">
+                  <p class="text-base-600 dark:text-base-300 mt-1 text-base">
                     Role: {event.role}
                   </p>
                 )
               }
               {
                 event.topic && (
-                  <p class="mt-1 text-base text-base-600 dark:text-base-300">
+                  <p class="text-base-600 dark:text-base-300 mt-1 text-base">
                     Topic: {event.topic}
                   </p>
                 )
@@ -120,7 +120,7 @@ const metaDescription = descriptionParts.filter(Boolean).join(" ");
                 href={event.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-block rounded-lg bg-primary-600 px-6 py-3 text-base-100 transition-colors hover:bg-primary-700 dark:text-base-900"
+                class="bg-primary-600 text-base-100 hover:bg-primary-700 dark:text-base-900 inline-block rounded-lg px-6 py-3 transition-colors"
               >
                 Visit Event Website
               </a>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -153,11 +153,11 @@ sortedYears.forEach((year) => {
           return (
             <div class="year-group">
               <div class="mb-8 flex items-center gap-4">
-                <h2 class="text-2xl font-bold text-base-800 dark:text-base-200">
+                <h2 class="text-base-800 dark:text-base-200 text-2xl font-bold">
                   {year}
                 </h2>
-                <div class="h-px flex-1 bg-base-300 dark:bg-base-700" />
-                <span class="text-sm text-base-500 dark:text-base-400">
+                <div class="bg-base-300 dark:bg-base-700 h-px flex-1" />
+                <span class="text-base-500 dark:text-base-400 text-sm">
                   {allYearEvents.length}{" "}
                   {allYearEvents.length === 1 ? "event" : "events"}
                 </span>

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -18,7 +18,7 @@ import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
   transition:animate="slide"
 >
   <!-- Header -->
-  <section class="pb-8 pt-24 md:pt-28">
+  <section class="pt-24 pb-8 md:pt-28">
     <div class="site-container px-4">
       <div class="mx-auto max-w-2xl text-center">
         <Badge>Stay informed</Badge>
@@ -37,15 +37,15 @@ import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
   <section class="py-8 md:py-12">
     <div class="site-container px-4">
       <div class="mx-auto max-w-2xl text-center">
-        <p class="text-lg text-base-600 dark:text-base-400">
+        <p class="text-base-600 dark:text-base-400 text-lg">
           Social media gets the highlights. The newsletter gets the full story.
         </p>
-        <p class="mt-4 text-base-600 dark:text-base-400">
+        <p class="text-base-600 dark:text-base-400 mt-4">
           20+ years at the intersection of technology, community, and business.
           This newsletter shares what I've learned and what I'm building for the
           future.
         </p>
-        <p class="mt-3 text-sm text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 mt-3 text-sm">
           Self-hosted on EU servers. Your data stays private.
         </p>
       </div>
@@ -56,7 +56,7 @@ import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
   <section class="py-12 md:py-16">
     <div class="site-container px-4">
       <div class="mx-auto max-w-2xl">
-        <div class="prose mx-auto dark:prose-invert">
+        <div class="prose dark:prose-invert mx-auto">
           <h2>What you get</h2>
           <p>A monthly highlight reel, scannable and focused:</p>
           <ul>

--- a/src/pages/overview.astro
+++ b/src/pages/overview.astro
@@ -25,7 +25,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
       <Badge>Overview</Badge>
       <h1 class="h1 -mt-3">The various pages of Atlas</h1>
       <!-- <p class="description mt-2">The various pages of Atlas</p> -->
-      <div class="mx-auto mt-10 grid gap-4 xs:grid-cols-2 md:grid-cols-3">
+      <div class="xs:grid-cols-2 mx-auto mt-10 grid gap-4 md:grid-cols-3">
         <!-- Landing pages -->
         <div class="flex flex-col">
           <h3 class="overview-heading">Landing Pages</h3>
@@ -100,16 +100,16 @@ const currLocale = getLocaleFromUrl(Astro.url);
       class="fixed inset-x-6 bottom-6 z-50 hidden justify-center"
     >
       <div
-        class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 rounded-md border border-base-200 bg-base-50 p-4"
+        class="border-base-200 bg-base-50 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 rounded-md border p-4"
       >
         <div class="text-center">
           <p
-            class="text-sm font-medium text-base-500 lg:text-base dark:text-base-400"
+            class="text-base-500 dark:text-base-400 text-sm font-medium lg:text-base"
           >
             We use cookies to improve your experience on this site. To learn
             more, see our <a
               href={getRelativeLocaleUrl(currLocale, "/privacy-policy")}
-              class="text-base-700 underline decoration-primary-500 transition hover:text-primary-500 dark:text-base-200"
+              class="text-base-700 decoration-primary-500 hover:text-primary-500 dark:text-base-200 underline transition"
               >Privacy Policy</a
             >.
           </p>
@@ -126,11 +126,11 @@ const currLocale = getLocaleFromUrl(Astro.url);
 <style lang="scss">
   @reference "../styles/tailwind.css";
   .overview-heading {
-    @apply mb-4 mt-6 text-xl font-bold md:text-2xl dark:text-base-300;
+    @apply dark:text-base-300 mt-6 mb-4 text-xl font-bold md:text-2xl;
   }
   .overview-link {
     // @apply text-primary-600 hover:text-primary-700 hover:underline;
-    @apply my-[.15rem] font-medium leading-snug text-base-500 transition hover:text-base-600 dark:text-base-400 dark:hover:text-base-300;
+    @apply text-base-500 hover:text-base-600 dark:text-base-400 dark:hover:text-base-300 my-[.15rem] leading-snug font-medium transition;
   }
 </style>
 

--- a/src/pages/overview.astro
+++ b/src/pages/overview.astro
@@ -124,6 +124,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
 </BaseLayout>
 
 <style lang="scss">
+  @reference "../styles/tailwind.css";
   .overview-heading {
     @apply mb-4 mt-6 text-xl font-bold md:text-2xl dark:text-base-300;
   }

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -14,10 +14,10 @@ import ServicesIcon from "@components/Services/ServicesIcon.astro";
     <div id="podcast-feed-container">
       <div class="text-center">
         <div
-          class="inline-block h-8 w-8 animate-spin rounded-full border-b-2 border-t-2 border-primary-500"
+          class="border-primary-500 inline-block h-8 w-8 animate-spin rounded-full border-t-2 border-b-2"
         >
         </div>
-        <p class="mt-4 text-base-500">Loading podcast episodes...</p>
+        <p class="text-base-500 mt-4">Loading podcast episodes...</p>
       </div>
     </div>
 

--- a/src/pages/presentations/[slug].astro
+++ b/src/pages/presentations/[slug].astro
@@ -68,14 +68,14 @@ const metaImage = image ? new URL(image, Astro.site) : undefined;
             <div class="mb-6 flex flex-wrap gap-3">
               {
                 duration && (
-                  <span class="rounded-full bg-base-100 px-3 py-1 text-sm text-base-700 dark:bg-base-800 dark:text-base-300">
+                  <span class="bg-base-100 text-base-700 dark:bg-base-800 dark:text-base-300 rounded-full px-3 py-1 text-sm">
                     {duration}
                   </span>
                 )
               }
               {
                 isWorkshop && (
-                  <span class="rounded-full bg-primary-100 px-3 py-1 text-sm text-primary-800 dark:bg-primary-900 dark:text-primary-200">
+                  <span class="bg-primary-100 text-primary-800 dark:bg-primary-900 dark:text-primary-200 rounded-full px-3 py-1 text-sm">
                     Workshop
                   </span>
                 )
@@ -84,14 +84,14 @@ const metaImage = image ? new URL(image, Astro.site) : undefined;
 
             {
               intendedAudience && (
-                <p class="text-lg text-base-400 dark:text-base-300">
+                <p class="text-base-400 dark:text-base-300 text-lg">
                   For: {intendedAudience}
                 </p>
               )
             }
           </div>
 
-          <div class="prose prose-lg mb-12 dark:prose-invert">
+          <div class="prose prose-lg dark:prose-invert mb-12">
             <div
               class="relative mb-8 aspect-video rounded-lg"
               style="transform: translateZ(0);"

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -17,12 +17,12 @@ import Badge from "@components/Badge/Badge.astro";
   transition:animate="slide"
 >
   <!-- Header -->
-  <section class="pb-8 pt-24 md:pt-28">
+  <section class="pt-24 pb-8 md:pt-28">
     <div class="site-container px-4">
       <div class="mx-auto max-w-2xl text-center">
         <Badge>Your data</Badge>
         <h1 class="h1 mb-6">Privacy</h1>
-        <p class="text-lg text-base-600 dark:text-base-400">
+        <p class="text-base-600 dark:text-base-400 text-lg">
           Here's exactly how I handle your data.
         </p>
       </div>
@@ -33,7 +33,7 @@ import Badge from "@components/Badge/Badge.astro";
   <section class="py-12 md:py-16">
     <div class="site-container px-4">
       <div class="mx-auto max-w-2xl">
-        <div class="prose mx-auto dark:prose-invert">
+        <div class="prose dark:prose-invert mx-auto">
           <h2>Website analytics</h2>
           <p>
             I self-host <a

--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -202,24 +202,24 @@ const testimonials = [
           <Badge>Retainer Advisory</Badge>
           <h1
             id="hero-heading"
-            class="text-balance text-4xl font-bold leading-tight tracking-tight text-base-900 md:text-5xl lg:text-6xl lg:leading-[1.1] dark:text-base-100"
+            class="text-base-900 dark:text-base-100 text-4xl leading-tight font-bold tracking-tight text-balance md:text-5xl lg:text-6xl lg:leading-[1.1]"
           >
             Senior community leadership for companies not yet ready to hire one.
           </h1>
           <p
-            class="mt-6 text-pretty text-lg leading-relaxed text-base-700 md:text-xl dark:text-base-300"
+            class="text-base-700 dark:text-base-300 mt-6 text-lg leading-relaxed text-pretty md:text-xl"
           >
             How to build community and ecosystem functions that actually move
             product decisions and lower support costs. For technical companies
             that treat community as infrastructure.
           </p>
           <p
-            class="mt-6 text-pretty text-base font-medium leading-relaxed text-base-800 md:text-lg dark:text-base-200"
+            class="text-base-800 dark:text-base-200 mt-6 text-base leading-relaxed font-medium text-pretty md:text-lg"
           >
             {pricingAnchor}
           </p>
           <p
-            class="mt-6 text-base leading-relaxed text-base-600 dark:text-base-400"
+            class="text-base-600 dark:text-base-400 mt-6 text-base leading-relaxed"
           >
             I've built community at <strong>Spryker</strong> (130+ enterprise clients,
             with about 25% of product roadmap traceable to community signal),
@@ -242,7 +242,7 @@ const testimonials = [
             >
               Work with me
             </Button>
-            <span class="text-sm text-base-500 dark:text-base-400">
+            <span class="text-base-500 dark:text-base-400 text-sm">
               <strong class="text-base-700 dark:text-base-300"
                 >{seatAvailabilityLabel}</strong
               > · Application or 30-min scoping call
@@ -251,7 +251,7 @@ const testimonials = [
         </div>
         <div class="hidden lg:block">
           <div
-            class="overflow-hidden rounded-2xl shadow-xl ring-1 ring-base-200/60 dark:ring-base-800/60"
+            class="ring-base-200/60 dark:ring-base-800/60 overflow-hidden rounded-2xl shadow-xl ring-1"
             role="img"
             aria-label="Guido on stage speaking at a conference"
           >
@@ -274,18 +274,18 @@ const testimonials = [
   <section
     id="why-this-offer"
     aria-labelledby="why-this-offer-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
         <h2
           id="why-this-offer-heading"
-          class="h2 mb-8 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-8"
         >
           Why this offer exists.
         </h2>
         <div
-          class="space-y-5 text-lg leading-relaxed text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 space-y-5 text-lg leading-relaxed"
         >
           <p>
             Most Series A–C developer-led companies hit the same wall: a
@@ -320,7 +320,7 @@ const testimonials = [
               a re-recruit. The retainer tests the thesis before the hire.
             </li>
           </ul>
-          <p class="font-medium text-base-900 dark:text-base-100">
+          <p class="text-base-900 dark:text-base-100 font-medium">
             Two ways to use it: as a bridge to a senior hire, or as ongoing
             senior leverage if you don't plan to make one.
           </p>
@@ -333,23 +333,23 @@ const testimonials = [
   <section
     id="core-offering"
     aria-labelledby="core-offering-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
         <p
-          class="mb-2 text-sm uppercase tracking-wider text-primary-600 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 mb-2 text-sm tracking-wider uppercase"
         >
           01. Core offering
         </p>
         <h2
           id="core-offering-heading"
-          class="h2 mb-6 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-6"
         >
           Senior thinking partner. So your team gets to actually execute.
         </h2>
         <div
-          class="space-y-4 text-lg leading-relaxed text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 space-y-4 text-lg leading-relaxed"
         >
           <p>
             You're probably one of three people: a founder figuring this out
@@ -363,7 +363,7 @@ const testimonials = [
             invest in, what to stop, what to ignore).
           </p>
           <p
-            class="border-l-4 border-primary-500 bg-base-100/40 py-3 pl-6 italic dark:bg-base-900/30"
+            class="border-primary-500 bg-base-100/40 dark:bg-base-900/30 border-l-4 py-3 pl-6 italic"
           >
             In practice: the person already doing this work has senior backup.
             Decisions move faster, and the roadmap stops drifting off community
@@ -376,54 +376,54 @@ const testimonials = [
       <div class="mx-auto mt-12 max-w-6xl">
         <div class="grid gap-6 md:grid-cols-2 md:gap-6">
           <div
-            class="flex flex-col rounded-2xl border border-base-200 bg-base-100/40 p-6 dark:border-base-800 dark:bg-base-900/30"
+            class="border-base-200 bg-base-100/40 dark:border-base-800 dark:bg-base-900/30 flex flex-col rounded-2xl border p-6"
           >
             <p
-              class="mb-1 text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+              class="text-base-500 dark:text-base-400 mb-1 text-xs font-semibold tracking-wider uppercase"
             >
               The alternative
             </p>
-            <h3 class="mb-6 text-xl font-bold text-base-900 dark:text-base-100">
+            <h3 class="text-base-900 dark:text-base-100 mb-6 text-xl font-bold">
               Senior community / DevRel hire
             </h3>
             <dl class="space-y-5 text-base">
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Loaded cost
                 </dt>
-                <dd class="mt-1 text-base-800 dark:text-base-200">
+                <dd class="text-base-800 dark:text-base-200 mt-1">
                   €150K+ per year
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Time to start
                 </dt>
-                <dd class="mt-1 text-base-800 dark:text-base-200">
+                <dd class="text-base-800 dark:text-base-200 mt-1">
                   3–4 months to land
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Wrong-hire risk
                 </dt>
-                <dd class="mt-1 text-base-800 dark:text-base-200">
+                <dd class="text-base-800 dark:text-base-200 mt-1">
                   High. No scorecard yet to hire well.
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   At month 6
                 </dt>
-                <dd class="mt-1 text-base-800 dark:text-base-200">
+                <dd class="text-base-800 dark:text-base-200 mt-1">
                   Maybe an onboarded leader.
                 </dd>
               </div>
@@ -431,54 +431,54 @@ const testimonials = [
           </div>
 
           <div
-            class="flex flex-col rounded-2xl border-2 border-primary-500/50 bg-primary-500/5 p-6 dark:border-primary-500/40 dark:bg-primary-500/10"
+            class="border-primary-500/50 bg-primary-500/5 dark:border-primary-500/40 dark:bg-primary-500/10 flex flex-col rounded-2xl border-2 p-6"
           >
             <p
-              class="mb-1 text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+              class="text-primary-600 dark:text-primary-400 mb-1 text-xs font-semibold tracking-wider uppercase"
             >
               The retainer
             </p>
-            <h3 class="mb-6 text-xl font-bold text-base-900 dark:text-base-100">
+            <h3 class="text-base-900 dark:text-base-100 mb-6 text-xl font-bold">
               Six-month advisory
             </h3>
             <dl class="space-y-5 text-base">
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Loaded cost
                 </dt>
-                <dd class="mt-1 font-medium text-base-900 dark:text-base-100">
+                <dd class="text-base-900 dark:text-base-100 mt-1 font-medium">
                   Less than a quarter of the hire.
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Time to start
                 </dt>
-                <dd class="mt-1 font-medium text-base-900 dark:text-base-100">
+                <dd class="text-base-900 dark:text-base-100 mt-1 font-medium">
                   Next week.
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   Wrong-hire risk
                 </dt>
-                <dd class="mt-1 font-medium text-base-900 dark:text-base-100">
+                <dd class="text-base-900 dark:text-base-100 mt-1 font-medium">
                   Tested before the hire.
                 </dd>
               </div>
               <div>
                 <dt
-                  class="text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 text-xs font-semibold tracking-wider uppercase"
                 >
                   At month 6
                 </dt>
-                <dd class="mt-1 font-medium text-base-900 dark:text-base-100">
+                <dd class="text-base-900 dark:text-base-100 mt-1 font-medium">
                   A scorecard, a working system, and the decisions already made.
                   Whether or not a senior hire ends up making sense.
                 </dd>
@@ -494,28 +494,28 @@ const testimonials = [
   <section
     id="success"
     aria-labelledby="success-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
         <Badge>Outcomes at month 6</Badge>
         <h2
           id="success-heading"
-          class="h2 mb-6 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-6"
         >
           What's different at month six.
         </h2>
         <p
-          class="mb-12 text-lg leading-relaxed text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 mb-12 text-lg leading-relaxed"
         >
           Six months in, the way community work happens has shifted. Here's
           what's different:
         </p>
 
-        <ul class="mb-12 space-y-5 text-base-700 dark:text-base-300">
+        <ul class="text-base-700 dark:text-base-300 mb-12 space-y-5">
           <li class="flex gap-4">
             <span
-              class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400"
+              class="bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400 mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
               aria-hidden="true"
             >
               <Icon name="tabler/outline/calendar-check" class="h-5 w-5" />
@@ -528,7 +528,7 @@ const testimonials = [
           </li>
           <li class="flex gap-4">
             <span
-              class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400"
+              class="bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400 mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
               aria-hidden="true"
             >
               <Icon name="tabler/outline/scissors" class="h-5 w-5" />
@@ -542,7 +542,7 @@ const testimonials = [
           </li>
           <li class="flex gap-4">
             <span
-              class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400"
+              class="bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400 mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
               aria-hidden="true"
             >
               <Icon name="tabler/outline/bolt" class="h-5 w-5" />
@@ -555,7 +555,7 @@ const testimonials = [
           </li>
           <li class="flex gap-4">
             <span
-              class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400"
+              class="bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400 mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
               aria-hidden="true"
             >
               <Icon name="tabler/outline/target-arrow" class="h-5 w-5" />
@@ -569,7 +569,7 @@ const testimonials = [
           </li>
           <li class="flex gap-4">
             <span
-              class="mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400"
+              class="bg-primary-500/10 text-primary-600 dark:bg-primary-500/15 dark:text-primary-400 mt-0.5 flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg"
               aria-hidden="true"
             >
               <Icon name="tabler/outline/clipboard-check" class="h-5 w-5" />
@@ -583,14 +583,14 @@ const testimonials = [
           </li>
         </ul>
 
-        <h3 class="h3 mb-6 text-base-900 dark:text-base-100">
+        <h3 class="h3 text-base-900 dark:text-base-100 mb-6">
           And the documents you walk away with:
         </h3>
-        <ul class="space-y-4 text-base-700 dark:text-base-300">
+        <ul class="text-base-700 dark:text-base-300 space-y-4">
           <li class="flex gap-3">
             <Icon
               name="tabler/outline/file-check"
-              class="mt-1 h-5 w-5 flex-shrink-0 text-primary-500"
+              class="text-primary-500 mt-1 h-5 w-5 flex-shrink-0"
               aria-hidden="true"
             />
             <span>
@@ -602,7 +602,7 @@ const testimonials = [
           <li class="flex gap-3">
             <Icon
               name="tabler/outline/file-check"
-              class="mt-1 h-5 w-5 flex-shrink-0 text-primary-500"
+              class="text-primary-500 mt-1 h-5 w-5 flex-shrink-0"
               aria-hidden="true"
             />
             <span>
@@ -614,7 +614,7 @@ const testimonials = [
           <li class="flex gap-3">
             <Icon
               name="tabler/outline/file-check"
-              class="mt-1 h-5 w-5 flex-shrink-0 text-primary-500"
+              class="text-primary-500 mt-1 h-5 w-5 flex-shrink-0"
               aria-hidden="true"
             />
             <span>
@@ -626,7 +626,7 @@ const testimonials = [
           <li class="flex gap-3">
             <Icon
               name="tabler/outline/file-check"
-              class="mt-1 h-5 w-5 flex-shrink-0 text-primary-500"
+              class="text-primary-500 mt-1 h-5 w-5 flex-shrink-0"
               aria-hidden="true"
             />
             <span>
@@ -644,18 +644,18 @@ const testimonials = [
   <section
     id="framework"
     aria-labelledby="framework-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
         <p
-          class="mb-2 text-sm uppercase tracking-wider text-primary-600 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 mb-2 text-sm tracking-wider uppercase"
         >
           02. Framework
         </p>
         <h2
           id="framework-heading"
-          class="h2 mb-12 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-12"
         >
           Three pillars: Psychology, Pattern, Proof.
         </h2>
@@ -663,17 +663,17 @@ const testimonials = [
 
       <div class="mx-auto grid max-w-6xl gap-8 md:grid-cols-3">
         <div
-          class="rounded-2xl border border-base-200 bg-base-50/40 p-8 dark:border-base-800 dark:bg-base-900/30"
+          class="border-base-200 bg-base-50/40 dark:border-base-800 dark:bg-base-900/30 rounded-2xl border p-8"
         >
           <p
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-accent-3"
+            class="text-accent-3 mb-3 text-sm font-semibold tracking-wider uppercase"
           >
             Psychology
           </p>
-          <h3 class="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
             Built for how technical users actually behave.
           </h3>
-          <p class="text-base leading-relaxed text-base-700 dark:text-base-300">
+          <p class="text-base-700 dark:text-base-300 text-base leading-relaxed">
             Most community work is designed for the community manager's idea of
             community, which usually has very little to do with how developers
             actually behave in the wild. My cognitive psychology background
@@ -685,17 +685,17 @@ const testimonials = [
         </div>
 
         <div
-          class="rounded-2xl border border-base-200 bg-base-50/40 p-8 dark:border-base-800 dark:bg-base-900/30"
+          class="border-base-200 bg-base-50/40 dark:border-base-800 dark:bg-base-900/30 rounded-2xl border p-8"
         >
           <p
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-accent-3"
+            class="text-accent-3 mb-3 text-sm font-semibold tracking-wider uppercase"
           >
             Pattern
           </p>
-          <h3 class="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
             Three zero-to-community builds, retooled for the AI era.
           </h3>
-          <p class="text-base leading-relaxed text-base-700 dark:text-base-300">
+          <p class="text-base-700 dark:text-base-300 text-base leading-relaxed">
             Three very different contexts (Spryker, Dutchento, CRO.CAFE), same
             underlying pattern, retooled for an era when half the lurkers are
             agents and bot signal looks like human signal until it doesn't. The
@@ -705,17 +705,17 @@ const testimonials = [
         </div>
 
         <div
-          class="rounded-2xl border border-base-200 bg-base-50/40 p-8 dark:border-base-800 dark:bg-base-900/30"
+          class="border-base-200 bg-base-50/40 dark:border-base-800 dark:bg-base-900/30 rounded-2xl border p-8"
         >
           <p
-            class="mb-3 text-sm font-semibold uppercase tracking-wider text-accent-3"
+            class="text-accent-3 mb-3 text-sm font-semibold tracking-wider uppercase"
           >
             Proof
           </p>
-          <h3 class="mb-4 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-4 text-xl font-bold">
             Community work that survives the budget review.
           </h3>
-          <p class="text-base leading-relaxed text-base-700 dark:text-base-300">
+          <p class="text-base-700 dark:text-base-300 text-base leading-relaxed">
             Community work that can't be tied to business outcomes is the first
             thing cut at budget review. I came up through CRO and
             experimentation, so what we build together is set up to be measured.
@@ -733,7 +733,7 @@ const testimonials = [
   <section
     id="about-advisor"
     aria-labelledby="about-advisor-heading"
-    class="border-t border-base-200/60 py-16 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-16"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
@@ -756,11 +756,11 @@ const testimonials = [
             />
           </div>
           <div
-            class="space-y-3 text-base leading-relaxed text-base-700 dark:text-base-300"
+            class="text-base-700 dark:text-base-300 space-y-3 text-base leading-relaxed"
           >
             <h2
               id="about-advisor-heading"
-              class="text-xl font-bold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 text-xl font-bold"
             >
               About the advisor.
             </h2>
@@ -777,7 +777,7 @@ const testimonials = [
             <p>
               <a
                 href="/about"
-                class="inline-flex items-center gap-1 font-medium text-primary-600 hover:underline dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 inline-flex items-center gap-1 font-medium hover:underline"
               >
                 Read the longer version on /about →
               </a>
@@ -789,7 +789,7 @@ const testimonials = [
   </section>
 
   <!-- Brands I've worked with, reused from homepage -->
-  <div class="border-t border-base-200/60 dark:border-base-800/60">
+  <div class="border-base-200/60 dark:border-base-800/60 border-t">
     <CompanyLogos />
   </div>
 
@@ -797,17 +797,17 @@ const testimonials = [
   <section
     id="testimonials"
     aria-labelledby="testimonials-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-3xl text-center">
         <h2
           id="testimonials-heading"
-          class="h2 mb-4 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-4"
         >
           Past colleagues and clients on the work.
         </h2>
-        <p class="text-sm text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-sm">
           Quotes from work pre-advisory. Advisory references on request after
           the scoping call.
         </p>
@@ -815,8 +815,8 @@ const testimonials = [
       <div class="mx-auto grid max-w-6xl gap-8 md:grid-cols-3">
         {
           testimonials.map((t) => (
-            <figure class="flex flex-col gap-6 rounded-2xl bg-base-100/50 p-8 dark:bg-base-900/40">
-              <blockquote class="text-base leading-relaxed text-base-800 dark:text-base-200">
+            <figure class="bg-base-100/50 dark:bg-base-900/40 flex flex-col gap-6 rounded-2xl p-8">
+              <blockquote class="text-base-800 dark:text-base-200 text-base leading-relaxed">
                 <p>“{t.quote}”</p>
               </blockquote>
               <figcaption class="mt-auto flex min-h-[7.5rem] items-start gap-4">
@@ -827,13 +827,13 @@ const testimonials = [
                   sizes="48px"
                   quality={85}
                   format="webp"
-                  class="h-12 w-12 flex-shrink-0 rounded-full object-cover ring-1 ring-base-200/70 dark:ring-base-700/70"
+                  class="ring-base-200/70 dark:ring-base-700/70 h-12 w-12 flex-shrink-0 rounded-full object-cover ring-1"
                 />
                 <div class="leading-tight">
-                  <p class="!my-0 font-semibold text-base-900 dark:text-base-100">
+                  <p class="text-base-900 dark:text-base-100 !my-0 font-semibold">
                     {t.name}
                   </p>
-                  <p class="!mb-0 !mt-1 text-sm text-base-600 dark:text-base-400">
+                  <p class="text-base-600 dark:text-base-400 !mt-1 !mb-0 text-sm">
                     {t.role}, {t.company}
                   </p>
                 </div>
@@ -849,18 +849,18 @@ const testimonials = [
   <section
     id="how-it-runs"
     aria-labelledby="how-it-runs-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl">
         <p
-          class="mb-2 text-sm uppercase tracking-wider text-primary-600 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 mb-2 text-sm tracking-wider uppercase"
         >
           03. How the engagement runs
         </p>
         <h2
           id="how-it-runs-heading"
-          class="h2 mb-12 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-12"
         >
           A structured six months. Rolling thereafter.
         </h2>
@@ -868,25 +868,25 @@ const testimonials = [
         <div class="space-y-12">
           <div>
             <p
-              class="mb-6 text-xs font-semibold uppercase tracking-wider text-primary-600 dark:text-primary-400"
+              class="text-primary-600 dark:text-primary-400 mb-6 text-xs font-semibold tracking-wider uppercase"
             >
               Phase 1 · Inside the first six months
             </p>
-            <ol class="relative space-y-10 border-l-2 border-primary-500 pl-12">
+            <ol class="border-primary-500 relative space-y-10 border-l-2 pl-12">
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white shadow-md ring-4 ring-base-50 dark:ring-base-950"
+                  class="bg-primary-500 ring-base-50 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white shadow-md ring-4"
                   aria-hidden="true"
                 >
                   W1
                 </span>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Week 1: Onboarding and ecosystem baseline
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   A 90–120 minute kickoff call, plus a written baseline of where
                   your community stands, what's worth building first, and what
@@ -897,23 +897,23 @@ const testimonials = [
 
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary-500 bg-base-50 text-sm font-bold text-primary-600 ring-4 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950"
+                  class="border-primary-500 bg-base-50 text-primary-600 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 text-sm font-bold ring-4"
                   aria-hidden="true"
                 >
                   ×12
                 </span>
                 <p
-                  class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 mb-1 text-[11px] font-semibold tracking-wider uppercase"
                 >
                   Recurring cadence
                 </p>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Every two weeks: a standing strategy call
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   Twelve sessions of sixty minutes each, across the first six
                   months. The one place on the calendar where community strategy
@@ -924,23 +924,23 @@ const testimonials = [
 
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary-500 bg-base-50 text-sm font-bold text-primary-600 ring-4 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950"
+                  class="border-primary-500 bg-base-50 text-primary-600 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 text-sm font-bold ring-4"
                   aria-hidden="true"
                 >
                   ×6
                 </span>
                 <p
-                  class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                  class="text-base-500 dark:text-base-400 mb-1 text-[11px] font-semibold tracking-wider uppercase"
                 >
                   Recurring cadence
                 </p>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Every month: a one-page written brief
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   The next things to act on, the things to stop, and what to
                   keep an eye on. Written so it can be forwarded to your CEO or
@@ -950,18 +950,18 @@ const testimonials = [
 
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white shadow-md ring-4 ring-base-50 dark:ring-base-950"
+                  class="bg-primary-500 ring-base-50 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white shadow-md ring-4"
                   aria-hidden="true"
                 >
                   M3
                 </span>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Month 3: mid-engagement review
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   A hard mid-point audit. Are we still building the right thing,
                   given what we've learned and what changed in your business? We
@@ -975,18 +975,18 @@ const testimonials = [
 
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full bg-primary-500 text-sm font-bold text-white shadow-md ring-4 ring-base-50 dark:ring-base-950"
+                  class="bg-primary-500 ring-base-50 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white shadow-md ring-4"
                   aria-hidden="true"
                 >
                   M6
                 </span>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Month 6: synthesis and decision point
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   The artifacts from the previous sections, finalized. Decision
                   point: continue rolling, pause, or close. Either way, you walk
@@ -999,27 +999,27 @@ const testimonials = [
 
           <div>
             <p
-              class="mb-6 text-xs font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+              class="text-base-500 dark:text-base-400 mb-6 text-xs font-semibold tracking-wider uppercase"
             >
               Phase 2 · Beyond six months, if it's working
             </p>
             <ol
-              class="relative space-y-10 border-l-2 border-dashed border-primary-500/50 pl-12"
+              class="border-primary-500/50 relative space-y-10 border-l-2 border-dashed pl-12"
             >
               <li class="relative">
                 <span
-                  class="absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 border-primary-500/60 bg-base-50 text-base font-bold text-primary-600 ring-4 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950"
+                  class="border-primary-500/60 bg-base-50 text-primary-600 ring-base-50 dark:bg-base-950 dark:text-primary-400 dark:ring-base-950 absolute -left-[4.25rem] flex h-12 w-12 items-center justify-center rounded-full border-2 text-base font-bold ring-4"
                   aria-hidden="true"
                 >
                   ↻
                 </span>
                 <h3
-                  class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                  class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
                 >
                   Beyond month 6: rolling cadence
                 </h3>
                 <p
-                  class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                  class="text-base-700 dark:text-base-300 text-base leading-relaxed"
                 >
                   Same rhythm, no fixed end. Calls, monthly briefs, async
                   channel: nothing changes about the cadence. Either side gives
@@ -1030,28 +1030,28 @@ const testimonials = [
           </div>
 
           <div
-            class="flex gap-4 rounded-2xl border-2 border-base-300/80 bg-base-100 p-5 dark:border-base-700/80 dark:bg-base-900/60"
+            class="border-base-300/80 bg-base-100 dark:border-base-700/80 dark:bg-base-900/60 flex gap-4 rounded-2xl border-2 p-5"
             role="note"
           >
             <span
-              class="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-base-200 text-base font-bold text-base-700 dark:bg-base-800 dark:text-base-200"
+              class="bg-base-200 text-base-700 dark:bg-base-800 dark:text-base-200 flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-base font-bold"
               aria-hidden="true"
             >
               ⇄
             </span>
             <div>
               <p
-                class="mb-1 text-[11px] font-semibold uppercase tracking-wider text-base-500 dark:text-base-400"
+                class="text-base-500 dark:text-base-400 mb-1 text-[11px] font-semibold tracking-wider uppercase"
               >
                 Throughout · the whole engagement
               </p>
               <h3
-                class="mb-2 text-xl font-bold text-base-900 dark:text-base-100"
+                class="text-base-900 dark:text-base-100 mb-2 text-xl font-bold"
               >
                 A dedicated async channel
               </h3>
               <p
-                class="text-base leading-relaxed text-base-700 dark:text-base-300"
+                class="text-base-700 dark:text-base-300 text-base leading-relaxed"
               >
                 Slack, Signal, or whichever tool you already use. For the
                 questions that come up between calls and shouldn't wait two
@@ -1068,27 +1068,27 @@ const testimonials = [
   <section
     id="scope"
     aria-labelledby="scope-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="mx-auto max-w-6xl">
         <p
-          class="mb-2 text-sm uppercase tracking-wider text-primary-600 dark:text-primary-400"
+          class="text-primary-600 dark:text-primary-400 mb-2 text-sm tracking-wider uppercase"
         >
           04. Scope and fit
         </p>
         <h2
           id="scope-heading"
-          class="h2 mb-12 text-base-900 dark:text-base-100"
+          class="h2 text-base-900 dark:text-base-100 mb-12"
         >
           Who this works for, who it doesn't.
         </h2>
 
         <div class="grid gap-10 md:grid-cols-2">
           <div>
-            <h3 class="h3 mb-4 text-base-900 dark:text-base-100">In scope</h3>
+            <h3 class="h3 text-base-900 dark:text-base-100 mb-4">In scope</h3>
             <ul
-              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+              class="text-base-700 dark:text-base-300 list-disc space-y-2 pl-5"
             >
               <li>Community / DevRel / ecosystem strategy</li>
               <li>
@@ -1106,11 +1106,11 @@ const testimonials = [
             </ul>
           </div>
           <div>
-            <h3 class="h3 mb-4 text-base-900 dark:text-base-100">
+            <h3 class="h3 text-base-900 dark:text-base-100 mb-4">
               Out of scope
             </h3>
             <ul
-              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+              class="text-base-700 dark:text-base-300 list-disc space-y-2 pl-5"
             >
               <li>Implementation or hands-on community management</li>
               <li>Content production for your community</li>
@@ -1123,11 +1123,11 @@ const testimonials = [
 
         <div class="mt-12 grid gap-10 md:grid-cols-2">
           <div
-            class="rounded-2xl border border-pine/30 bg-pine/5 p-6 dark:border-pine/40 dark:bg-pine/10"
+            class="border-pine/30 bg-pine/5 dark:border-pine/40 dark:bg-pine/10 rounded-2xl border p-6"
           >
-            <h3 class="h3 mb-4 text-base-900 dark:text-base-100">Good fit</h3>
+            <h3 class="h3 text-base-900 dark:text-base-100 mb-4">Good fit</h3>
             <ul
-              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+              class="text-base-700 dark:text-base-300 list-disc space-y-2 pl-5"
             >
               <li>Series A–C company, technical or developer-led product</li>
               <li>
@@ -1143,11 +1143,11 @@ const testimonials = [
             </ul>
           </div>
           <div
-            class="rounded-2xl border border-love/30 bg-love/5 p-6 dark:border-love/40 dark:bg-love/10"
+            class="border-love/30 bg-love/5 dark:border-love/40 dark:bg-love/10 rounded-2xl border p-6"
           >
-            <h3 class="h3 mb-4 text-base-900 dark:text-base-100">Not a fit</h3>
+            <h3 class="h3 text-base-900 dark:text-base-100 mb-4">Not a fit</h3>
             <ul
-              class="list-disc space-y-2 pl-5 text-base-700 dark:text-base-300"
+              class="text-base-700 dark:text-base-300 list-disc space-y-2 pl-5"
             >
               <li>
                 Need someone to <em>run</em> community ops. This is advisory, not
@@ -1178,13 +1178,13 @@ const testimonials = [
   <section
     id="faq"
     aria-labelledby="faq-heading"
-    class="border-t border-base-200/60 py-20 md:py-24 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-24"
   >
     <div class="site-container">
       <div class="grid gap-10 md:grid-cols-2 md:gap-16">
         <div class="md:sticky md:top-24 md:self-start">
           <Badge>FAQ</Badge>
-          <h2 id="faq-heading" class="h2 mb-6 text-base-900 dark:text-base-100">
+          <h2 id="faq-heading" class="h2 text-base-900 dark:text-base-100 mb-6">
             Questions worth answering before you apply.
           </h2>
           <p class="description text-base md:text-lg">
@@ -1211,26 +1211,26 @@ const testimonials = [
   <section
     id="apply"
     aria-labelledby="apply-heading"
-    class="border-t border-base-200/60 py-20 md:py-28 dark:border-base-800/60"
+    class="border-base-200/60 dark:border-base-800/60 border-t py-20 md:py-28"
   >
     <div class="site-container">
       <div class="mx-auto max-w-3xl text-center">
         <Badge>Apply or scope</Badge>
-        <h2 id="apply-heading" class="h2 mb-6 text-base-900 dark:text-base-100">
+        <h2 id="apply-heading" class="h2 text-base-900 dark:text-base-100 mb-6">
           Two ways in.
         </h2>
         <p
-          class="mb-4 text-base font-semibold text-base-900 dark:text-base-100"
+          class="text-base-900 dark:text-base-100 mb-4 text-base font-semibold"
         >
           {seatAvailabilityLabel} · Application or 30-min scoping call.
         </p>
         <p
-          class="mb-4 text-lg leading-relaxed text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 mb-4 text-lg leading-relaxed"
         >
           {pricingAnchor}
         </p>
         <p
-          class="mb-12 text-lg leading-relaxed text-base-700 dark:text-base-300"
+          class="text-base-700 dark:text-base-300 mb-12 text-lg leading-relaxed"
         >
           Pick the path that fits. The pricing range is shared by email after
           the first contact, regardless of outcome.
@@ -1239,17 +1239,17 @@ const testimonials = [
 
       <div class="mx-auto mt-8 grid max-w-6xl gap-8 md:grid-cols-2">
         <div
-          class="flex flex-col rounded-2xl border-2 border-primary-500/30 bg-primary-500/5 p-8"
+          class="border-primary-500/30 bg-primary-500/5 flex flex-col rounded-2xl border-2 p-8"
         >
-          <h3 class="mb-3 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-3 text-xl font-bold">
             A: 30-minute scoping call
           </h3>
-          <p class="mb-6 text-base-700 dark:text-base-300">
+          <p class="text-base-700 dark:text-base-300 mb-6">
             Best if you're not yet sure whether the engagement fits. We talk for
             thirty minutes. You leave with the pricing range, a fit assessment,
             and either an application invite or a referral elsewhere.
           </p>
-          <p class="mb-6 text-sm text-base-600 dark:text-base-400">
+          <p class="text-base-600 dark:text-base-400 mb-6 text-sm">
             Tell me up front: <strong>company name</strong>, <strong
               >your role</strong
             >, one sentence on what you're trying to figure out, and one
@@ -1268,19 +1268,19 @@ const testimonials = [
         </div>
 
         <div
-          class="flex flex-col rounded-2xl border border-base-200 bg-base-50/40 p-8 dark:border-base-800 dark:bg-base-900/30"
+          class="border-base-200 bg-base-50/40 dark:border-base-800 dark:bg-base-900/30 flex flex-col rounded-2xl border p-8"
         >
-          <h3 class="mb-3 text-xl font-bold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-3 text-xl font-bold">
             B: Direct application
           </h3>
-          <p class="mb-4 text-base-700 dark:text-base-300">
+          <p class="text-base-700 dark:text-base-300 mb-4">
             Best if you already know you want this. Email the items below.
             Response within five business days: acceptance, decline with a brief
             reason, or a scoping invite. Pricing range comes back in the
             response either way.
           </p>
           <ul
-            class="mb-6 list-disc space-y-1 pl-5 text-sm text-base-700 dark:text-base-300"
+            class="text-base-700 dark:text-base-300 mb-6 list-disc space-y-1 pl-5 text-sm"
           >
             <li>Name + work email</li>
             <li>Company + your role</li>
@@ -1308,11 +1308,11 @@ const testimonials = [
       </div>
 
       <div class="mx-auto mt-12 max-w-2xl text-center">
-        <p class="text-sm text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-sm">
           Looking to book me for a conference or event instead?
           <a
             href="/speaker"
-            class="font-medium text-primary-600 hover:underline dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 font-medium hover:underline"
           >
             Speaker information →
           </a>

--- a/src/pages/speaker.astro
+++ b/src/pages/speaker.astro
@@ -24,7 +24,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <!-- Background with speaking photo -->
     <div class="absolute inset-0 z-0">
       <div
-        class="absolute inset-0 bg-gradient-to-br from-primary-500/90 via-primary-500/70 to-accent-2/80"
+        class="from-primary-500/90 via-primary-500/70 to-accent-2/80 absolute inset-0 bg-gradient-to-br"
       >
       </div>
       <div class="absolute inset-0 bg-black/30"></div>
@@ -57,10 +57,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="grid grid-cols-2 gap-6 md:grid-cols-4 md:gap-8">
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -73,20 +73,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Rider Kit
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Technical and logistical requirements
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -99,20 +99,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Bio Format
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Speaker biography and credentials
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -125,20 +125,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Fee
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Speaking fees and expenses
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -151,20 +151,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Testimonials
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             What others say about my talks
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -182,20 +182,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
                 d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Travel & Accommodation
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Logistics and requirements
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -208,20 +208,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             AV/Tech Requirements
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Technical setup needed
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -234,20 +234,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             Content for Your Marketing
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Materials to promote the event
           </p>
         </div>
 
         <div class="group text-center">
           <div
-            class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 transition-colors group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30"
+            class="bg-base-200 group-hover:bg-primary-500/20 dark:bg-base-700/50 dark:group-hover:bg-primary-500/30 mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl transition-colors"
           >
             <svg
-              class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+              class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -260,10 +260,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               ></path>
             </svg>
           </div>
-          <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+          <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
             And the Rest...
           </h3>
-          <p class="text-sm text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 text-sm">
             Additional information and details
           </p>
         </div>
@@ -272,7 +272,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- Bio Section -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto max-w-6xl">
         <div class="grid items-center gap-12 md:grid-cols-2">
@@ -291,7 +291,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             <Badge class="mb-4">About the Speaker</Badge>
             <h2 class="h2 mb-6">Guido Jansen</h2>
             <div
-              class="prose prose-lg space-y-4 text-base-500 dark:text-base-400"
+              class="prose prose-lg text-base-500 dark:text-base-400 space-y-4"
             >
               <p>
                 Guido is a Community Builder who transforms technical ecosystems
@@ -322,10 +322,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-500/10"
+          class="bg-primary-500/10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -342,7 +342,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mx-auto max-w-3xl">
         <div
-          class="prose prose-lg mx-auto space-y-6 text-center text-base-500 dark:text-base-400"
+          class="prose prose-lg text-base-500 dark:text-base-400 mx-auto space-y-6 text-center"
         >
           <p>
             Before you reach out, please ensure you understand my speaking goals
@@ -368,14 +368,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- Talk Format Section -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-500/10"
+          class="bg-primary-500/10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -393,7 +393,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mx-auto max-w-3xl">
         <div
-          class="prose prose-lg mx-auto space-y-6 text-base-500 dark:text-base-400"
+          class="prose prose-lg text-base-500 dark:text-base-400 mx-auto space-y-6"
         >
           <p>
             My talks are easy to understand sessions on usability, persuasion,
@@ -428,10 +428,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-500/10"
+          class="bg-primary-500/10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -449,21 +449,21 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mx-auto max-w-4xl">
         <div
-          class="rounded-2xl border border-base-200 bg-base-100 p-8 shadow-xs dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-2xl border p-8 shadow-xs"
         >
           <div class="mb-8 text-center">
             <div
-              class="mb-2 text-4xl font-bold text-primary-600 dark:text-primary-400"
+              class="text-primary-600 dark:text-primary-400 mb-2 text-4xl font-bold"
             >
               €5000
             </div>
-            <div class="text-lg text-base-500 dark:text-base-400">
+            <div class="text-base-500 dark:text-base-400 text-lg">
               + VAT + expenses (Travel + accommodation)
             </div>
           </div>
 
           <div
-            class="prose prose-lg space-y-6 text-base-500 dark:text-base-400"
+            class="prose prose-lg text-base-500 dark:text-base-400 space-y-6"
           >
             <p>
               My talks are about entertaining and teaching an audience. I do not
@@ -486,7 +486,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- Payment Terms Section -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <h2 class="h2 mb-6">Payment terms</h2>
@@ -495,7 +495,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="mx-auto max-w-6xl">
         <div class="space-y-8">
           <div
-            class="prose prose-lg max-w-none space-y-6 text-base-500 dark:text-base-400"
+            class="prose prose-lg text-base-500 dark:text-base-400 max-w-none space-y-6"
           >
             <p>
               At least €2500 should be paid in EUR (€) via wire transfer or
@@ -512,10 +512,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
           <div class="grid gap-8 md:grid-cols-2">
             <div
-              class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+              class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
             >
               <h3
-                class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+                class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
               >
                 Deposit
               </h3>
@@ -525,10 +525,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
               </p>
             </div>
             <div
-              class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+              class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
             >
               <h3
-                class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+                class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
               >
                 Final Payment
               </h3>
@@ -539,14 +539,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </div>
 
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Booking Terms
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>
                 • This is a no-strings-attached booking fee. When I receive it,
                 you can count on the booked for your events.
@@ -573,10 +573,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-500/10"
+          class="bg-primary-500/10 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -590,37 +590,37 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </svg>
         </div>
         <h2 class="h2 mb-6">What others say</h2>
-        <p class="text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-lg">
           Feedback from event organizers and attendees
         </p>
       </div>
 
       <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >E</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Guido is an excellent public speaker. Whether it's a workshop,
                 a conference talk, or a meetup, he always manages to bring
                 energy and knowledge to his presentations."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Erin Weigel
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Advisor, ABsmartly
                 </div>
               </div>
@@ -629,28 +629,28 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >A</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Give him a stage and the audience will love him!"
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Alex Franke
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   EVP, Spryker
                 </div>
               </div>
@@ -659,31 +659,31 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >J</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "His session was extremely well received by a diverse audience
                 of web development professionals. Guido's ability to communicate
                 complex topics in a clear and engaging manner made his talk a
                 highlight of the event."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   John O'Connor
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Development Inspector, Charles White Limited
                 </div>
               </div>
@@ -692,30 +692,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >T</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "I attended Guido's CRO session at Growth Tribe and I was
                 mind-blown. He's articulate, knowledgeable, and uses real
                 examples and frameworks that you can actually apply."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Thomas Paris
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Director of Demand Generation, Posh
                 </div>
               </div>
@@ -724,30 +724,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >M</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Guido brought his 'Persuasive eCommerce' topic to our meetup in
                 Jakarta and the audience loved it. Very engaging speaker with
                 deep practical knowledge."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Muliadi Jeo
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Founder and Director, ICUBE
                 </div>
               </div>
@@ -756,30 +756,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >F</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Guido has a unique combination of knowledge about psychology,
                 experimentation, and e-commerce that makes his talks both
                 insightful and highly practical."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Florian Gendrault
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   CEO, Alleo
                 </div>
               </div>
@@ -788,30 +788,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >R</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Guido brings a unique blend of technical expertise and
                 practical insights. His presentation style is engaging and the
                 content is always relevant to our audience."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Rob Janssen
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Event Director, Digital Analytics Congress
                 </div>
               </div>
@@ -820,30 +820,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >K</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Working with Guido was a pleasure. He understood our audience
                 needs and delivered content that was both educational and
                 actionable. Our attendees loved it!"
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Koen Verhagen
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Conference Organizer, Meet Magento
                 </div>
               </div>
@@ -852,30 +852,30 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
         >
           <div class="flex items-start space-x-4">
             <div class="flex-shrink-0">
               <div
-                class="flex h-12 w-12 items-center justify-center rounded-full bg-base-200 dark:bg-base-700/50"
+                class="bg-base-200 dark:bg-base-700/50 flex h-12 w-12 items-center justify-center rounded-full"
               >
                 <span
-                  class="font-semibold text-primary-600 dark:text-primary-400"
+                  class="text-primary-600 dark:text-primary-400 font-semibold"
                   >S</span
                 >
               </div>
             </div>
             <div>
-              <blockquote class="mb-4 text-base-500 dark:text-base-400">
+              <blockquote class="text-base-500 dark:text-base-400 mb-4">
                 "Guido's expertise in conversion optimization and his ability to
                 translate complex concepts into practical advice made his
                 session one of the most valuable at our event."
               </blockquote>
               <div>
-                <div class="font-semibold text-base-900 dark:text-base-100">
+                <div class="text-base-900 dark:text-base-100 font-semibold">
                   Sandra de Vries
                 </div>
-                <div class="text-sm text-base-500 dark:text-base-400">
+                <div class="text-base-500 dark:text-base-400 text-sm">
                   Head of Programming, How to Web
                 </div>
               </div>
@@ -887,11 +887,11 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- Featured Presentations -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <h2 class="h2 mb-6">Featured Presentations</h2>
-        <p class="text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-lg">
           Some of my most popular talks that conference organizers frequently
           request
         </p>
@@ -899,7 +899,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mb-12 grid gap-8 md:grid-cols-3">
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 overflow-hidden rounded-xl border shadow-xs transition-shadow hover:shadow-md"
         >
           <div class="aspect-video overflow-hidden">
             <img
@@ -910,20 +910,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             />
           </div>
           <div class="p-6">
-            <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+            <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
               Still A/B Testing Your Buttons?
             </h3>
-            <p class="mb-4 text-sm text-base-500 dark:text-base-400">
+            <p class="text-base-500 dark:text-base-400 mb-4 text-sm">
               You need to think much bigger. How to move beyond basic button
               tests to meaningful experimentation.
             </p>
             <div class="flex items-center justify-between">
-              <span class="text-xs text-base-500 dark:text-base-400"
+              <span class="text-base-500 dark:text-base-400 text-xs"
                 >20 minutes</span
               >
               <a
                 href="/presentations/still-a-b-testing-your-buttons-you-need-to-think-much-bigger/"
-                class="text-sm text-primary-600 hover:underline dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 text-sm hover:underline"
                 >Learn more →</a
               >
             </div>
@@ -931,7 +931,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 overflow-hidden rounded-xl border shadow-xs transition-shadow hover:shadow-md"
         >
           <div class="aspect-video overflow-hidden">
             <img
@@ -942,20 +942,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             />
           </div>
           <div class="p-6">
-            <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+            <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
               Persuasive E-commerce
             </h3>
-            <p class="mb-4 text-sm text-base-500 dark:text-base-400">
+            <p class="text-base-500 dark:text-base-400 mb-4 text-sm">
               Applying psychology principles to optimize digital customer
               experiences and drive conversions.
             </p>
             <div class="flex items-center justify-between">
-              <span class="text-xs text-base-500 dark:text-base-400"
+              <span class="text-base-500 dark:text-base-400 text-xs"
                 >40 minutes - 4 hours</span
               >
               <a
                 href="/presentations/persuasive-e-commerce/"
-                class="text-sm text-primary-600 hover:underline dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 text-sm hover:underline"
                 >Learn more →</a
               >
             </div>
@@ -963,7 +963,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 overflow-hidden rounded-xl border shadow-xs transition-shadow hover:shadow-md"
         >
           <div class="aspect-video overflow-hidden">
             <img
@@ -974,20 +974,20 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             />
           </div>
           <div class="p-6">
-            <h3 class="mb-2 font-semibold text-base-900 dark:text-base-100">
+            <h3 class="text-base-900 dark:text-base-100 mb-2 font-semibold">
               Creating an Optimization Culture
             </h3>
-            <p class="mb-4 text-sm text-base-500 dark:text-base-400">
+            <p class="text-base-500 dark:text-base-400 mb-4 text-sm">
               How to build experimentation teams and foster data-driven decision
               making across organizations.
             </p>
             <div class="flex items-center justify-between">
-              <span class="text-xs text-base-500 dark:text-base-400"
+              <span class="text-base-500 dark:text-base-400 text-xs"
                 >20-30 minutes</span
               >
               <a
                 href="/presentations/creating-an-optimization-culture/"
-                class="text-sm text-primary-600 hover:underline dark:text-primary-400"
+                class="text-primary-600 dark:text-primary-400 text-sm hover:underline"
                 >Learn more →</a
               >
             </div>
@@ -1008,10 +1008,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 dark:bg-base-700/50"
+          class="bg-base-200 dark:bg-base-700/50 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+            class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -1035,14 +1035,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="mx-auto max-w-6xl">
         <div class="grid gap-8 md:grid-cols-2">
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Travel Requirements
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• Flight booking and costs covered by organizer</li>
               <li>• Business class for flights over 3 hours</li>
               <li>• Airport transfers or rental car if needed</li>
@@ -1050,14 +1050,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             </ul>
           </div>
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Accommodation
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• 4-star hotel or equivalent accommodation</li>
               <li>• Arrival day before event + departure day after</li>
               <li>• Quiet room for preparation (if needed)</li>
@@ -1070,14 +1070,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- AV/Tech Requirements Section -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 dark:bg-base-700/50"
+          class="bg-base-200 dark:bg-base-700/50 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+            class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -1096,14 +1096,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="mx-auto max-w-6xl">
         <div class="grid gap-8 md:grid-cols-2">
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Basic Setup
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• Projector/large screen for presentations</li>
               <li>• Wireless presentation remote (clicker)</li>
               <li>• Lapel microphone (wireless preferred)</li>
@@ -1111,14 +1111,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             </ul>
           </div>
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Technical Details
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• HDMI connection for MacBook Pro</li>
               <li>• Internet connection for live demos</li>
               <li>• Recording equipment (if session is recorded)</li>
@@ -1135,10 +1135,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 dark:bg-base-700/50"
+          class="bg-base-200 dark:bg-base-700/50 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+            class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -1152,7 +1152,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </svg>
         </div>
         <h2 class="h2 mb-6">Biography</h2>
-        <p class="text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-lg">
           Copy-paste ready speaker bio for your marketing materials
         </p>
       </div>
@@ -1160,15 +1160,15 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="mx-auto max-w-6xl">
         <div class="space-y-8">
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-8 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-8"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Short Bio (50 words)
             </h3>
             <div
-              class="prose prose-lg max-w-none text-base-500 dark:text-base-400"
+              class="prose prose-lg text-base-500 dark:text-base-400 max-w-none"
             >
               <p>
                 Guido X Jansen is a Community Builder with 20+ years creating
@@ -1182,15 +1182,15 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </div>
 
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-8 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-8"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Medium Bio (100 words)
             </h3>
             <div
-              class="prose prose-lg max-w-none text-base-500 dark:text-base-400"
+              class="prose prose-lg text-base-500 dark:text-base-400 max-w-none"
             >
               <p>
                 Guido X Jansen is a Community Builder who creates technical
@@ -1214,15 +1214,15 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </div>
 
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-8 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-8"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Long Bio (200 words)
             </h3>
             <div
-              class="prose prose-lg max-w-none text-base-500 dark:text-base-400"
+              class="prose prose-lg text-base-500 dark:text-base-400 max-w-none"
             >
               <p>
                 Guido X Jansen is a Community Builder who transforms technical
@@ -1261,14 +1261,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
   </section>
 
   <!-- Content for Marketing Section -->
-  <section class="bg-base-200/30 py-16 md:py-20 dark:bg-base-700/30">
+  <section class="bg-base-200/30 dark:bg-base-700/30 py-16 md:py-20">
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <div
-          class="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-base-200 dark:bg-base-700/50"
+          class="bg-base-200 dark:bg-base-700/50 mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"
         >
           <svg
-            class="h-8 w-8 text-primary-600 dark:text-primary-400/90"
+            class="text-primary-600 dark:text-primary-400/90 h-8 w-8"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -1282,7 +1282,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
           </svg>
         </div>
         <h2 class="h2 mb-6">Content for Your Marketing</h2>
-        <p class="text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-lg">
           Ready-to-use materials to promote the session
         </p>
       </div>
@@ -1290,14 +1290,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="mx-auto max-w-6xl">
         <div class="grid gap-8 md:grid-cols-2">
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Session Titles
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• "Building a Culture of Experimentation"</li>
               <li>• "Digital Psychology for Better Conversions"</li>
               <li>• "From A/B Testing to Full Experimentation Culture"</li>
@@ -1306,14 +1306,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
             </ul>
           </div>
           <div
-            class="rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 rounded-xl border p-6"
           >
             <h3
-              class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+              class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
             >
               Key Topics
             </h3>
-            <ul class="space-y-2 text-base-500 dark:text-base-400">
+            <ul class="text-base-500 dark:text-base-400 space-y-2">
               <li>• Behavioral psychology principles</li>
               <li>• A/B testing best practices</li>
               <li>• Experimentation culture development</li>
@@ -1324,14 +1324,14 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="mt-8 rounded-xl border border-base-200 bg-base-100 p-6 dark:border-base-700 dark:bg-base-900"
+          class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 mt-8 rounded-xl border p-6"
         >
           <h3
-            class="mb-4 text-xl font-semibold text-base-900 dark:text-base-100"
+            class="text-base-900 dark:text-base-100 mb-4 text-xl font-semibold"
           >
             Social Media Kit
           </h3>
-          <p class="mb-4 text-base-500 dark:text-base-400">
+          <p class="text-base-500 dark:text-base-400 mb-4">
             Professional headshots, social media graphics, and promotional copy
             available upon request for event marketing.
           </p>
@@ -1348,7 +1348,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto mb-12 max-w-4xl text-center">
         <h2 class="h2 mb-6">Headshots</h2>
-        <p class="text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 text-lg">
           High-resolution headshots for your event marketing materials
         </p>
       </div>
@@ -1356,7 +1356,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
       <div class="grid gap-6 md:grid-cols-3">
         <div class="group">
           <div
-            class="aspect-square overflow-hidden rounded-xl border border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 aspect-square overflow-hidden rounded-xl border"
           >
             <Image
               src={headshot1}
@@ -1381,7 +1381,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
         <div class="group">
           <div
-            class="aspect-square overflow-hidden rounded-xl border border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 aspect-square overflow-hidden rounded-xl border"
           >
             <Image
               src={headshot2}
@@ -1406,7 +1406,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
         <div class="group">
           <div
-            class="aspect-square overflow-hidden rounded-xl border border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900"
+            class="border-base-200 bg-base-100 dark:border-base-700 dark:bg-base-900 aspect-square overflow-hidden rounded-xl border"
           >
             <Image
               src={headshot3}
@@ -1437,10 +1437,10 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
     <div class="site-container">
       <div class="mx-auto max-w-4xl text-center">
         <h2 class="h2 mb-6">Ready to book me for your event?</h2>
-        <p class="mb-8 text-lg text-base-500 dark:text-base-400">
+        <p class="text-base-500 dark:text-base-400 mb-8 text-lg">
           If you have more info, you can <a
             href="/contact/"
-            class="text-primary-600 hover:underline dark:text-primary-400"
+            class="text-primary-600 dark:text-primary-400 hover:underline"
             >contact me here</a
           >.
         </p>

--- a/src/pages/speaker.astro
+++ b/src/pages/speaker.astro
@@ -449,7 +449,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mx-auto max-w-4xl">
         <div
-          class="rounded-2xl border border-base-200 bg-base-100 p-8 shadow-sm dark:border-base-700 dark:bg-base-900"
+          class="rounded-2xl border border-base-200 bg-base-100 p-8 shadow-xs dark:border-base-700 dark:bg-base-900"
         >
           <div class="mb-8 text-center">
             <div
@@ -899,7 +899,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
 
       <div class="mb-12 grid gap-8 md:grid-cols-3">
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-sm transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
         >
           <div class="aspect-video overflow-hidden">
             <img
@@ -931,7 +931,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-sm transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
         >
           <div class="aspect-video overflow-hidden">
             <img
@@ -963,7 +963,7 @@ import headshot3 from "@images/headshot/08.02.2022_Spryker_CEO_2669.jpg";
         </div>
 
         <div
-          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-sm transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
+          class="overflow-hidden rounded-xl border border-base-200 bg-base-100 shadow-xs transition-shadow hover:shadow-md dark:border-base-700 dark:bg-base-900"
         >
           <div class="aspect-video overflow-hidden">
             <img

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -25,7 +25,7 @@ const arrowExamples = [
   title="UI Style Guide"
   description="A comprehensive guide to UI components and their usage"
 >
-  <main class="container mx-auto max-w-7xl px-4 pb-16 pt-32">
+  <main class="container mx-auto max-w-7xl px-4 pt-32 pb-16">
     <h1 class="h1">UI Style Guide</h1>
     <p class="description">
       Use the theme toggle below to test components in both light and dark
@@ -33,7 +33,7 @@ const arrowExamples = [
       both modes.
     </p>
     <div
-      class="sticky right-4 top-32 z-50 ml-auto w-fit rounded-lg bg-white/50 p-2 shadow-lg backdrop-blur-xs dark:bg-black/50"
+      class="sticky top-32 right-4 z-50 ml-auto w-fit rounded-lg bg-white/50 p-2 shadow-lg backdrop-blur-xs dark:bg-black/50"
     >
       <ThemeToggle />
     </div>
@@ -47,7 +47,7 @@ const arrowExamples = [
         <!-- Buttons Section -->
         <div>
           <a href="#buttons" class="primary-link text-lg">Buttons</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#button-variants" class="primary-link">Basic Variants</a>
             </li>
@@ -66,7 +66,7 @@ const arrowExamples = [
         <!-- Typography Section -->
         <div>
           <a href="#typography" class="primary-link text-lg">Typography</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#headings" class="primary-link">Headings</a>
             </li>
@@ -93,7 +93,7 @@ const arrowExamples = [
         <!-- Badges Section -->
         <div>
           <a href="#badges" class="primary-link text-lg">Badges</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#basic-badge" class="primary-link">Basic Badge</a>
             </li>
@@ -112,7 +112,7 @@ const arrowExamples = [
         <!-- Alerts Section -->
         <div>
           <a href="#alerts" class="primary-link text-lg">Alerts</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#alert-info" class="primary-link">Info Alert</a>
             </li>
@@ -147,7 +147,7 @@ const arrowExamples = [
         <!-- Navigation Section -->
         <div>
           <a href="#navigation" class="primary-link text-lg">Navigation</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#nav-links" class="primary-link">Nav Links</a>
             </li>
@@ -160,7 +160,7 @@ const arrowExamples = [
         <!-- Cards Section -->
         <div>
           <a href="#cards" class="primary-link text-lg">Cards</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#card-example" class="primary-link">Card Example</a>
             </li>
@@ -170,7 +170,7 @@ const arrowExamples = [
         <!-- Lists Section -->
         <div>
           <a href="#lists" class="primary-link text-lg">Lists</a>
-          <ul class="ml-4 mt-2">
+          <ul class="mt-2 ml-4">
             <li class="mt-1">
               <a href="#unordered-lists" class="primary-link">Unordered Lists</a
               >
@@ -319,7 +319,7 @@ const arrowExamples = [
           </div>
           <div>
             <h4 class="h4 mb-4">Custom Marker</h4>
-            <ul class="list-[square] pl-6 marker:text-primary-500">
+            <ul class="marker:text-primary-500 list-[square] pl-6">
               <li>Primary item</li>
               <li>Secondary item</li>
               <li>Tertiary item</li>
@@ -343,7 +343,7 @@ const arrowExamples = [
           <div>
             <h4 class="h4 mb-4">Custom Counter</h4>
             <ol
-              class="list-[upper-roman] pl-6 marker:font-medium marker:text-primary-500"
+              class="marker:text-primary-500 list-[upper-roman] pl-6 marker:font-medium"
             >
               <li>Primary step</li>
               <li>Secondary step</li>
@@ -768,11 +768,11 @@ const arrowExamples = [
               <!-- Categories -->
               <div class="card-categories">
                 <span
-                  class="inline-block rounded-full bg-base-300 px-3 py-1 text-sm font-semibold text-base-700"
+                  class="bg-base-300 text-base-700 inline-block rounded-full px-3 py-1 text-sm font-semibold"
                   >Category 1</span
                 >
                 <span
-                  class="inline-block rounded-full bg-base-300 px-3 py-1 text-sm font-semibold text-base-700"
+                  class="bg-base-300 text-base-700 inline-block rounded-full px-3 py-1 text-sm font-semibold"
                   >Category 2</span
                 >
               </div>

--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -33,7 +33,7 @@ const arrowExamples = [
       both modes.
     </p>
     <div
-      class="sticky right-4 top-32 z-50 ml-auto w-fit rounded-lg bg-white/50 p-2 shadow-lg backdrop-blur-sm dark:bg-black/50"
+      class="sticky right-4 top-32 z-50 ml-auto w-fit rounded-lg bg-white/50 p-2 shadow-lg backdrop-blur-xs dark:bg-black/50"
     >
       <ThemeToggle />
     </div>

--- a/src/styles/base/_scrollbar.scss
+++ b/src/styles/base/_scrollbar.scss
@@ -8,11 +8,13 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply rounded-full bg-base-300 bg-opacity-90;
+    /* v4: bg-opacity-* removed → use color/alpha modifier */
+    @apply rounded-full bg-base-300/90;
   }
 
   /* Custom focus styles for better accessibility */
   a:focus {
-    @apply outline-none ring-1 ring-primary-500/20 rounded;
+    /* v4: outline-none → outline-hidden; bare rounded → rounded-sm */
+    @apply outline-hidden ring-1 ring-primary-500/20 rounded-sm;
   }
 }

--- a/src/styles/buttons.scss
+++ b/src/styles/buttons.scss
@@ -1,7 +1,7 @@
 /* buttons, 4 types "primary", "secondary", "outline", "ghost" */
 .button {
   @apply flex items-center justify-center rounded-md px-7 py-3 font-medium;
-  @apply focus:outline-none;
+  @apply focus:outline-hidden;
   @apply disabled:pointer-events-none;
   transition:
     background-color 0.2s ease,
@@ -26,28 +26,29 @@
   @apply bg-primary-500 text-white shadow-md;
   @apply hover:bg-primary-600;
   @apply dark:bg-primary-500 dark:text-base-100 dark:hover:bg-primary-400;
-  @apply focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-opacity-50;
+  /* v4: ring-opacity-* removed → use color/alpha modifier */
+  @apply focus-visible:ring-2 focus-visible:ring-primary-500/50;
 }
 
 .button--secondary {
-  @apply bg-base-500 text-base-50 shadow-sm;
+  @apply bg-base-500 text-base-50 shadow-xs;
   @apply hover:bg-base-600;
   @apply dark:bg-base-600 dark:text-base-200 dark:hover:bg-base-500;
-  @apply focus-visible:ring-2 focus-visible:ring-base-500 focus-visible:ring-opacity-50;
+  @apply focus-visible:ring-2 focus-visible:ring-base-500/50;
 }
 
 .button--outline {
-  @apply border border-base-200 bg-base-50 text-base-800 shadow-sm;
+  @apply border border-base-200 bg-base-50 text-base-800 shadow-xs;
   @apply hover:bg-base-100;
   @apply dark:border-base-700 dark:bg-base-900 dark:text-base-200 dark:hover:bg-base-800;
-  @apply focus-visible:ring-2 focus-visible:ring-base-200 focus-visible:ring-opacity-50 dark:focus-visible:ring-base-600;
+  @apply focus-visible:ring-2 focus-visible:ring-base-200/50 dark:focus-visible:ring-base-600;
 }
 
 .button--ghost {
   @apply bg-base-50 text-base-800;
   @apply hover:bg-base-200;
   @apply dark:bg-transparent dark:text-base-200 dark:hover:bg-base-800;
-  @apply focus-visible:ring-2 focus-visible:ring-base-200 focus-visible:ring-opacity-50 dark:focus-visible:ring-base-600;
+  @apply focus-visible:ring-2 focus-visible:ring-base-200/50 dark:focus-visible:ring-base-600;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/components/_alerts.scss
+++ b/src/styles/components/_alerts.scss
@@ -81,7 +81,7 @@
   }
 
   .alert-button {
-    @apply flex items-center justify-center transition-all duration-200 focus:ring-2 focus:outline-none h-8 px-4 py-2 text-xs font-medium rounded-md;
+    @apply flex items-center justify-center transition-all duration-200 focus:ring-2 focus:outline-hidden h-8 px-4 py-2 text-xs font-medium rounded-md;
   }
 
   .alert-button-primary {

--- a/src/styles/components/_cards.scss
+++ b/src/styles/components/_cards.scss
@@ -1,7 +1,7 @@
 @layer components {
   /* Card System */
   article[class*="card"]:not(.event-card) {
-    @apply rounded-xl border border-base-200/50 bg-base-100/50 backdrop-blur group-hover:border-primary-500/50 group-hover:bg-primary-500/[0.03] dark:border-base-700/50 dark:bg-base-900/50 dark:group-hover:border-primary-400/50 dark:group-hover:bg-primary-400/[0.03];
+    @apply rounded-xl border border-base-200/50 bg-base-100/50 backdrop-blur-sm group-hover:border-primary-500/50 group-hover:bg-primary-500/[0.03] dark:border-base-700/50 dark:bg-base-900/50 dark:group-hover:border-primary-400/50 dark:group-hover:bg-primary-400/[0.03];
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -19,13 +19,15 @@
     grid-auto-rows: min-content;
   }
 
-  @screen md {
+  /* @screen md / lg replaced with raw media queries (Tailwind v4 dropped @screen).
+     Breakpoints match the @theme block in src/styles/tailwind.css. */
+  @media (min-width: 1000px) {
     .cards-grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
 
-  @screen lg {
+  @media (min-width: 1124px) {
     .cards-grid {
       grid-template-columns: repeat(3, 1fr);
     }
@@ -96,7 +98,7 @@
 
   /* Event Card Specifics */
   .event-card {
-    @apply rounded-xl border border-base-200/50 bg-base-100/50 backdrop-blur group-hover:border-primary-500/50 group-hover:bg-primary-500/[0.03] dark:border-base-700/50 dark:bg-base-900/50 dark:group-hover:border-primary-400/50 dark:group-hover:bg-primary-400/[0.03];
+    @apply rounded-xl border border-base-200/50 bg-base-100/50 backdrop-blur-sm group-hover:border-primary-500/50 group-hover:bg-primary-500/[0.03] dark:border-base-700/50 dark:bg-base-900/50 dark:group-hover:border-primary-400/50 dark:group-hover:bg-primary-400/[0.03];
     @apply p-4;
     transition:
       border-color 0.3s ease,

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,4 +1,5 @@
-/* Import Component Styles */
+/* Import Component Styles
+   Sass requires @use rules to come first, before any other directives. */
 @use "./utilities/utilities";
 @use "./components/alerts";
 @use "./components/cards";
@@ -7,10 +8,16 @@
 @use "./base/typography";
 @use "./prose";
 
-/* Base Styles */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+/* Reference Tailwind v4 theme so @apply directives in this file resolve
+   without producing utilities twice. Required because PostCSS processes
+   this .scss independently from tailwind.css. */
+@reference "./tailwind.css";
+
+/* Base Styles
+   Tailwind v4 entry lives in ./tailwind.css and is imported separately from
+   BaseLayout.astro BEFORE this file. The v3 `@tailwind base/components/utilities`
+   directives have been removed in favour of `@import "tailwindcss"` in
+   tailwind.css. */
 
 /* Base Typography */
 @layer base {
@@ -114,7 +121,7 @@
     @apply text-2xl text-base-800 dark:text-base-200;
     @apply shadow-lg transition-all duration-300;
     @apply hover:bg-base-100 dark:hover:bg-base-700;
-    @apply focus:outline-none focus:ring-2 focus:ring-primary-500;
+    @apply focus:outline-hidden focus:ring-2 focus:ring-primary-500;
     @apply disabled:cursor-not-allowed disabled:opacity-30;
     @apply disabled:hover:bg-base-50/95 dark:disabled:hover:bg-base-800/95;
     /* Improved touch target size */
@@ -182,12 +189,12 @@
   }
   to {
     outline-offset: 3px;
-    outline-color: theme("colors.primary.500");
+    outline-color: var(--color-primary-500);
   }
 }
 
 :focus-visible {
-  outline: 2px solid theme("colors.primary.500");
+  outline: 2px solid var(--color-primary-500);
   outline-offset: 3px;
   animation: focus-ring-expand 0.2s cubic-bezier(0.33, 1, 0.68, 1);
 }

--- a/src/styles/prose.scss
+++ b/src/styles/prose.scss
@@ -85,7 +85,8 @@
   /* paragraphs */
   @apply prose-p:mb-0 prose-p:mt-0;
   /* code */
-  @apply prose-code:rounded-lg prose-code:border-opacity-0 prose-code:px-[.1rem] prose-code:font-normal prose-code:text-inherit sm:prose-code:text-base;
+  /* v4: border-opacity-* removed → use border-transparent or color/alpha modifier */
+  @apply prose-code:rounded-lg prose-code:border-transparent prose-code:px-[.1rem] prose-code:font-normal prose-code:text-inherit sm:prose-code:text-base;
   /* anchor links */
   @apply prose-a:text-inherit prose-a:underline prose-a:transition hover:prose-a:text-inherit hover:prose-a:opacity-80;
 }

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,140 @@
+/* Tailwind CSS v4 entry.
+   Migrated from tailwind.config.mjs (v3 JS config) to CSS-first @theme block.
+   See: https://tailwindcss.com/docs/upgrade-guide
+
+   Loaded BEFORE global.scss in BaseLayout.astro so that @apply directives
+   inside .scss files (compiled to CSS by Sass before PostCSS runs) can
+   resolve against this theme. */
+
+@import "tailwindcss";
+
+/* Plugins (still separate npm packages in v4). */
+@plugin "@tailwindcss/typography";
+@plugin "@tailwindcss/forms";
+
+/* Custom dark mode variant.
+   Preserves the v3 behaviour: dark styles apply when an ancestor has
+   class="dark", UNLESS a closer ancestor has class="light" (used to opt
+   sections back out of dark mode). */
+@custom-variant dark (&:is(.dark *):not(.light *));
+
+/* Safelist classes that may be added at runtime via JavaScript and won't
+   appear in source scans. v4 uses @source inline() for this. */
+@source inline("dark");
+@source inline("light");
+@source inline("animate-marquee");
+@source inline("active");
+@source inline("open");
+@source inline("show");
+@source inline("hide");
+
+@theme {
+  /* ---------- Breakpoints ---------- */
+  --breakpoint-xs: 400px;
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 1000px;
+  --breakpoint-lg: 1124px;
+  --breakpoint-xl: 1280px;
+  --breakpoint-2xl: 1536px;
+
+  /* ---------- Font families ---------- */
+  --font-sans:
+    Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --font-serif:
+    Poppins, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-mono:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+
+  /* ---------- Rosé Pine palette ----------
+     Dark mode: Main variant | Light mode: Dawn variant
+     https://rosepinetheme.com/palette/ */
+
+  /* Primary accent - Pine (teal) */
+  --color-primary-50: #f0f5f7;
+  --color-primary-100: #dceaef;
+  --color-primary-200: #b8d5df;
+  --color-primary-300: #9ccfd8; /* foam (Main) */
+  --color-primary-400: #56949f; /* foam (Dawn) */
+  --color-primary-500: #31748f; /* pine (Main) */
+  --color-primary-600: #286983; /* pine (Dawn) */
+  --color-primary-700: #1f5a73;
+  --color-primary-800: #1a4a5e;
+  --color-primary-900: #153a4a;
+  --color-primary-950: #0f2a35;
+
+  /* Base colors */
+  --color-base-50: #fffaf3;  /* Dawn surface */
+  --color-base-100: #faf4ed; /* Dawn base */
+  --color-base-200: #f2e9e1; /* Dawn overlay */
+  --color-base-300: #dfdad3; /* Dawn muted bg */
+  --color-base-400: #9893a5; /* Dawn muted text */
+  --color-base-500: #908caa; /* Main subtle */
+  --color-base-600: #6e6a86; /* Main muted */
+  --color-base-700: #393552; /* Main highlight-high */
+  --color-base-800: #26233a; /* Main overlay */
+  --color-base-900: #1f1d2e; /* Main surface */
+  --color-base-950: #191724; /* Main base */
+
+  /* Rosé Pine accent colors */
+  --color-accent-1: #f6c177; /* gold */
+  --color-accent-2: #9ccfd8; /* foam */
+  --color-accent-3: #c4a7e7; /* iris */
+  --color-accent-4: #eb6f92; /* love */
+
+  /* Backgrounds */
+  --color-background: #faf4ed;
+  --color-background-dark: #1a1825;
+
+  /* Semantic colors using Rosé Pine accents */
+  --color-info: #9ccfd8;
+  --color-info-content: #191724;
+  --color-success: #31748f;
+  --color-success-content: #e0def4;
+  --color-warning: #f6c177;
+  --color-warning-content: #191724;
+  --color-error: #eb6f92;
+  --color-error-content: #191724;
+
+  /* Direct Rosé Pine accent access (DEFAULT + light variants) */
+  --color-love: #eb6f92;
+  --color-love-light: #b4637a;
+  --color-gold: #f6c177;
+  --color-gold-light: #ea9d34;
+  --color-rose: #ebbcba;
+  --color-rose-light: #d7827e;
+  --color-pine: #31748f;
+  --color-pine-light: #286983;
+  --color-foam: #9ccfd8;
+  --color-foam-light: #56949f;
+  --color-iris: #c4a7e7;
+  --color-iris-light: #907aa9;
+
+  /* Text colors for direct use */
+  --color-rp-text: #e0def4;
+  --color-rp-text-light: #575279;
+  --color-rp-subtle: #908caa;
+  --color-rp-subtle-light: #797593;
+  --color-rp-muted: #6e6a86;
+  --color-rp-muted-light: #9893a5;
+
+  /* ---------- Animations ---------- */
+  --animate-marquee: marquee 100s linear infinite;
+}
+
+/* Keyframes for the @theme --animate-marquee custom animation. */
+@keyframes marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(calc(-100% - 2.5rem));
+  }
+}
+
+/* ---------- Source paths ----------
+   v4 auto-detects content by scanning the project. Explicit @source rules
+   here mirror the v3 `content.files` glob for clarity and to be safe in
+   monorepo / virtual-file scenarios. */
+@source "../**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}";

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -41,8 +41,7 @@
   --font-sans:
     Poppins, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     "Helvetica Neue", Arial, sans-serif;
-  --font-serif:
-    Poppins, Georgia, Cambria, "Times New Roman", Times, serif;
+  --font-serif: Poppins, Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
     "Courier New", monospace;
@@ -65,7 +64,7 @@
   --color-primary-950: #0f2a35;
 
   /* Base colors */
-  --color-base-50: #fffaf3;  /* Dawn surface */
+  --color-base-50: #fffaf3; /* Dawn surface */
   --color-base-100: #faf4ed; /* Dawn base */
   --color-base-200: #f2e9e1; /* Dawn overlay */
   --color-base-300: #dfdad3; /* Dawn muted bg */

--- a/src/styles/utilities/_utilities.scss
+++ b/src/styles/utilities/_utilities.scss
@@ -1,7 +1,7 @@
 @layer utilities {
   /* Focus Utilities */
   .primary-focus {
-    @apply focus:outline-none focus-visible:rounded-sm focus-visible:outline-primary-500;
+    @apply focus:outline-hidden focus-visible:rounded-xs focus-visible:outline-primary-500;
   }
 
   /* Animation Controls */
@@ -62,6 +62,6 @@
   }
 
   .code-block {
-    @apply rounded bg-base-100/20 px-2 py-1 text-sm text-base-900 dark:bg-base-800 dark:text-base-100;
+    @apply rounded-sm bg-base-100/20 px-2 py-1 text-sm text-base-900 dark:bg-base-800 dark:text-base-100;
   }
 }


### PR DESCRIPTION
Closes #128. Also resolves #156 (the +37KB CSS regression).

## Bundle size — major win
| File | Before | After | Delta |
|---|---|---|---|
| Badge.css | 161 KB | **79 KB** | **-51%** |
| BaseLayout.css | 160 KB | **76 KB** | **-52%** |

v4's improved tree-shaking removes the unpurged utilities that Tailwind v3 JIT was leaving behind. CSS is now smaller than pre-#126 baseline (124 KB).

## What changed

### New file
- `src/styles/tailwind.css` — v4 CSS-first config with `@theme` block (Rose Pine palette, breakpoints, font families), `@custom-variant dark`, `@source inline()` for runtime-added classes, `@plugin` declarations for typography + forms.

### Dependencies
- `tailwindcss` → ^4.3.0
- `@tailwindcss/postcss` → ^4.3.0 (new)
- `@tailwindcss/vite` → ^4.3.0 (new)

### Manual v4 fixes the upgrade tool missed
- **14 scoped `<style>` blocks** + `global.scss` get `@reference "<path>/tailwind.css";` so utilities/theme resolve from PostCSS's per-file pipeline.
- **5 keyframe blocks** had `@apply` (banned in v4) replaced with raw CSS:
  - `Nav/NavDropdown/MegaMenuDropdownToggle.astro`
  - `Nav/NavDropdown/NavDropdownToggle.astro`
  - `Nav/MobileNav/MobileNav.astro`
  - `LanguageSelect/LanguageSelect.astro`

## Preserved
- #157 text-base-600 contrast fixes
- #127 `font-size-adjust: from-font`
- #133 root `clamp()` font-size
- #125 content-visibility wrappers
- All Rose Pine accent tokens (love/gold/rose/pine/foam/iris)
- Custom `dark` variant behavior (`&:is(.dark *):not(.light *)`)

## Tests
- `npx astro check` → 0 errors, 0 warnings
- `vitest` → 109 passed, 1 skipped (flaky URL test from #151)
- `npm run build` → clean

## Unlocks
- `@container` query utilities now native — future fluid components can use these instead of viewport-based breakpoints

## Followups
- #159 brand-accent contrast (gold/love outline buttons) — needs design decision