### PR TITLE
fix(css): card-wrapper anchors no longer inherit random underline

### DIFF
--- a/src/styles/components/links.scss
+++ b/src/styles/components/links.scss
@@ -1,20 +1,20 @@
 /* Link Colors - Rosé Pine accent palette */
 :root {
   /* Light mode colors (Dawn variant) */
-  --link-love-light: #b4637a;      /* love (Dawn) - reds/errors */
-  --link-gold-light: #ea9d34;      /* gold (Dawn) - yellows/warnings */
-  --link-rose-light: #d7827e;      /* rose (Dawn) - highlights */
-  --link-pine-light: #286983;      /* pine (Dawn) - greens/keywords */
-  --link-foam-light: #56949f;      /* foam (Dawn) - blues/information */
-  --link-iris-light: #907aa9;      /* iris (Dawn) - magentas/hints */
+  --link-love-light: #b4637a; /* love (Dawn) - reds/errors */
+  --link-gold-light: #ea9d34; /* gold (Dawn) - yellows/warnings */
+  --link-rose-light: #d7827e; /* rose (Dawn) - highlights */
+  --link-pine-light: #286983; /* pine (Dawn) - greens/keywords */
+  --link-foam-light: #56949f; /* foam (Dawn) - blues/information */
+  --link-iris-light: #907aa9; /* iris (Dawn) - magentas/hints */
 
   /* Dark mode colors (Main variant) */
-  --link-love-dark: #eb6f92;       /* love (Main) */
-  --link-gold-dark: #f6c177;       /* gold (Main) */
-  --link-rose-dark: #ebbcba;       /* rose (Main) */
-  --link-pine-dark: #31748f;       /* pine (Main) */
-  --link-foam-dark: #9ccfd8;       /* foam (Main) */
-  --link-iris-dark: #c4a7e7;       /* iris (Main) */
+  --link-love-dark: #eb6f92; /* love (Main) */
+  --link-gold-dark: #f6c177; /* gold (Main) */
+  --link-rose-dark: #ebbcba; /* rose (Main) */
+  --link-pine-dark: #31748f; /* pine (Main) */
+  --link-foam-dark: #9ccfd8; /* foam (Main) */
+  --link-iris-dark: #c4a7e7; /* iris (Main) */
 }
 
 /* Base link styling */
@@ -33,7 +33,7 @@ a:not(
   .site-content *,
   .services-icon a,
   .services-icon *,
-  [class*="group flex h-full"],
+  .group.flex.h-full, /* order-independent — Tailwind v4 may sort dark: variants between these */
   .linkedin-cta a,
   .content-type-selector a,
   [class*="bg-primary-"],
@@ -50,10 +50,10 @@ a:not(
   text-decoration: underline;
   text-decoration-thickness: 0.2em;
   text-underline-offset: 0.1em;
-  
+
   /* Default color that will be overridden by JS */
   text-decoration-color: transparent;
-  
+
   &:hover {
     @apply opacity-80;
   }
@@ -73,7 +73,7 @@ footer a,
 .site-content *,
 .services-icon a,
 .services-icon *,
-[class*="group flex h-full"],
+.group.flex.h-full, /* order-independent — Tailwind v4 may sort dark: variants between these */
 .linkedin-cta a,
 .content-type-selector a,
 [class*="bg-primary-"],
@@ -89,7 +89,12 @@ footer a,
 }
 
 /* Heading links inherit heading styles but keep underline */
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   a {
     @apply text-base-900 dark:text-base-100;
   }

--- a/src/styles/components/random-link-colors.scss
+++ b/src/styles/components/random-link-colors.scss
@@ -21,7 +21,7 @@ a:not(
   .site-content *,
   .services-icon a,
   .services-icon *,
-  [class*="group flex h-full"],
+  .group.flex.h-full, /* order-independent — Tailwind v4 may sort dark: variants between these */
   .linkedin-cta a,
   .content-type-selector a,
   [class*="bg-primary-"],
@@ -35,12 +35,24 @@ a:not(
   [class*="rounded-full"],
   .no-random-underline
 ) {
-  &:nth-of-type(6n + 1) { text-decoration-color: var(--link-love-light); }
-  &:nth-of-type(6n + 2) { text-decoration-color: var(--link-gold-light); }
-  &:nth-of-type(6n + 3) { text-decoration-color: var(--link-rose-light); }
-  &:nth-of-type(6n + 4) { text-decoration-color: var(--link-pine-light); }
-  &:nth-of-type(6n + 5) { text-decoration-color: var(--link-foam-light); }
-  &:nth-of-type(6n + 6) { text-decoration-color: var(--link-iris-light); }
+  &:nth-of-type(6n + 1) {
+    text-decoration-color: var(--link-love-light);
+  }
+  &:nth-of-type(6n + 2) {
+    text-decoration-color: var(--link-gold-light);
+  }
+  &:nth-of-type(6n + 3) {
+    text-decoration-color: var(--link-rose-light);
+  }
+  &:nth-of-type(6n + 4) {
+    text-decoration-color: var(--link-pine-light);
+  }
+  &:nth-of-type(6n + 5) {
+    text-decoration-color: var(--link-foam-light);
+  }
+  &:nth-of-type(6n + 6) {
+    text-decoration-color: var(--link-iris-light);
+  }
 }
 
 /* Dark mode (Main variants) ------------------------------------------- */
@@ -60,7 +72,7 @@ a:not(
   .site-content *,
   .services-icon a,
   .services-icon *,
-  [class*="group flex h-full"],
+  .group.flex.h-full, /* order-independent — Tailwind v4 may sort dark: variants between these */
   .linkedin-cta a,
   .content-type-selector a,
   [class*="bg-primary-"],
@@ -74,10 +86,22 @@ a:not(
   [class*="rounded-full"],
   .no-random-underline
 ) {
-  &:nth-of-type(6n + 1) { text-decoration-color: var(--link-love-dark); }
-  &:nth-of-type(6n + 2) { text-decoration-color: var(--link-gold-dark); }
-  &:nth-of-type(6n + 3) { text-decoration-color: var(--link-rose-dark); }
-  &:nth-of-type(6n + 4) { text-decoration-color: var(--link-pine-dark); }
-  &:nth-of-type(6n + 5) { text-decoration-color: var(--link-foam-dark); }
-  &:nth-of-type(6n + 6) { text-decoration-color: var(--link-iris-dark); }
+  &:nth-of-type(6n + 1) {
+    text-decoration-color: var(--link-love-dark);
+  }
+  &:nth-of-type(6n + 2) {
+    text-decoration-color: var(--link-gold-dark);
+  }
+  &:nth-of-type(6n + 3) {
+    text-decoration-color: var(--link-rose-dark);
+  }
+  &:nth-of-type(6n + 4) {
+    text-decoration-color: var(--link-pine-dark);
+  }
+  &:nth-of-type(6n + 5) {
+    text-decoration-color: var(--link-foam-dark);
+  }
+  &:nth-of-type(6n + 6) {
+    text-decoration-color: var(--link-iris-dark);
+  }
 }


### PR DESCRIPTION
## What broke
After #161 (Tailwind v4 migration), prettier-plugin-tailwindcss reordered the anchor class list on `ContentCard` and `ServiceCardIcon`:
- Before: `"group flex h-full ... dark:hover:bg-base-900"`
- After:  `"group dark:hover:bg-base-900 flex h-full ..."`

The links.scss + random-link-colors.scss exclusion lists relied on `[class*="group flex h-full"]` — a brittle substring match. With `dark:` variants inserted between "group" and "flex", the substring no longer matched, and every card-wrapping `<a>` started inheriting the random Rose Pine underline through its h3 + paragraph + button contents.

## Fix
Replace the substring selector with the order-independent class-combo selector `.group.flex.h-full` in all 4 places where it appears (light + dark inclusion rules in random-link-colors.scss, plus the base + override rules in links.scss).

Class-combo selectors match whenever all three classes are present regardless of order — they're immune to Tailwind v4's class sorting.

## Affected components (confirmed by audit)
- `src/components/SiteContent/ContentCard.astro` (homepage Resources cards — the reported regression)
- `src/components/ServiceCard/ServiceCardIcon.astro` (services page)

Both grep-confirmed: `<a>` with both `group` and `h-full` in class list.

## Verification
- `npx astro check` → clean
- Built CSS now contains `.group.flex.h-full` in the exclusion
- Visually: card content text reverts to plain (no underline)