### PR TITLE
fix(ama): unbreak SSR routing + honest copy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -66,11 +66,11 @@
   to = "/.well-known/:splat"
   status = 200
 
-# Function handling (keep this last)
-[[redirects]]
-  from = "/*"
-  to = "/.netlify/functions/entry"
-  status = 200
+# SSR routing is handled by the @astrojs/netlify adapter via its v2
+# function in .netlify/v1/functions/ssr (declared path: "/*",
+# preferStatic: true). A previous catch-all here pointed at a
+# non-existent /.netlify/functions/entry, which silently 404'd every
+# dynamic route once SSR endpoints landed in /api/.
 
 # Content Security Policy headers
 [[headers]]

--- a/src/lib/ama/render.ts
+++ b/src/lib/ama/render.ts
@@ -4,14 +4,17 @@
    renders don't re-read them.
    ===================================================================== */
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import satori from "satori";
 import { Resvg } from "@resvg/resvg-js";
 import { AmaCard, type Persona, type Variant } from "./card";
 import { OgFeedStack } from "./og";
 
-const fontDir = join(dirname(fileURLToPath(import.meta.url)), "fonts");
+// import.meta.url points at the bundled chunk path on Netlify (e.g.
+// .netlify/build/chunks/render_XXX.mjs), not at src/lib/ama/render.ts.
+// Resolve from the function's working directory instead — the adapter
+// sets includedFiles:['**/*'] so the project tree is present at runtime.
+const fontDir = join(process.cwd(), "src/lib/ama/fonts");
 
 const fonts = [
   {

--- a/src/pages/ama.astro
+++ b/src/pages/ama.astro
@@ -89,9 +89,10 @@ const description =
           </div>
 
           <p class="text-base-500 dark:text-base-400 text-xs">
-            URLs and questions over 500 characters are blocked. Submitting
-            doesn't store an email, name, or IP address — only a short-lived
-            hash for rate limiting.
+            URLs and questions over 500 characters are blocked. There's no email
+            or name field, and your IP isn't stored (just a short-lived hash for
+            rate limiting). Whatever you type in the question is stored as-is,
+            so leave personal info out.
           </p>
 
           <div
@@ -127,7 +128,7 @@ const description =
             <path d="M5 12l5 5L20 7"></path>
           </svg>
         </div>
-        <h2 class="h2 mb-3">Thanks — your question is in.</h2>
+        <h2 class="h2 mb-3">Thanks, your question is in.</h2>
         <p class="description mb-8 text-base md:text-lg">
           I answer on Bluesky. Follow me there to see the reply when it lands.
         </p>
@@ -192,7 +193,7 @@ const description =
           id="ama-feed-empty"
           class="text-base-500 dark:text-base-400 hidden text-center text-sm"
         >
-          No answered questions yet — yours could be the first.
+          No answered questions yet. Yours could be the first.
         </div>
       </div>
     </div>
@@ -245,7 +246,7 @@ const description =
 
       const q = textarea.value.trim();
       if (q.length < 10) {
-        setError("A bit too short — give me a few more words.");
+        setError("A bit too short. Give me a few more words.");
         return;
       }
       if (/(https?:\/\/|www\.)/i.test(q)) {
@@ -283,7 +284,7 @@ const description =
         }
       } catch (err) {
         console.error("AMA submit failed:", err);
-        setError("Network error — please try again.");
+        setError("Network error. Please try again.");
         if (submitBtn) submitBtn.removeAttribute("disabled");
       }
     });

--- a/src/pages/ama.astro
+++ b/src/pages/ama.astro
@@ -92,7 +92,8 @@ const description =
             URLs and questions over 500 characters are blocked. There's no email
             or name field, and your IP isn't stored (just a short-lived hash for
             rate limiting). Whatever you type in the question is stored as-is,
-            so leave personal info out.
+            so leave out any (personal) info you don't want shared in the public
+            answer.
           </p>
 
           <div

--- a/src/pages/ama.astro
+++ b/src/pages/ama.astro
@@ -267,7 +267,10 @@ const description =
       status.className = "ama-status text-sm text-base-600 dark:text-base-400";
 
       try {
-        const res = await fetch("/api/ama/submit", {
+        // Trailing slash matters: netlify.toml redirects extension-less
+        // paths to /...path/, which a browser follows as GET and 404s our
+        // POST handler. recent.json is exempted because it has an extension.
+        const res = await fetch("/api/ama/submit/", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ question: q, altcha: altchaSolution }),

--- a/src/pages/api/ama/submit.ts
+++ b/src/pages/api/ama/submit.ts
@@ -82,7 +82,7 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     if (prev && now - prev.first < RATE_LIMIT_WINDOW_MS) {
       if (prev.count >= RATE_LIMIT_MAX) {
         return json(
-          { error: "Too many questions — try again in an hour." },
+          { error: "Too many questions. Try again in an hour." },
           429,
         );
       }


### PR DESCRIPTION
## Summary
- Removed the broken catch-all redirect in `netlify.toml` that pointed every dynamic route at `/.netlify/functions/entry` (a function that has never existed). Static pages were unaffected because the trailing-slash redirect runs first with `force=false`, but every `/api/ama/*` SSR route landed in #173/#174 was silently 404'ing. The Netlify v2 SSR function declares its own `path:"/*"` so the catch-all isn't needed.
- Rewrote the privacy line under the form. The old wording said we don't store name/email/IP — true for our form fields, but misleading once someone types those into the question itself.
- Stripped em-dashes from user-facing strings (success heading, empty state, validation messages, rate-limit error).

## Test plan
- [ ] On the deploy preview, `curl -I /api/ama/recent.json` returns 200 (not 404)
- [ ] Submit a question from `/ama` → Telegram receives it
- [ ] Recently-answered feed loads (or shows empty state if no #ama posts yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)