### PR TITLE
refactor: replace ClientRouter with CSS-only view transitions

### DIFF
--- a/src/components/Feature/FeatureFlagsMarquee.astro
+++ b/src/components/Feature/FeatureFlagsMarquee.astro
@@ -35,11 +35,7 @@ const marqueeBottom = {
 };
 ---
 
-<section
-  id="feature-flags-marquee"
-  class="relative py-24 md:py-28"
-  transition:animate="fade"
->
+<section id="feature-flags-marquee" class="relative py-24 md:py-28">
   <div class="site-container relative">
     <div class="relative">
       <div class="relative flex justify-center">

--- a/src/components/Nav/Nav.astro
+++ b/src/components/Nav/Nav.astro
@@ -46,7 +46,6 @@ const shouldReduceMotion =
   style={shouldReduceMotion
     ? ""
     : "transition: background-color 0.3s cubic-bezier(0.33, 1, 0.68, 1), border-color 0.3s ease, padding 0.3s ease, backdrop-filter 0.3s ease;"}
-  transition:name={`nav`}
 >
   <div class="mx-auto flex w-full">
     <div class="site-container flex h-14 w-full items-center px-4">

--- a/src/components/PostCard/PostCardAtlas.astro
+++ b/src/components/PostCard/PostCardAtlas.astro
@@ -42,7 +42,6 @@ const filteredCategories = filterCategoriesByCount(categories, allPosts);
           widths={[360, 640, 768, 1024, 1600]}
           sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33.333vw, 400px"
           class="w-full rounded-t-xl object-cover"
-          transition:name={`heroImage-${post.id}`}
           style="background: transparent;"
           quality={85}
           format="webp"

--- a/src/components/Presentations/PresentationCard.astro
+++ b/src/components/Presentations/PresentationCard.astro
@@ -21,7 +21,6 @@ const { title, duration, intendedAudience, isWorkshop, image } =
           width={1600}
           height={900}
           class="w-full rounded-t-xl object-cover"
-          transition:name={`presentation-image-${presentation.id}`}
           style="background: transparent;"
         />
       )

--- a/src/components/SiteLogo/SiteLogo.astro
+++ b/src/components/SiteLogo/SiteLogo.astro
@@ -54,7 +54,6 @@ const currLocale = getLocaleFromUrl(Astro.url);
 </style>
 
 <a
-  transition:persist
   class="site-logo primary-focus text-base-600 dark:text-base-200 flex items-center gap-2 align-middle text-xl font-bold"
   href={getRelativeLocaleUrl(currLocale)}
 >

--- a/src/config/siteSettings.json.ts
+++ b/src/config/siteSettings.json.ts
@@ -22,7 +22,6 @@ export const languageSwitcherMap = {
 
 // site settings that don't change between languages
 export const siteSettings: SiteSettingsProps = {
-  useViewTransitions: true,
   useAnimations: true,
 };
 

--- a/src/config/types/configDataTypes.ts
+++ b/src/config/types/configDataTypes.ts
@@ -76,6 +76,5 @@ export interface teamMember {
 // --------------------------------------------------------
 // site settings types
 export interface SiteSettingsProps {
-  useViewTransitions?: boolean;
   useAnimations?: boolean;
 }

--- a/src/layouts/BaseHead.astro
+++ b/src/layouts/BaseHead.astro
@@ -1,12 +1,10 @@
 ---
 import { type CollectionEntry } from "astro:content";
-import { ClientRouter } from "astro:transitions";
 
 // component imports
 import Seo from "@components/Seo/Seo.astro";
 
 // data
-import siteSettings from "@config/siteSettings.json";
 import standardSiteConfig from "@config/standardSite.json";
 import { CONFIG } from "../config"; // Use .env for indexing
 
@@ -186,9 +184,6 @@ const noindex = !CONFIG.ALLOW_INDEXING;
 
   // runs on initial page load
   initTheme();
-
-  // runs on view transitions navigation
-  document.addEventListener("astro:after-swap", initTheme);
 </script>
 
 <Seo
@@ -200,9 +195,6 @@ const noindex = !CONFIG.ALLOW_INDEXING;
   postFrontmatter={postFrontmatter}
   noindex={noindex}
 />
-
-<!-- no fallback as I saw issues with firefox fallback -->
-{siteSettings.useViewTransitions && <ClientRouter fallback="none" />}
 
 {
   /*

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -54,12 +54,6 @@ const currLocale = getLocaleFromUrl(Astro.url);
       noindex={noindex}
     />
     <style>
-      /* will-change applied only during active transitions via JS.
-         Letting browser compositor decide layer promotion (no manual hacks). */
-      .transition-ready.is-transitioning {
-        will-change: opacity, transform;
-      }
-
       /* Noise background animation */
       @keyframes noise {
         0% {
@@ -124,13 +118,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
     <div class="z-base relative flex-1">
       <Nav />
       <div class="site-container px-4">
-        <main
-          id="main-content"
-          class="transition-ready"
-          transition:animate="fade"
-          transition:animate.duration="0.2"
-          transition:animate.timing="ease-out"
-        >
+        <main id="main-content" class="transition-ready">
           <slot />
         </main>
       </div>
@@ -140,20 +128,6 @@ const currLocale = getLocaleFromUrl(Astro.url);
 
     <!-- Performance optimizations -->
     <script>
-      // Inform the browser about upcoming transitions
-      document.addEventListener("astro:before-preparation", () => {
-        document.querySelectorAll(".transition-ready").forEach((el) => {
-          el.classList.add("is-transitioning");
-        });
-      });
-
-      // Clean up after transition
-      document.addEventListener("astro:after-swap", () => {
-        document.querySelectorAll(".transition-ready").forEach((el) => {
-          el.classList.remove("is-transitioning");
-        });
-      });
-
       // Pause noise animation when tab is backgrounded to save CPU/battery
       const noiseEl = document.querySelector(".noise-background");
       if (noiseEl) {

--- a/src/layouts/BlogLayoutCenter.astro
+++ b/src/layouts/BlogLayoutCenter.astro
@@ -25,10 +25,9 @@ import HumanNotAI from "@images/Written-By-Human-Not-By-AI-Badge-black.svg";
 interface Props {
   post: CollectionEntry<"post">;
   allPosts: CollectionEntry<"post">[];
-  transitionName?: string;
 }
 
-const { post, allPosts, transitionName } = Astro.props;
+const { post, allPosts } = Astro.props;
 const {
   title,
   description,
@@ -205,7 +204,6 @@ const newsletterDescription =
                 class="max-h-[70vh] w-full rounded-xl object-cover"
                 loading="eager"
                 fetchpriority="high"
-                transition:name={transitionName}
                 itemprop="image"
                 quality={90}
                 format="webp"

--- a/src/layouts/__tests__/BaseHead.test.ts
+++ b/src/layouts/__tests__/BaseHead.test.ts
@@ -146,13 +146,17 @@ describe("BaseHead", () => {
   });
 
   it("includes theme change script", () => {
+    // ClientRouter has been removed in favour of CSS-only view transitions
+    // (issue #131). The inline theme script only needs to run once per
+    // document — full-page navigation re-runs it automatically, so the
+    // legacy astro:after-swap listener is no longer needed.
     const markup = `
       <head>
         <script>
           function initTheme() {
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
             let colorTheme = localStorage.getItem("colorTheme");
-            
+
             function applyTheme(theme) {
               if (theme === "dark") {
                 document.documentElement.classList.add("dark");
@@ -179,7 +183,6 @@ describe("BaseHead", () => {
           }
 
           initTheme();
-          document.addEventListener("astro:after-swap", initTheme);
         </script>
       </head>
     `.trim();
@@ -191,7 +194,7 @@ describe("BaseHead", () => {
     expect(script?.textContent).toContain("prefers-color-scheme: dark");
     expect(script?.textContent).toContain('localStorage.getItem("colorTheme")');
     expect(script?.textContent).toContain("document.documentElement.classList");
-    expect(script?.textContent).toContain("astro:after-swap");
+    expect(script?.textContent).not.toContain("astro:after-swap");
   });
 
   it("handles SEO meta tags", () => {

--- a/src/layouts/__tests__/BaseLayout.test.ts
+++ b/src/layouts/__tests__/BaseLayout.test.ts
@@ -8,7 +8,7 @@ describe("BaseLayout", () => {
 
     const markup = `
       <!doctype html>
-      <html 
+      <html
         lang="en"
         dir="ltr"
         class="antialiased"
@@ -18,40 +18,33 @@ describe("BaseLayout", () => {
           <meta name="description" content="${props.description}">
           <meta name="viewport" content="width=device-width, initial-scale=1">
           <meta charset="UTF-8">
-          <ClientRouter />
         </head>
         <body
           id="body"
           class="bg-background dark:bg-background-dark use-animations relative isolate overflow-x-hidden min-h-screen flex flex-col"
         >
           <div class="fixed inset-0 z-background">
-            <div 
+            <div
               class="noise-background"
               aria-hidden="true"
               role="presentation"
             ></div>
-            <div 
+            <div
               class="gradient-top-left"
               aria-hidden="true"
               role="presentation"
             ></div>
-            <div 
+            <div
               class="gradient-bottom-right"
               aria-hidden="true"
               role="presentation"
             ></div>
           </div>
-          
+
           <div class="relative z-base flex-1">
             <nav></nav>
             <div class="site-container px-4">
-              <main 
-                id="main-content"
-                class="transition-ready" 
-                transition:animate="fade" 
-                transition:animate.duration="0.2" 
-                transition:animate.timing="ease-out"
-              >
+              <main id="main-content" class="transition-ready">
                 <slot></slot>
               </main>
             </div>
@@ -125,27 +118,24 @@ describe("BaseLayout", () => {
     });
   });
 
-  it("handles view transitions correctly", () => {
+  it("uses CSS-only cross-document view transitions", () => {
+    // Native CSS-only view transitions (Astro 6 + Baseline 2024) replace the
+    // ClientRouter SPA. The main element no longer carries Astro
+    // transition:* directives; the @view-transition at-rule in tailwind.css
+    // drives the cross-document fade instead.
     const markup = `
-      <main 
-        id="main-content"
-        class="transition-ready" 
-        transition:animate="fade" 
-        transition:animate.duration="0.2" 
-        transition:animate.timing="ease-out"
-      >
+      <main id="main-content" class="transition-ready">
         <slot></slot>
       </main>
     `.trim();
 
     const parsedHtml = parseHTML(markup);
 
-    // Check transition attributes
     const main = parsedHtml.querySelector("main");
-    expect(main?.classList.contains("transition-ready")).toBe(true);
-    expect(main?.getAttribute("transition:animate")).toBe("fade");
-    expect(main?.getAttribute("transition:animate.duration")).toBe("0.2");
-    expect(main?.getAttribute("transition:animate.timing")).toBe("ease-out");
+    expect(main?.id).toBe("main-content");
+    expect(main?.getAttribute("transition:animate")).toBeFalsy();
+    expect(main?.getAttribute("transition:animate.duration")).toBeFalsy();
+    expect(main?.getAttribute("transition:animate.timing")).toBeFalsy();
   });
 
   it("handles SEO meta tags correctly", () => {
@@ -218,49 +208,42 @@ describe("BaseLayout", () => {
     ).toBe("summary_large_image");
   });
 
-  it("includes performance optimizations", () => {
+  it("declares CSS-only @view-transition rules", () => {
+    // CSS-only view transitions don't need any JS lifecycle hooks. The
+    // performance optimization is the absence of the ~10KB ClientRouter
+    // runtime, plus root-level fade declared in tailwind.css.
     const markup = `
       <html>
         <head>
           <style>
-            .transition-ready {
-              will-change: opacity, transform;
-              transform: translateZ(0);
-              backface-visibility: hidden;
+            @view-transition {
+              navigation: auto;
+            }
+            ::view-transition-old(root),
+            ::view-transition-new(root) {
+              animation-duration: 0.2s;
+              animation-timing-function: ease-out;
+            }
+            @media (prefers-reduced-motion: reduce) {
+              ::view-transition-old(root),
+              ::view-transition-new(root) {
+                animation: none;
+              }
             }
           </style>
         </head>
         <body>
-          <main class="transition-ready"></main>
-          <script>
-            document.addEventListener('astro:before-preparation', () => {
-              document.querySelectorAll('.transition-ready').forEach(el => {
-                el.style.willChange = 'opacity, transform';
-              });
-            });
-
-            document.addEventListener('astro:after-swap', () => {
-              document.querySelectorAll('.transition-ready').forEach(el => {
-                el.style.willChange = 'auto';
-              });
-            });
-          </script>
+          <main id="main-content" class="transition-ready"></main>
         </body>
       </html>
     `.trim();
 
     const parsedHtml = parseHTML(markup);
-
-    // Check performance CSS
     const style = parsedHtml.querySelector("style");
-    expect(style?.textContent).toContain("will-change: opacity, transform");
-    expect(style?.textContent).toContain("transform: translateZ(0)");
-    expect(style?.textContent).toContain("backface-visibility: hidden");
-
-    // Check performance script
-    const script = parsedHtml.querySelector("script");
-    expect(script?.textContent).toContain("astro:before-preparation");
-    expect(script?.textContent).toContain("astro:after-swap");
-    expect(script?.textContent).toContain("willChange");
+    expect(style?.textContent).toContain("@view-transition");
+    expect(style?.textContent).toContain("navigation: auto");
+    expect(style?.textContent).toContain("::view-transition-old(root)");
+    expect(style?.textContent).toContain("::view-transition-new(root)");
+    expect(style?.textContent).toContain("prefers-reduced-motion: reduce");
   });
 });

--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -89,7 +89,6 @@ const communities = [
 <BaseLayout
   title="Community Building | Guido X Jansen"
   description="Track record of building developer and technical communities from zero: Joomla!, Dutchento/Meet Magento, CRO.CAFE, and Spryker. Community Builder Award recipient."
-  transition:animate="slide"
 >
   <!-- Hero Section -->
   <section class="py-24 md:py-28">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,7 +10,6 @@ import SocialCards from "@components/SocialCards/SocialCards.astro";
 <BaseLayout
   title="Book me for your event"
   description="Get in touch! Contact me using the form below or send me a DM."
-  transition:animate="slide"
 >
   <section class="py-24 md:py-28">
     <div class="site-container px-4">

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -87,11 +87,7 @@ sortedYears.forEach((year) => {
 });
 ---
 
-<BaseLayout
-  title="Events"
-  description="Overview of all events"
-  transition:animate="slide"
->
+<BaseLayout title="Events" description="Overview of all events">
   {/* Upcoming Events Section */}
   <section class="py-24 md:py-28">
     <UpcomingEvents events={sortedEvents} />

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -15,7 +15,6 @@ import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
 <BaseLayout
   title="Newsletter"
   description="Big Tech alternatives, AI meets DevRel, automation tips, and personal updates I don't share on social. No spam, no tracking."
-  transition:animate="slide"
 >
   <!-- Header -->
   <section class="pt-24 pb-8 md:pt-28">

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -6,11 +6,10 @@ import ServicesIcon from "@components/Services/ServicesIcon.astro";
 <BaseLayout
   title="Guido's Podcasts"
   description="Overview of the podcasts that I host and produce."
-  transition:animate="slide"
 >
   <ServicesIcon />
 
-  <div class="mt-16" transition:animate="fade">
+  <div class="mt-16">
     <div id="podcast-feed-container">
       <div class="text-center">
         <div

--- a/src/pages/presentations/[slug].astro
+++ b/src/pages/presentations/[slug].astro
@@ -104,7 +104,6 @@ const metaImage = image ? new URL(image, Astro.site) : undefined;
                 class="absolute inset-0 h-full w-full rounded-lg object-cover"
                 loading="eager"
                 style="z-index: 100;"
-                transition:name={`presentation-image-${entry.id}`}
               />
             </div>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -14,7 +14,6 @@ import Badge from "@components/Badge/Badge.astro";
 <BaseLayout
   title="Privacy"
   description="How I handle your data. Self-hosted infrastructure, no tracking pixels, GDPR compliant."
-  transition:animate="slide"
 >
   <!-- Header -->
   <section class="pt-24 pb-8 md:pt-28">

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -13,7 +13,6 @@ import { indieProjects } from "@data/indieProjects";
 <BaseLayout
   title="IndieHacker Projects"
   description="Check out the indie projects I'm currently working on."
-  transition:animate="slide"
 >
   <section class="py-24 md:py-28">
     <div class="site-container px-4">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -137,3 +137,26 @@
    here mirror the v3 `content.files` glob for clarity and to be safe in
    monorepo / virtual-file scenarios. */
 @source "../**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}";
+
+/* ---------- Cross-document view transitions (Baseline 2024) ----------
+   Native CSS-only replacement for Astro's ClientRouter SPA (issue #131).
+   Firefox view-transition support is incomplete and will degrade gracefully
+   to plain full-page navigation. */
+@view-transition {
+  navigation: auto;
+}
+
+/* Smooth fade transition for the main content swap */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.2s;
+  animation-timing-function: ease-out;
+}
+
+/* Respect reduced-motion preference */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary

Replaces Astro's `ClientRouter` SPA with native CSS-only cross-document view transitions (`@view-transition` at-rule, Baseline 2024). Per #131, the SPA soft-navigation was never working well in practice; full-page navigation is now the default, with an optional CSS-only fade between documents.

Closes #131

## What changed

**Removed:**
- `ClientRouter` import + usage in `src/layouts/BaseHead.astro`
- Theme-script `astro:after-swap` listener in `BaseHead.astro` (full-page nav re-runs the inline script automatically)
- `astro:before-preparation` / `astro:after-swap` listeners in `BaseLayout.astro` (only fired under ClientRouter)
- `.transition-ready.is-transitioning` CSS rule (dead code without SPA)
- `useViewTransitions` flag from `siteSettings.json.ts` + `SiteSettingsProps` type
- `transitionName` prop from `BlogLayoutCenter.astro` (unused after directive removal)
- `transition:animate` / `transition:name` / `transition:persist` directives across:
  - `src/components/Feature/FeatureFlagsMarquee.astro`
  - `src/components/Nav/Nav.astro`
  - `src/components/PostCard/PostCardAtlas.astro`
  - `src/components/Presentations/PresentationCard.astro`
  - `src/components/SiteLogo/SiteLogo.astro`
  - `src/layouts/BaseLayout.astro`
  - `src/layouts/BlogLayoutCenter.astro`
  - `src/pages/communities.astro`, `contact.astro`, `events/index.astro`, `newsletter.astro`, `podcasts.astro`, `presentations/[slug].astro`, `privacy.astro`, `projects.astro`

**Added** (to `src/styles/tailwind.css`):
```css
@view-transition { navigation: auto; }
::view-transition-old(root),
::view-transition-new(root) {
  animation-duration: 0.2s;
  animation-timing-function: ease-out;
}
@media (prefers-reduced-motion: reduce) {
  ::view-transition-old(root),
  ::view-transition-new(root) { animation: none; }
}
```

**Tests updated:** `BaseHead.test.ts` and `BaseLayout.test.ts` now assert the new behaviour (no transition directives on `<main>`, no `astro:after-swap` listener in the theme script, `@view-transition` CSS rules present).

## JS bundle delta

| | Total JS (bytes) | ClientRouter chunk |
| --- | --- | --- |
| master | 1,050,542 | 13,617 bytes (`ClientRouter.astro_*.js`) |
| this PR | 1,036,826 | — (not emitted) |
| Delta | **-13,716 bytes (-13.4 KB)** | — |

## Verification

- `npx astro check`: 0 errors, 0 warnings, 90 hints (unchanged)
- `npx vitest run`: 110/110 passing
- `npm run build`: succeeds
- `grep -rn 'astro-route-announcer\|astro-view-transitions\|ClientRouter' dist/`: empty
- `grep -l '@view-transition' dist/_astro/*.css`: `BaseLayout.*.css`, `Badge.*.css`
- prettier-clean on all touched files

## Notes & known limits

- **Firefox view-transition support is still incomplete.** Firefox will degrade gracefully to plain full-page navigation without the fade. Chromium and Safari (modern versions) get the cross-document fade.
- The `prefetch: { defaultStrategy: 'viewport' }` config in `astro.config.mjs` was left untouched — it benefits both SPA and full-nav modes.
- The `noise` keyframe animation and the `visibilitychange` listener (from #130) are preserved untouched.
- Several other components still have `astro:after-swap` listeners as setup-rewrap patterns. They become no-ops without ClientRouter but were left in place per the issue scope; they can be cleaned up in a follow-up.

## Test plan

- [ ] Verify build deploys cleanly to Netlify
- [ ] Hard-refresh in Chromium and confirm a brief root-level fade on cross-page navigation
- [ ] Hard-refresh in Firefox and confirm clean full-page navigation (no errors)
- [ ] Verify theme toggle still persists across navigations
- [ ] With `prefers-reduced-motion: reduce`, confirm no fade animation between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)