### PR TITLE
fix(a11y): remove redundant aria-labelledby from service card inner div

### DIFF
--- a/src/components/ServiceCard/ServiceCardSideImage.astro
+++ b/src/components/ServiceCard/ServiceCardSideImage.astro
@@ -55,10 +55,7 @@ const cardId = `biography-${title.toLowerCase().replace(/\s+/g, "-")}`;
   aria-labelledby={`${cardId}-title`}
 >
   <!-- Text content -->
-  <div
-    class={`${imageSide === "left" ? "md:order-last" : ""} col-span-1`}
-    aria-labelledby={`${cardId}-title`}
-  >
+  <div class={`${imageSide === "left" ? "md:order-last" : ""} col-span-1`}>
     <header>
       <h3 id={`${cardId}-title`} class="h2 mt-6">
         {title}


### PR DESCRIPTION
Followup to #157/#159 cleanup. axe flags `aria-prohibited-attr` (4 nodes on homepage Services grid) because aria-labelledby is not supported on a `<div>` without a role.

The wrapping `<article role="listitem">` already has the same attribute, so removing the duplicate is the correct fix.

1 file, +1/-4 lines.