### PR TITLE
chore: remove BlueSpark View Project link

### DIFF
--- a/src/components/Projects/ProjectCard.astro
+++ b/src/components/Projects/ProjectCard.astro
@@ -7,7 +7,7 @@ interface Props {
   name: string;
   description: string;
   mainImage: string;
-  link: string;
+  link?: string;
   iconBgColor: string;
   license?: string;
   tagline?: string;

--- a/src/data/indieProjects.ts
+++ b/src/data/indieProjects.ts
@@ -3,7 +3,7 @@ interface IndieProject {
   description: string;
   mainImage: string;
 
-  link: string;
+  link?: string;
   iconBgColor: string; // Tailwind color class for the icon background
   license?: string; // Optional license information
   tagline?: string; // Optional custom tagline (overrides license display)
@@ -94,7 +94,6 @@ export const indieProjects: IndieProject[] = [
     description:
       "AI-powered conversation starter generator for BlueSky followers. You can use the SaaS version, run it locally or host it yourself (Netlify instructions included).",
     mainImage: "/icons/bluespark.svg",
-    link: "https://bluespark.gui.do/",
     iconBgColor: "bg-black-600",
     githubUrl: "https://github.com/gxjansen/bluespark",
     license: "MIT",


### PR DESCRIPTION
## Summary
The `bluespark.gui.do` SaaS is no longer hosted, so the **View Project** button on the BlueSpark card at `/projects/` linked to a dead page. Remove the link while keeping the card content and the **Available on GitHub** button.

- `src/data/indieProjects.ts`: drop the `link` field from the BlueSpark entry; make `link` optional on `IndieProject`.
- `src/components/Projects/ProjectCard.astro`: make `link` optional. Title and "View Project" button only render when a link is present, so they're now omitted for BlueSpark.

## Test plan
- [ ] Visit `/projects/` — BlueSpark card renders with description, GitHub button, no "View Project" button, no title link
- [ ] Other project cards (with `link` set) still render the title link and "View Project" button