### PR TITLE
feat(ama): sanitize question for render correctness

### DIFF
--- a/src/lib/ama/sanitize.ts
+++ b/src/lib/ama/sanitize.ts
@@ -1,0 +1,35 @@
+/**
+ * Sanitize an AMA question before validation, storage, and rendering.
+ *
+ * Goal: render correctness, not abuse-prevention. The card renderer
+ * (Satori), the Telegram caption (plain text, no parse_mode), and the
+ * Astro template (auto-escaped) are already injection-safe by design.
+ * What can still go wrong is *visual* — bidi overrides reverse text,
+ * zero-width chars insert invisible content, combining marks render
+ * inconsistently across font fallbacks. This helper normalizes those.
+ *
+ * The function is intentionally *not* destructive beyond stripping
+ * known-bad codepoints and collapsing whitespace runs. Emoji, mixed
+ * scripts, and ordinary Unicode pass through untouched.
+ */
+
+// Strip:
+// - U+0000–U+0008, U+000B–U+001F : C0 controls (keep \t \n \r,
+//                                  collapsed to space below)
+// - U+007F                       : DEL
+// - U+200B–U+200D                : zero-width space/non-joiner/joiner
+// - U+202A–U+202E                : bidi overrides (visual spoofing)
+// - U+2066–U+2069                : directional isolates
+// - U+FEFF                       : byte order mark
+const STRIP_RE = new RegExp(
+  "[\\u0000-\\u0008\\u000B-\\u001F\\u007F\\u200B-\\u200D\\u202A-\\u202E\\u2066-\\u2069\\uFEFF]",
+  "g",
+);
+
+export function sanitizeQuestion(input: string): string {
+  return input
+    .normalize("NFC")
+    .replace(STRIP_RE, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}

--- a/src/pages/api/ama/submit.ts
+++ b/src/pages/api/ama/submit.ts
@@ -12,6 +12,7 @@ import { verifySolution } from "altcha-lib";
 import { getStore } from "@netlify/blobs";
 import crypto from "node:crypto";
 import { renderAmaCard } from "../../../lib/ama/render";
+import { sanitizeQuestion } from "../../../lib/ama/sanitize";
 import {
   adminTokenFor,
   adminUrlFor,
@@ -47,8 +48,8 @@ export const POST: APIRoute = async ({ request, clientAddress }) => {
       question?: unknown;
       altcha?: unknown;
     };
-    const question =
-      typeof body.question === "string" ? body.question.trim() : "";
+    const rawQuestion = typeof body.question === "string" ? body.question : "";
+    const question = sanitizeQuestion(rawQuestion);
     const altcha = typeof body.altcha === "string" ? body.altcha : undefined;
 
     if (question.length < MIN_LEN || question.length > MAX_LEN) {


### PR DESCRIPTION
Stranded commit from PR #181 that didn't make it into the squash. Adds \`sanitizeQuestion()\` called once on submit:

- NFC normalize (combining marks compose with their base)
- Strip C0 controls, DEL, bidi overrides (visual spoofing vector), directional isolates, zero-width chars, and BOM
- Collapse whitespace runs to single space

Goal is visual/render correctness, not abuse-prevention (Satori, Telegram caption, and Astro auto-escape are already injection-safe). Emoji, mixed scripts, and ordinary Unicode pass through untouched.

## Test plan
- [ ] Submit a question with a zero-width joiner inserted between words → stored without it
- [ ] Submit with multiple newlines → collapsed to single spaces on the card
- [ ] Submit with combining diacritics → renders identically to precomposed form
- [ ] Plain ASCII question still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)