### PR TITLE
feat(ama): Telegram inline-keyboard regenerate + delete

### DIFF
--- a/src/lib/ama/card.tsx
+++ b/src/lib/ama/card.tsx
@@ -1527,6 +1527,23 @@ export function pickAdjective(persona: Persona, question: string): string {
   return persona.adjectives[idx];
 }
 
+/**
+ * Random pick for all three identity dimensions at once. Used by the
+ * admin Regenerate button and the Telegram inline-keyboard regenerate
+ * callback. The current pick may come up again — that's fine, just hit
+ * Regenerate again. Cheaper than tracking exclusions.
+ */
+export function pickRandomOverrides(): {
+  variantId: string;
+  personaName: string;
+  adjective: string;
+} {
+  const v = variants[Math.floor(Math.random() * variants.length)];
+  const p = personas[Math.floor(Math.random() * personas.length)];
+  const a = p.adjectives[Math.floor(Math.random() * p.adjectives.length)];
+  return { variantId: v.id, personaName: p.name, adjective: a };
+}
+
 // Different salt from the variant pick so persona and variant are
 // independent — same question stays stable across renders.
 export function pickPersona(question: string): Persona {

--- a/src/lib/ama/telegram.ts
+++ b/src/lib/ama/telegram.ts
@@ -1,0 +1,140 @@
+/**
+ * Telegram Bot API helpers for the AMA pipeline.
+ *
+ * Shared between the submit endpoint (initial sendPhoto) and the
+ * webhook callback endpoint (regenerate / delete from inline keyboard).
+ */
+import crypto from "node:crypto";
+
+const TG_API = "https://api.telegram.org";
+
+export function adminTokenFor(id: string, secret: string): string {
+  return crypto
+    .createHmac("sha256", secret)
+    .update(`admin:${id}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+export function adminUrlFor(id: string, token: string): string {
+  return `https://gui.do/ama/q/${id}?t=${token}`;
+}
+
+export function captionFor(question: string, adminUrl: string): string {
+  // Telegram captions cap at 1024 chars; question is ≤500 so plenty of room.
+  return `New AMA question:\n\n"${question}"\n\nAdmin: ${adminUrl}`;
+}
+
+/**
+ * Inline keyboard attached to every AMA photo message.
+ *
+ * Two callback buttons + one URL button:
+ * - Regenerate: tap to re-roll variant/persona/adjective and edit the
+ *   image in place (no new message).
+ * - Delete: tap to remove the question from the store and from the chat.
+ * - Open admin: opens /ama/q/[id] in a browser for download/manual work.
+ *
+ * callback_data must be ≤64 bytes; "regen:<8-hex-id>" = 14 bytes, fine.
+ */
+export function keyboardFor(id: string, adminUrl: string) {
+  return {
+    inline_keyboard: [
+      [
+        { text: "🎲 Regenerate", callback_data: `regen:${id}` },
+        { text: "🗑 Delete", callback_data: `delete:${id}` },
+      ],
+      [{ text: "Open admin →", url: adminUrl }],
+    ],
+  };
+}
+
+type SendPhotoArgs = {
+  botToken: string;
+  chatId: string;
+  png: Buffer;
+  caption: string;
+  filename: string;
+  keyboard: ReturnType<typeof keyboardFor>;
+};
+
+export async function sendPhoto(args: SendPhotoArgs): Promise<Response> {
+  const form = new FormData();
+  form.append("chat_id", args.chatId);
+  form.append("caption", args.caption);
+  form.append("reply_markup", JSON.stringify(args.keyboard));
+  form.append(
+    "photo",
+    new Blob([new Uint8Array(args.png)], { type: "image/png" }),
+    args.filename,
+  );
+  return fetch(`${TG_API}/bot${args.botToken}/sendPhoto`, {
+    method: "POST",
+    body: form,
+  });
+}
+
+type EditPhotoArgs = {
+  botToken: string;
+  chatId: number | string;
+  messageId: number;
+  png: Buffer;
+  caption: string;
+  filename: string;
+  keyboard: ReturnType<typeof keyboardFor>;
+};
+
+/**
+ * Replace the photo on an existing message in place.
+ * Telegram requires the new media to be re-uploaded via multipart with
+ * an attach:// reference from the InputMediaPhoto JSON.
+ */
+export async function editMessageMedia(args: EditPhotoArgs): Promise<Response> {
+  const form = new FormData();
+  form.append("chat_id", String(args.chatId));
+  form.append("message_id", String(args.messageId));
+  form.append(
+    "media",
+    JSON.stringify({
+      type: "photo",
+      media: "attach://photo",
+      caption: args.caption,
+    }),
+  );
+  form.append("reply_markup", JSON.stringify(args.keyboard));
+  form.append(
+    "photo",
+    new Blob([new Uint8Array(args.png)], { type: "image/png" }),
+    args.filename,
+  );
+  return fetch(`${TG_API}/bot${args.botToken}/editMessageMedia`, {
+    method: "POST",
+    body: form,
+  });
+}
+
+export async function deleteMessage(
+  botToken: string,
+  chatId: number | string,
+  messageId: number,
+): Promise<Response> {
+  return fetch(`${TG_API}/bot${botToken}/deleteMessage`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, message_id: messageId }),
+  });
+}
+
+export async function answerCallbackQuery(
+  botToken: string,
+  callbackQueryId: string,
+  text?: string,
+): Promise<Response> {
+  return fetch(`${TG_API}/bot${botToken}/answerCallbackQuery`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      callback_query_id: callbackQueryId,
+      text: text ?? "",
+    }),
+  });
+}

--- a/src/pages/api/ama/q/[id]/action.ts
+++ b/src/pages/api/ama/q/[id]/action.ts
@@ -8,7 +8,7 @@
 import type { APIRoute } from "astro";
 import { getStore } from "@netlify/blobs";
 import crypto from "node:crypto";
-import { variants, personas } from "../../../../../lib/ama/card";
+import { pickRandomOverrides } from "../../../../../lib/ama/card";
 
 export const prerender = false;
 
@@ -29,10 +29,6 @@ function constantTimeEqual(a: string, b: string): boolean {
   } catch {
     return false;
   }
-}
-
-function pickRandom<T>(items: readonly T[]): T {
-  return items[Math.floor(Math.random() * items.length)];
 }
 
 export const POST: APIRoute = async ({ params, request, url }) => {
@@ -75,19 +71,7 @@ export const POST: APIRoute = async ({ params, request, url }) => {
   }
 
   if (action === "regenerate") {
-    // Random pick for all three. The current pick may come up again
-    // for any individual dimension — that's fine, just hit Regenerate
-    // again. Cheaper than tracking exclusions and the user already has
-    // the feedback loop right here.
-    const nextVariant = pickRandom(variants);
-    const nextPersona = pickRandom(personas);
-    const nextAdjective = pickRandom(nextPersona.adjectives);
-    await store.setJSON(id, {
-      ...data,
-      variantId: nextVariant.id,
-      personaName: nextPersona.name,
-      adjective: nextAdjective,
-    });
+    await store.setJSON(id, { ...data, ...pickRandomOverrides() });
     return new Response(null, {
       status: 303,
       headers: { location: adminUrl },

--- a/src/pages/api/ama/submit.ts
+++ b/src/pages/api/ama/submit.ts
@@ -12,6 +12,13 @@ import { verifySolution } from "altcha-lib";
 import { getStore } from "@netlify/blobs";
 import crypto from "node:crypto";
 import { renderAmaCard } from "../../../lib/ama/render";
+import {
+  adminTokenFor,
+  adminUrlFor,
+  captionFor,
+  keyboardFor,
+  sendPhoto,
+} from "../../../lib/ama/telegram";
 
 export const prerender = false;
 
@@ -104,24 +111,16 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
     const botToken = process.env.TELEGRAM_BOT_TOKEN;
     const chatId = process.env.TELEGRAM_CHAT_ID;
     if (botToken && chatId) {
-      const adminToken = hmac(signingSecret, `admin:${id}`).slice(0, 16);
-      const adminUrl = `https://gui.do/ama/q/${id}?t=${adminToken}`;
-      // Telegram captions cap at 1024 chars; question is ≤500 so plenty of room.
-      const caption = `New AMA question:\n\n"${question}"\n\nAdmin: ${adminUrl}`;
-
-      const form = new FormData();
-      form.append("chat_id", chatId);
-      form.append("caption", caption);
-      form.append(
-        "photo",
-        new Blob([new Uint8Array(png)], { type: "image/png" }),
-        `ama-${id}.png`,
-      );
-
-      const tgRes = await fetch(
-        `https://api.telegram.org/bot${botToken}/sendPhoto`,
-        { method: "POST", body: form },
-      );
+      const token = adminTokenFor(id, signingSecret);
+      const adminUrl = adminUrlFor(id, token);
+      const tgRes = await sendPhoto({
+        botToken,
+        chatId,
+        png,
+        caption: captionFor(question, adminUrl),
+        filename: `ama-${id}.png`,
+        keyboard: keyboardFor(id, adminUrl),
+      });
       if (!tgRes.ok) {
         console.error(
           "Telegram sendPhoto failed:",

--- a/src/pages/api/ama/telegram-callback.ts
+++ b/src/pages/api/ama/telegram-callback.ts
@@ -1,0 +1,156 @@
+/**
+ * Telegram webhook for AMA inline-keyboard callbacks.
+ *
+ * Receives `callback_query` updates when Guido taps [Regenerate] or
+ * [Delete] on an AMA message. Validates the secret header set during
+ * setWebhook, mutates state via the same code paths as the web admin
+ * (pickRandomOverrides + blob store), edits the photo in place via
+ * editMessageMedia, then answers the callback to dismiss the loading
+ * spinner in the Telegram client.
+ *
+ * One-time setup (after deploying):
+ *
+ *   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+ *     -d "url=https://gui.do/api/ama/telegram-callback/" \
+ *     -d "secret_token=<SECRET>" \
+ *     -d 'allowed_updates=["callback_query"]'
+ *
+ * Where <SECRET> matches the Netlify env var TELEGRAM_WEBHOOK_SECRET.
+ */
+import type { APIRoute } from "astro";
+import { getStore } from "@netlify/blobs";
+import { pickRandomOverrides, variants, personas } from "../../../lib/ama/card";
+import { renderAmaCard, type RenderOverrides } from "../../../lib/ama/render";
+import {
+  adminTokenFor,
+  adminUrlFor,
+  captionFor,
+  keyboardFor,
+  editMessageMedia,
+  deleteMessage,
+  answerCallbackQuery,
+} from "../../../lib/ama/telegram";
+
+export const prerender = false;
+
+type StoredQuestion = {
+  id: string;
+  question: string;
+  createdAt: string;
+  ipHash?: string;
+  variantId?: string;
+  personaName?: string;
+  adjective?: string;
+};
+
+type CallbackQuery = {
+  id: string;
+  message?: {
+    message_id: number;
+    chat: { id: number | string };
+  };
+  data?: string;
+};
+
+type Update = {
+  callback_query?: CallbackQuery;
+};
+
+function ok(): Response {
+  // Telegram only checks 2xx; body is ignored.
+  return new Response("ok", { status: 200 });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN;
+  const signingSecret = process.env.AMA_SIGNING_SECRET;
+  const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  if (!botToken || !signingSecret || !webhookSecret) {
+    console.error("Telegram callback missing env vars");
+    return new Response("misconfigured", { status: 500 });
+  }
+
+  // Telegram sets this header on every webhook call when secret_token
+  // was passed to setWebhook. Defends against random POSTs to the URL.
+  const headerSecret = request.headers.get("x-telegram-bot-api-secret-token");
+  if (headerSecret !== webhookSecret) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const update = (await request.json().catch(() => ({}))) as Update;
+  const cq = update.callback_query;
+  if (!cq || !cq.data || !cq.message) {
+    // Not a callback we handle — ack so Telegram stops retrying.
+    return ok();
+  }
+
+  const [action, id] = cq.data.split(":");
+  if (!action || !id) {
+    await answerCallbackQuery(botToken, cq.id, "Invalid callback.");
+    return ok();
+  }
+
+  const store = getStore("ama-questions");
+  const data = (await store.get(id, { type: "json" })) as StoredQuestion | null;
+
+  if (!data) {
+    await answerCallbackQuery(botToken, cq.id, "Question no longer exists.");
+    return ok();
+  }
+
+  const chatId = cq.message.chat.id;
+  const messageId = cq.message.message_id;
+  const token = adminTokenFor(id, signingSecret);
+  const adminUrl = adminUrlFor(id, token);
+
+  if (action === "delete") {
+    await store.delete(id);
+    await deleteMessage(botToken, chatId, messageId);
+    await answerCallbackQuery(botToken, cq.id, "Deleted.");
+    return ok();
+  }
+
+  if (action === "regen") {
+    const next = pickRandomOverrides();
+    const merged: StoredQuestion = { ...data, ...next };
+    await store.setJSON(id, merged);
+
+    const variant = variants.find((v) => v.id === next.variantId);
+    const persona = personas.find((p) => p.name === next.personaName);
+    const overrides: RenderOverrides = {
+      variant,
+      persona,
+      adjective: next.adjective,
+    };
+    const png = await renderAmaCard(data.question, overrides);
+
+    const editRes = await editMessageMedia({
+      botToken,
+      chatId,
+      messageId,
+      png,
+      caption: captionFor(data.question, adminUrl),
+      filename: `ama-${id}.png`,
+      keyboard: keyboardFor(id, adminUrl),
+    });
+    if (!editRes.ok) {
+      console.error(
+        "Telegram editMessageMedia failed:",
+        editRes.status,
+        await editRes.text().catch(() => "<no body>"),
+      );
+      await answerCallbackQuery(botToken, cq.id, "Edit failed — see logs.");
+      return ok();
+    }
+    await answerCallbackQuery(
+      botToken,
+      cq.id,
+      `${next.adjective} ${next.personaName}`,
+    );
+    return ok();
+  }
+
+  await answerCallbackQuery(botToken, cq.id, "Unknown action.");
+  return ok();
+};


### PR DESCRIPTION
## Summary
Adds [Regenerate] / [Delete] / [Open admin] inline keyboard buttons to every AMA Telegram message. Regenerate edits the photo in place; delete removes the message and the blob row. Web admin page remains and shares the random-pick logic via the new `pickRandomOverrides()` helper.

## New files
- `src/lib/ama/telegram.ts` — Telegram Bot API helpers (`sendPhoto`, `editMessageMedia`, `deleteMessage`, `answerCallbackQuery`) + shared caption/keyboard builders.
- `src/pages/api/ama/telegram-callback.ts` — webhook endpoint Telegram POSTs to when a button is tapped. Header-secret-token authenticated.

## One-time setup (after deploy lands)
1. Generate a random secret: `openssl rand -hex 32`
2. Add Netlify env var `TELEGRAM_WEBHOOK_SECRET` = that secret
3. Register the webhook:
   ```bash
   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
     -d "url=https://gui.do/api/ama/telegram-callback/" \
     -d "secret_token=<SECRET>" \
     -d 'allowed_updates=["callback_query"]'
   ```

## Test plan
- [ ] Submit a question. Telegram message arrives with three buttons.
- [ ] Tap [Regenerate] → photo updates in place; tap reply shows the new persona name.
- [ ] Tap [Regenerate] a few more times → variety, no errors in function logs.
- [ ] Tap [Delete] → message disappears; opening the Open admin URL afterwards returns 404.
- [ ] POST to `/api/ama/telegram-callback/` without the secret header → 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)