### PR TITLE
fix(ama): name the missing env var in telegram-callback 500

### DIFF
--- a/src/pages/api/ama/telegram-callback.ts
+++ b/src/pages/api/ama/telegram-callback.ts
@@ -67,8 +67,15 @@ export const POST: APIRoute = async ({ request }) => {
   const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
 
   if (!botToken || !signingSecret || !webhookSecret) {
-    console.error("Telegram callback missing env vars");
-    return new Response("misconfigured", { status: 500 });
+    const missing = [
+      !botToken && "TELEGRAM_BOT_TOKEN",
+      !signingSecret && "AMA_SIGNING_SECRET",
+      !webhookSecret && "TELEGRAM_WEBHOOK_SECRET",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    console.error("Telegram callback missing env vars:", missing);
+    return new Response(`misconfigured: missing ${missing}`, { status: 500 });
   }
 
   // Telegram sets this header on every webhook call when secret_token


### PR DESCRIPTION
Quick diagnostic: previously returned a bare \`misconfigured\` body when one of the three required env vars was undefined. Now the response body and the function log identify which one is missing.

Triggering a redeploy is the secondary benefit — \`TELEGRAM_WEBHOOK_SECRET\` was added after PR #178's deploy and Netlify v2 functions sometimes don't pick up new env vars until the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)