### PR TITLE
HOTFIX: import tailwind.css entry in BaseLayout (broken since #161)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -7,7 +7,9 @@ import Nav from "@components/Nav/Nav.astro";
 import Footer from "@components/Footer/Footer.astro";
 import EnvironmentBanner from "../components/EnvironmentBanner/EnvironmentBanner.astro";
 
-// style import
+// style imports — Tailwind v4 entry MUST load before global.scss so that
+// @apply directives in SCSS resolve against the v4 theme.
+import "../styles/tailwind.css";
 import "../styles/global.scss";
 
 // utils


### PR DESCRIPTION
Site is fully unstyled in production. Tailwind v4 migration (#161) created `src/styles/tailwind.css` but never added the `import` statement to BaseLayout.astro. Tailwind never ran in the production build — only scoped component CSS was emitted.

Single-line fix: add the missing import.

Built CSS after fix:
- Badge.css: 200 KB (was 0 KB after #161/#162)
- BaseLayout.css: 196 KB (was 75 KB, scoped-only)

Merging via admin given production breakage.