### PR TITLE
fix(ama): admin URL trailing slash + re-add Bluesky button

### DIFF
--- a/src/lib/ama/telegram.ts
+++ b/src/lib/ama/telegram.ts
@@ -17,12 +17,29 @@ export function adminTokenFor(id: string, secret: string): string {
 }
 
 export function adminUrlFor(id: string, token: string): string {
-  return `https://gui.do/ama/q/${id}?t=${token}`;
+  // Trailing slash matters: site's trailing-slash redirect runs with
+  // force=false but the @astrojs/netlify SSR function's path:"/*" wins,
+  // so /ama/q/<id> goes straight to Astro which doesn't match
+  // (trailingSlash: 'always') and 404s. Bake the slash in here.
+  return `https://gui.do/ama/q/${id}/?t=${token}`;
 }
 
 export function captionFor(question: string, adminUrl: string): string {
   // Telegram captions cap at 1024 chars; question is ≤500 so plenty of room.
   return `New AMA question:\n\n"${question}"\n\nAdmin: ${adminUrl}`;
+}
+
+/**
+ * Bluesky compose intent URL with the standard answer footer pre-filled.
+ * Two leading newlines so the cursor lands at the top of the composer
+ * with the footer visible underneath — type the answer above it.
+ *
+ * Bluesky's compose intent only accepts `text=`. There's no way to
+ * pre-attach an image, so this is a tab-switch + manual image attach.
+ */
+export function blueskyComposeUrl(): string {
+  const footer = "\n\ngui.do/ama #ama";
+  return `https://bsky.app/intent/compose?text=${encodeURIComponent(footer)}`;
 }
 
 /**
@@ -43,7 +60,10 @@ export function keyboardFor(id: string, adminUrl: string) {
         { text: "🎲 Regenerate", callback_data: `regen:${id}` },
         { text: "🗑 Delete", callback_data: `delete:${id}` },
       ],
-      [{ text: "Open admin →", url: adminUrl }],
+      [
+        { text: "🦋 Post on Bluesky", url: blueskyComposeUrl() },
+        { text: "Open admin →", url: adminUrl },
+      ],
     ],
   };
 }

--- a/src/pages/ama/q/[id].astro
+++ b/src/pages/ama/q/[id].astro
@@ -18,6 +18,7 @@ import { getStore } from "@netlify/blobs";
 import crypto from "node:crypto";
 import { renderAmaCard, type RenderOverrides } from "../../../lib/ama/render";
 import { variants, personas } from "../../../lib/ama/card";
+import { blueskyComposeUrl } from "../../../lib/ama/telegram";
 
 const id = Astro.params.id;
 const token = Astro.url.searchParams.get("t") ?? "";
@@ -135,6 +136,14 @@ const description = "Admin view for a submitted AMA question.";
         >
           Download card
         </a>
+        <a
+          href={blueskyComposeUrl()}
+          target="_blank"
+          rel="noopener"
+          class="border-base-300 dark:border-base-700 hover:bg-base-100 dark:hover:bg-base-800 inline-flex items-center rounded-full border px-4 py-2 text-sm font-medium"
+        >
+          🦋 Post on Bluesky
+        </a>
         <form method="POST" action={actionUrl} class="contents">
           <input type="hidden" name="action" value="delete" />
           <button
@@ -148,7 +157,9 @@ const description = "Admin view for a submitted AMA question.";
 
       <p class="text-base-500 dark:text-base-400 mt-6 text-xs">
         Regenerate picks a fresh random variant, persona, and adjective. Hit it
-        again if you don't like the result. Delete is permanent.
+        again if you don't like the result. Delete is permanent. Bluesky opens a
+        composer with the footer pre-filled; attach the downloaded card manually
+        (Bluesky's intent URL doesn't accept images).
       </p>
     </div>
   </section>


### PR DESCRIPTION
## Two fixes
1. **Admin 404** — Telegram caption links like \`/ama/q/<id>?t=...\` 404'd. The site's trailing-slash redirect runs with \`force=false\` but Astro's SSR function (\`path: "/*"\`) wins, so \`/ama/q/<id>\` reached Astro directly and didn't match (\`trailingSlash: 'always'\`). Fix: bake the trailing slash into \`adminUrlFor\`.
2. **Bluesky button** — Lost when PR #178 squash-merged before my late commit \`421a948\` landed. Re-adding the \`🦋 Post on Bluesky\` button to both the Telegram inline keyboard and the admin page.

## Test plan
- [ ] Submit a fresh AMA. Telegram link in the caption now uses trailing slash.
- [ ] Click the link → admin page loads (no 404).
- [ ] Existing buttons still work (Regenerate, Delete).
- [ ] New 🦋 Post on Bluesky button appears in both surfaces, opens composer with footer prefilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)