### PR TITLE
feat(ama): submit endpoint with Telegram delivery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@astrojs/sitemap": "^3.7.1",
         "@atproto/api": "^0.20.0",
         "@iconify-json/tabler": "^1.2.35",
+        "@netlify/blobs": "^10.7.8",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/postcss": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@astrojs/sitemap": "^3.7.1",
     "@atproto/api": "^0.20.0",
     "@iconify-json/tabler": "^1.2.35",
+    "@netlify/blobs": "^10.7.8",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.3.0",

--- a/src/pages/ama.astro
+++ b/src/pages/ama.astro
@@ -224,35 +224,67 @@ const description =
     });
   }
 
-  // ── Form submit (stubbed until backend lands) ─────────────────────────
+  // ── Form submit ───────────────────────────────────────────────────────
   const form = document.getElementById("ama-form");
   const status = document.getElementById("ama-status");
   const formSection = document.getElementById("ama-form-section");
   const successSection = document.getElementById("ama-success");
+  const submitBtn = form && form.querySelector('button[type="submit"]');
+
+  function setError(msg) {
+    if (!status) return;
+    status.textContent = msg;
+    status.className = "ama-status text-sm text-red-600 dark:text-red-400";
+  }
 
   if (form) {
-    form.addEventListener("submit", (e) => {
+    form.addEventListener("submit", async (e) => {
       e.preventDefault();
       if (!status || !textarea) return;
+      status.textContent = "";
 
       const q = textarea.value.trim();
       if (q.length < 10) {
-        status.textContent = "A bit too short — give me a few more words.";
-        status.className = "ama-status text-sm text-red-600 dark:text-red-400";
+        setError("A bit too short — give me a few more words.");
         return;
       }
       if (/(https?:\/\/|www\.)/i.test(q)) {
-        status.textContent = "Links aren't allowed in questions.";
-        status.className = "ama-status text-sm text-red-600 dark:text-red-400";
+        setError("Links aren't allowed in questions.");
         return;
       }
 
-      // STUB: backend wiring lands in a follow-up PR. For now, immediately
-      // pretend success so the UI flow is testable end-to-end.
-      if (formSection) formSection.classList.add("hidden");
-      if (successSection) {
-        successSection.classList.remove("hidden");
-        successSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      const altchaInput = form.querySelector('input[name="altcha"]');
+      const altchaSolution = altchaInput && altchaInput.value;
+      if (!altchaSolution) {
+        setError("Please wait for verification to complete, then try again.");
+        return;
+      }
+
+      if (submitBtn) submitBtn.setAttribute("disabled", "true");
+      status.textContent = "Sending…";
+      status.className = "ama-status text-sm text-base-600 dark:text-base-400";
+
+      try {
+        const res = await fetch("/api/ama/submit", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ question: q, altcha: altchaSolution }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok || !data.ok) {
+          setError(data.error || "Something went wrong. Try again.");
+          if (submitBtn) submitBtn.removeAttribute("disabled");
+          return;
+        }
+        if (formSection) formSection.classList.add("hidden");
+        if (successSection) {
+          successSection.classList.remove("hidden");
+          successSection.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      } catch (err) {
+        console.error("AMA submit failed:", err);
+        setError("Network error — please try again.");
+        if (submitBtn) submitBtn.removeAttribute("disabled");
       }
     });
   }

--- a/src/pages/api/ama/submit.ts
+++ b/src/pages/api/ama/submit.ts
@@ -1,0 +1,145 @@
+/**
+ * AMA submission endpoint.
+ *
+ * Pipeline: validate → altcha verify → rate-limit (per IP-hash) → render
+ * question card PNG → store metadata in Netlify Blobs → push to Telegram
+ * via sendPhoto with a signed admin-link in the caption.
+ *
+ * Returns { ok: true } on success, or { error: string } with 4xx/5xx.
+ */
+import type { APIRoute } from "astro";
+import { verifySolution } from "altcha-lib";
+import { getStore } from "@netlify/blobs";
+import crypto from "node:crypto";
+import { renderAmaCard } from "../../../lib/ama/render";
+
+export const prerender = false;
+
+const MIN_LEN = 10;
+const MAX_LEN = 500;
+
+// 5 questions per IP per rolling hour is plenty for legitimate use and
+// keeps a single botnet node from filling the Telegram chat.
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_MAX = 5;
+
+function hmac(secret: string, input: string): string {
+  return crypto.createHmac("sha256", secret).update(input).digest("hex");
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+export const POST: APIRoute = async ({ request, clientAddress }) => {
+  try {
+    const body = (await request.json().catch(() => ({}))) as {
+      question?: unknown;
+      altcha?: unknown;
+    };
+    const question =
+      typeof body.question === "string" ? body.question.trim() : "";
+    const altcha = typeof body.altcha === "string" ? body.altcha : undefined;
+
+    if (question.length < MIN_LEN || question.length > MAX_LEN) {
+      return json({ error: "Question must be 10–500 characters." }, 400);
+    }
+    if (/(https?:\/\/|www\.)/i.test(question)) {
+      return json({ error: "Links aren't allowed in questions." }, 400);
+    }
+
+    const altchaKey = process.env.ALTCHA_HMAC_KEY;
+    if (altchaKey) {
+      if (!altcha) {
+        return json({ error: "Verification required. Please refresh." }, 400);
+      }
+      const valid = await verifySolution(altcha, altchaKey).catch(() => false);
+      if (!valid) {
+        return json({ error: "Verification failed. Please refresh." }, 400);
+      }
+    }
+
+    const signingSecret = process.env.AMA_SIGNING_SECRET;
+    if (!signingSecret) {
+      console.error("AMA_SIGNING_SECRET not configured");
+      return json({ error: "Server misconfigured." }, 500);
+    }
+
+    // IP-hash: never store raw IPs. The hash is salted with the signing
+    // secret so it can't be reversed via rainbow tables of common IPs.
+    const ip = clientAddress || "0.0.0.0";
+    const ipHash = hmac(signingSecret, `ip:${ip}`).slice(0, 24);
+
+    const rl = getStore("ama-ratelimit");
+    const prev = (await rl.get(ipHash, { type: "json" })) as {
+      count: number;
+      first: number;
+    } | null;
+    const now = Date.now();
+    if (prev && now - prev.first < RATE_LIMIT_WINDOW_MS) {
+      if (prev.count >= RATE_LIMIT_MAX) {
+        return json(
+          { error: "Too many questions — try again in an hour." },
+          429,
+        );
+      }
+      await rl.setJSON(ipHash, { count: prev.count + 1, first: prev.first });
+    } else {
+      await rl.setJSON(ipHash, { count: 1, first: now });
+    }
+
+    const id = crypto.randomBytes(8).toString("hex");
+    const png = await renderAmaCard(question);
+
+    await getStore("ama-questions").setJSON(id, {
+      id,
+      question,
+      createdAt: new Date().toISOString(),
+      ipHash,
+    });
+
+    const botToken = process.env.TELEGRAM_BOT_TOKEN;
+    const chatId = process.env.TELEGRAM_CHAT_ID;
+    if (botToken && chatId) {
+      const adminToken = hmac(signingSecret, `admin:${id}`).slice(0, 16);
+      const adminUrl = `https://gui.do/ama/q/${id}?t=${adminToken}`;
+      // Telegram captions cap at 1024 chars; question is ≤500 so plenty of room.
+      const caption = `New AMA question:\n\n"${question}"\n\nAdmin: ${adminUrl}`;
+
+      const form = new FormData();
+      form.append("chat_id", chatId);
+      form.append("caption", caption);
+      form.append(
+        "photo",
+        new Blob([new Uint8Array(png)], { type: "image/png" }),
+        `ama-${id}.png`,
+      );
+
+      const tgRes = await fetch(
+        `https://api.telegram.org/bot${botToken}/sendPhoto`,
+        { method: "POST", body: form },
+      );
+      if (!tgRes.ok) {
+        console.error(
+          "Telegram sendPhoto failed:",
+          tgRes.status,
+          await tgRes.text().catch(() => "<no body>"),
+        );
+        // Don't 500 the submitter — the question is stored, we can retry
+        // delivery later from the admin side.
+      }
+    } else {
+      console.warn(
+        "Telegram credentials not set — question stored but not delivered.",
+      );
+    }
+
+    return json({ ok: true, id });
+  } catch (e) {
+    console.error("AMA submit error:", e);
+    return json({ error: "Something went wrong. Try again." }, 500);
+  }
+};


### PR DESCRIPTION
## Summary
- New `POST /api/ama/submit` endpoint: validate → altcha verify → rate-limit (5/hour per IP-hash, Netlify Blobs) → render PNG → Telegram `sendPhoto`
- Replaces the stub in `/ama` with a real fetch + altcha solution wiring
- Stores question metadata in Netlify Blobs so a future admin page can reroll/delete

## Netlify env vars required
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`
- `AMA_SIGNING_SECRET`
- (`ALTCHA_HMAC_KEY` already present)

## Test plan
- [ ] Submit a valid question from the deploy preview's `/ama` — Telegram chat receives a photo with the rendered card + admin link in caption
- [ ] Submit a question containing a URL → 400 with link-blocked message
- [ ] Submit 6 questions in <1h from the same IP → 6th returns 429
- [ ] Submit without solved altcha → 400

## Out of scope
- Admin edit page at `/ama/q/[id]` (reroll variant/persona, delete) — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)