### PR TITLE
fix(a11y): use high-contrast neutral text on outline buttons

### DIFF
--- a/src/components/Button/Button.astro
+++ b/src/components/Button/Button.astro
@@ -171,9 +171,15 @@ const baseClasses = [
 
   .button--outline {
     @apply border-2 bg-transparent transition-all duration-200;
-    /* Use CSS custom property for color - set by data-color attribute */
+    /* Border carries the brand accent; text uses a high-contrast neutral
+       so the button passes WCAG AA regardless of which random accent is
+       assigned. Hover state still fills with the brand colour. */
     border-color: var(--btn-color);
-    color: var(--btn-color);
+    color: #191724; /* Rose Pine base — passes contrast on every page bg */
+  }
+
+  :global(.dark) .button--outline {
+    color: #e0def4; /* Rose Pine text — passes contrast on dark page bg */
   }
 
   .button--outline:hover {


### PR DESCRIPTION
## Problem
Outline buttons set both border AND text color to a randomly-rotated Rose Pine accent. Axe-core finds contrast violations on whichever accent gets assigned per page load:

| accent | contrast on #faf4ed | status |
|---|---|---|
| gold #ea9d34 | 2.05:1 | FAIL |
| foam #56949f | 3.42:1 | FAIL |
| iris #907aa9 | 3.78:1 | FAIL |
| love #b4637a | 3.84:1 | FAIL |
| rose #d7827e | ~similar | FAIL |
| pine #286983 | passes | OK |

5 of 6 accents fail. Random assignment means any page load has ~83% chance of contrast failures.

## Fix
Keep the random-rotation visual identity by retaining brand accent on the **border**. Switch **text** to high-contrast neutral:

- Light mode: text \`#191724\` (Rose Pine base) — ≥15:1 on #faf4ed
- Dark mode: text \`#e0def4\` (Rose Pine text) — ≥14:1 on #1A1825

Hover state unchanged (fills with brand accent + white text).

## Trade-off
Slight visual change: at rest the button label is now neutral-coloured (border is still the brand accent). Hover still pops with full brand colour. Net: still feels "Rose Pine" but every random assignment now passes WCAG AA.

## Files changed
- \`src/components/Button/Button.astro\` (+8/-2)

## Followups not in scope
Other brand-color text usages exist outside outline buttons (in alerts, ManaBar, GameUI, decorative components). Those likely also fail axe on whatever pages render them, but they're decorative/themed components rather than CTAs, and would require per-component design decisions. Filing as separate followups if Lighthouse flags them post-deploy.

Closes #159.