### PR TITLE
fix(a11y): move card aria-labels to article + drop redundant copyright label

### DIFF
--- a/src/components/FeatureCard/FeatureCardSmall.astro
+++ b/src/components/FeatureCard/FeatureCardSmall.astro
@@ -24,12 +24,15 @@ const { icon, title, text, suffix = "", ...rest } = Astro.props as Props;
 const cardId = `feature-${title.toLowerCase().replace(/\s+/g, "-")}${suffix}`;
 ---
 
-<article {...rest} class="group">
+<article
+  {...rest}
+  class="group"
+  aria-labelledby={`${cardId}-title`}
+  aria-describedby={`${cardId}-description`}
+>
   <div
     class="focus-within:ring-primary-500 dark:hover:bg-base-900 h-full rounded-md p-6 transition duration-200 focus-within:ring-2 focus-within:ring-offset-2 hover:bg-white hover:shadow-xl"
     tabindex="0"
-    aria-labelledby={`${cardId}-title`}
-    aria-describedby={`${cardId}-description`}
   >
     <div class="flex h-full flex-col">
       <header class="flex items-start gap-2">

--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -82,8 +82,7 @@ const today = new Date();
       <div class="mt-2">
         <div class="flex flex-col justify-between gap-6 sm:flex-row">
           <p class="order-2 my-auto pt-8 sm:order-1">
-            <span aria-label="Copyright">&copy;</span>
-            {today.getFullYear()}
+            &copy; {today.getFullYear()}
             {" "}{siteData.name}. All rights reserved.
           </p>
 


### PR DESCRIPTION
Two cleanups for axe's `aria-prohibited-attr` (4 nodes) on the homepage:

1. **FeatureCardSmall.astro** — moved aria-labelledby + aria-describedby from the inner focus-wrapper `<div>` (no role) up to the `<article>` wrapper. tabindex stays on the inner div so the focus ring still works. Different component from #164's ServiceCardSideImage fix; identical pattern.

2. **Footer.astro** — removed `<span aria-label="Copyright">` wrapping the © glyph. aria-label on a span without a role is prohibited, and the © character already announces as 'copyright' in screen readers.

2 files, +7/-5 lines.