### PR TITLE
feat(ama): admin view at /ama/q/[id]

### DIFF
--- a/src/pages/ama/q/[id].astro
+++ b/src/pages/ama/q/[id].astro
@@ -1,0 +1,148 @@
+---
+/**
+ * AMA admin view for a single question.
+ *
+ * Token-gated (HMAC of `admin:<id>` against AMA_SIGNING_SECRET, shipped in
+ * the Telegram deep-link). Lets Guido see the question, view/download the
+ * rendered card, reroll the variant or persona if the deterministic pick
+ * landed poorly, and delete spam.
+ *
+ * GET renders the page; POST to the sibling action endpoint mutates the
+ * stored question and redirects back here.
+ */
+export const prerender = false;
+
+import BaseLayout from "@layouts/BaseLayout.astro";
+import Button from "@components/Button/Button.astro";
+import { getStore } from "@netlify/blobs";
+import crypto from "node:crypto";
+import { renderAmaCard, type RenderOverrides } from "../../../lib/ama/render";
+import { variants, personas } from "../../../lib/ama/card";
+
+const id = Astro.params.id;
+const token = Astro.url.searchParams.get("t") ?? "";
+const secret = process.env.AMA_SIGNING_SECRET;
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
+
+if (!id || !secret) {
+  return new Response("Not found", { status: 404 });
+}
+
+const expectedToken = crypto
+  .createHmac("sha256", secret)
+  .update(`admin:${id}`)
+  .digest("hex")
+  .slice(0, 16);
+
+if (!constantTimeEqual(token, expectedToken)) {
+  return new Response("Forbidden", { status: 403 });
+}
+
+type StoredQuestion = {
+  id: string;
+  question: string;
+  createdAt: string;
+  ipHash?: string;
+  variantId?: string;
+  personaName?: string;
+};
+
+const store = getStore("ama-questions");
+const data = (await store.get(id, { type: "json" })) as StoredQuestion | null;
+
+if (!data) {
+  return new Response("Question not found or deleted.", { status: 404 });
+}
+
+const variantOverride = data.variantId
+  ? variants.find((v) => v.id === data.variantId)
+  : undefined;
+const personaOverride = data.personaName
+  ? personas.find((p) => p.name === data.personaName)
+  : undefined;
+
+const overrides: RenderOverrides = {
+  variant: variantOverride,
+  persona: personaOverride,
+};
+
+const png = await renderAmaCard(data.question, overrides);
+const dataUrl = `data:image/png;base64,${png.toString("base64")}`;
+
+const submittedAt = new Date(data.createdAt).toLocaleString("en-GB", {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const actionUrl = `/api/ama/q/${id}/action/?t=${encodeURIComponent(token)}`;
+const description = "Admin view for a submitted AMA question.";
+---
+
+<BaseLayout title="AMA admin" description={description} noindex>
+  <section class="pt-24 pb-16 md:pt-28">
+    <div class="site-container mx-auto max-w-3xl px-4">
+      <p
+        class="text-base-500 dark:text-base-400 mb-2 text-xs tracking-wide uppercase"
+      >
+        AMA admin
+      </p>
+      <h1 class="h2 mb-1">Question</h1>
+      <p class="text-base-500 dark:text-base-400 mb-4 text-xs">
+        Submitted {submittedAt} · ID {data.id}
+      </p>
+
+      <blockquote
+        class="border-primary-300 dark:border-primary-700 bg-base-50/60 dark:bg-base-900/40 mb-6 rounded-lg border-l-4 p-4 text-lg"
+      >
+        {data.question}
+      </blockquote>
+
+      <img
+        src={dataUrl}
+        alt="Rendered AMA question card"
+        width="1200"
+        height="630"
+        class="border-base-300 dark:border-base-700 mb-6 w-full rounded-xl border"
+      />
+
+      <div class="flex flex-wrap gap-3">
+        <form method="POST" action={actionUrl} class="contents">
+          <input type="hidden" name="action" value="reroll-variant" />
+          <Button type="submit" variant="outline">Reroll colors</Button>
+        </form>
+        <form method="POST" action={actionUrl} class="contents">
+          <input type="hidden" name="action" value="reroll-persona" />
+          <Button type="submit" variant="outline">Reroll persona</Button>
+        </form>
+        <a
+          href={dataUrl}
+          download={`ama-${data.id}.png`}
+          class="border-base-300 dark:border-base-700 hover:bg-base-100 dark:hover:bg-base-800 inline-flex items-center rounded-full border px-4 py-2 text-sm font-medium"
+        >
+          Download card
+        </a>
+        <form method="POST" action={actionUrl} class="contents">
+          <input type="hidden" name="action" value="delete" />
+          <button
+            type="submit"
+            class="inline-flex items-center rounded-full border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-300 dark:hover:bg-red-950/40"
+          >
+            Delete
+          </button>
+        </form>
+      </div>
+
+      <p class="text-base-500 dark:text-base-400 mt-6 text-xs">
+        Reroll cycles to the next entry in the list. Delete is permanent.
+      </p>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/api/ama/q/[id]/action.ts
+++ b/src/pages/api/ama/q/[id]/action.ts
@@ -1,0 +1,112 @@
+/**
+ * Admin action endpoint for a single AMA question.
+ *
+ * POST with a form field `action` of "reroll-variant" | "reroll-persona" |
+ * "delete". Gated by the same HMAC token as the view page. Redirects back
+ * to the view on success.
+ */
+import type { APIRoute } from "astro";
+import { getStore } from "@netlify/blobs";
+import crypto from "node:crypto";
+import {
+  variants,
+  personas,
+  pickVariant,
+  pickPersona,
+} from "../../../../../lib/ama/card";
+
+export const prerender = false;
+
+type StoredQuestion = {
+  id: string;
+  question: string;
+  createdAt: string;
+  ipHash?: string;
+  variantId?: string;
+  personaName?: string;
+};
+
+function constantTimeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
+  } catch {
+    return false;
+  }
+}
+
+function nextIndex<T>(items: T[], current: number): number {
+  return (current + 1) % items.length;
+}
+
+export const POST: APIRoute = async ({ params, request, url }) => {
+  const id = params.id;
+  const token = url.searchParams.get("t") ?? "";
+  const secret = process.env.AMA_SIGNING_SECRET;
+
+  if (!id || !secret) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(`admin:${id}`)
+    .digest("hex")
+    .slice(0, 16);
+
+  if (!constantTimeEqual(token, expected)) {
+    return new Response("Forbidden", { status: 403 });
+  }
+
+  const form = await request.formData();
+  const action = String(form.get("action") ?? "");
+
+  const store = getStore("ama-questions");
+  const data = (await store.get(id, { type: "json" })) as StoredQuestion | null;
+
+  if (!data) {
+    return new Response("Question not found.", { status: 404 });
+  }
+
+  const adminUrl = `/ama/q/${id}/?t=${encodeURIComponent(token)}`;
+
+  if (action === "delete") {
+    await store.delete(id);
+    return new Response(null, {
+      status: 303,
+      headers: { location: "/ama/" },
+    });
+  }
+
+  if (action === "reroll-variant") {
+    const currentVariant = data.variantId
+      ? variants.find((v) => v.id === data.variantId)
+      : pickVariant(data.question);
+    const currentIdx = variants.findIndex(
+      (v) => v.id === (currentVariant?.id ?? ""),
+    );
+    const nextVariant = variants[nextIndex(variants, currentIdx)];
+    await store.setJSON(id, { ...data, variantId: nextVariant.id });
+    return new Response(null, {
+      status: 303,
+      headers: { location: adminUrl },
+    });
+  }
+
+  if (action === "reroll-persona") {
+    const currentPersona = data.personaName
+      ? personas.find((p) => p.name === data.personaName)
+      : pickPersona(data.question);
+    const currentIdx = personas.findIndex(
+      (p) => p.name === (currentPersona?.name ?? ""),
+    );
+    const nextPersona = personas[nextIndex(personas, currentIdx)];
+    await store.setJSON(id, { ...data, personaName: nextPersona.name });
+    return new Response(null, {
+      status: 303,
+      headers: { location: adminUrl },
+    });
+  }
+
+  return new Response("Unknown action", { status: 400 });
+};


### PR DESCRIPTION
## Summary
- Resolves the dangling deep-link from the Telegram caption (introduced in #174)
- New token-gated page at `/ama/q/[id]` with the question, rendered card, and four actions: reroll colors, reroll persona, download, delete
- Reroll cycles through the variant/persona arrays in `card.tsx`. Overrides persist on the stored question so the rerolled pick survives page reloads.
- Card is base64-inlined into the page; no separate image endpoint needed.

## Auth
Same HMAC as the submit endpoint: `hmac(AMA_SIGNING_SECRET, "admin:<id>")` truncated to 16 chars. Constant-time compared.

## Test plan
- [ ] Submit a question, click the Telegram link, page loads
- [ ] Hit the page with a wrong/missing `t=` → 403
- [ ] Hit `/ama/q/<random>/?t=anything` → 403 / 404
- [ ] "Reroll colors" cycles the card to the next variant; persists on refresh
- [ ] "Reroll persona" cycles the persona
- [ ] "Download card" downloads the current PNG
- [ ] "Delete" removes the question and redirects to `/ama/`; re-hitting the link returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)