### PR TITLE
feat(agent-readiness): llms.txt, AI-crawler robots rules, Person JSON-LD

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,54 @@
+# Guido X Jansen — gui.do
+
+> Community strategist and DevRel leader with 20+ years building technical
+> ecosystems around open-source platforms. Founded communities around
+> Joomla! and Magento (Meet Magento NL, 600+ attendees), created the
+> CRO.CAFE podcast (200+ episodes, 4 languages), and built the community
+> function at Spryker. Based in the Netherlands.
+
+This file follows the llms.txt convention (https://llmstxt.org/) and the
+specification.website agent-readiness spec
+(https://specification.website/spec/agent-readiness/llms-txt/).
+
+## About
+
+- [About Guido](https://gui.do/about/): biography, expertise, credentials, awards
+- [Contact](https://gui.do/contact/): how to reach Guido
+- [Press kit](https://gui.do/press/): bio, headshots, brand assets
+- [Author profile](https://gui.do/authors/gxjansen/): canonical author page with all social profiles
+
+## Services
+
+- [Retainer / advisory](https://gui.do/retainer/): community + DevRel advisory engagements
+- [Services overview](https://gui.do/services/): the engagement menu
+- [Speaker](https://gui.do/speaker/): conference and event speaking
+
+## Speaking and presentations
+
+- [Events](https://gui.do/events/): conferences, workshops, and meetups Guido has spoken at
+- [Presentations](https://gui.do/presentations/): talk catalogue with abstracts
+
+## Communities and projects
+
+- [Communities](https://gui.do/communities/): communities Guido has founded, led, or shaped
+- [Projects](https://gui.do/projects/): notable initiatives and side projects
+- [Podcasts](https://gui.do/podcasts/): CRO.CAFE and other podcast work
+
+## Writing
+
+- [Articles](https://gui.do/post/): long-form posts on community, DevRel, experimentation, e-commerce
+- [Newsletter](https://gui.do/newsletter/): how to subscribe
+- [RSS feed](https://gui.do/rss.xml): full-text feed for syndication
+
+## AMA
+
+- [Ask Guido anything](https://gui.do/ama/): public AMA powered by AT Protocol / Bluesky
+
+## Site
+
+- [Sitemap index](https://gui.do/sitemap-index.xml): full URL index
+- [robots.txt](https://gui.do/robots.txt): crawl policy (AI crawlers are explicitly allowed)
+
+## Optional
+
+- [Privacy](https://gui.do/privacy/): privacy policy

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,108 @@
 User-agent: *
 Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+# Named AI crawlers — explicit allow per
+# https://specification.website/spec/agent-readiness/robots-for-ai-crawlers/
+User-agent: GPTBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Claude-Web
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: anthropic-ai
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Perplexity-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: GoogleOther
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Applebot-Extended
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Bingbot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: CCBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Meta-ExternalAgent
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: cohere-ai
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Amazonbot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: DuckAssistBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: YouBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: MistralAI-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
 
 Sitemap: https://gui.do/sitemap-index.xml

--- a/robots/robots.production.txt
+++ b/robots/robots.production.txt
@@ -2,4 +2,106 @@ User-agent: *
 Disallow: /conference-terms
 Disallow: /styleguide
 
+# Named AI crawlers — explicit allow per
+# https://specification.website/spec/agent-readiness/robots-for-ai-crawlers/
+User-agent: GPTBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Claude-Web
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: anthropic-ai
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Perplexity-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: GoogleOther
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Applebot-Extended
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Bingbot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: CCBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Meta-ExternalAgent
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: cohere-ai
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: Amazonbot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: DuckAssistBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: YouBot
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
+User-agent: MistralAI-User
+Allow: /
+Disallow: /conference-terms
+Disallow: /styleguide
+
 Sitemap: https://gui.do/sitemap-index.xml

--- a/src/js/jsonLD.ts
+++ b/src/js/jsonLD.ts
@@ -205,26 +205,76 @@ export default function jsonLDGenerator(props: JsonLDProps) {
     </script>`;
   }
 
+  const site = import.meta.env.SITE;
+  const inLanguage =
+    "language" in siteData ? (siteData as any).language : "en";
+
+  // Person graph for Guido — sourced from the authors collection front-matter
+  // (src/content/authors/gxjansen/index.mdx). Kept in sync manually because
+  // siteData has no access to the content layer at this point.
+  const personId = `${site}/about/#guido`;
+  const person = {
+    "@type": "Person",
+    "@id": personId,
+    name: "Guido X Jansen",
+    alternateName: "Guido Jansen",
+    url: site,
+    email: "mailto:x@gui.do",
+    jobTitle: "Global Business & Technology Evangelist",
+    description:
+      "Community strategist with 20+ years building technical ecosystems around open-source platforms.",
+    worksFor: {
+      "@type": "Organization",
+      name: "Spryker",
+      url: "https://spryker.com/",
+    },
+    knowsAbout: [
+      "Community Building",
+      "Developer Relations",
+      "E-commerce & CRO",
+      "Experimentation & A/B Testing",
+      "Open Source Strategy",
+      "Digital Usability",
+      "Community-Led Growth",
+      "Developer Experience",
+    ],
+    sameAs: [
+      "https://www.linkedin.com/in/guidoxjansen/",
+      "https://github.com/gxjansen",
+      "https://bsky.app/profile/gui.do",
+      "https://sifa.id/p/gui.do",
+    ],
+  };
+
+  const website = {
+    "@type": "WebSite",
+    "@id": `${site}/#website`,
+    name: siteData.title,
+    url: site,
+    inLanguage,
+    publisher: { "@id": personId },
+    author: { "@id": personId },
+    accessibilityAPI: "ARIA",
+    accessibilityControl: [
+      "fullKeyboardControl",
+      "fullMouseControl",
+      "fullTouchControl",
+    ],
+    accessibilityFeature: [
+      "alternativeText",
+      "structuralNavigation",
+      "highContrastDisplay",
+      "largePrint",
+    ],
+    accessibilityHazard: "none",
+  };
+
+  const graph = {
+    "@context": "https://schema.org",
+    "@graph": [website, person],
+  };
+
   return `<script type="application/ld+json">
-    {
-      "@context": "https://schema.org/",
-      "@type": "WebSite",
-      "name": "${siteData.title}",
-      "url": "${import.meta.env.SITE}",
-      "inLanguage": "${"language" in siteData ? (siteData as any).language : "en"}",
-      "accessibilityAPI": "ARIA",
-      "accessibilityControl": [
-        "fullKeyboardControl",
-        "fullMouseControl",
-        "fullTouchControl"
-      ],
-      "accessibilityFeature": [
-        "alternativeText",
-        "structuralNavigation",
-        "highContrastDisplay",
-        "largePrint"
-      ],
-      "accessibilityHazard": "none"
-    }
-  </script>`;
+${JSON.stringify(graph, null, 2)}
+</script>`;
 }

--- a/src/js/jsonLD.ts
+++ b/src/js/jsonLD.ts
@@ -206,8 +206,7 @@ export default function jsonLDGenerator(props: JsonLDProps) {
   }
 
   const site = import.meta.env.SITE;
-  const inLanguage =
-    "language" in siteData ? (siteData as any).language : "en";
+  const inLanguage = "language" in siteData ? (siteData as any).language : "en";
 
   // Person graph for Guido — sourced from the authors collection front-matter
   // (src/content/authors/gxjansen/index.mdx). Kept in sync manually because


### PR DESCRIPTION
## Summary

Quick wins from auditing gui.do against the [specification.website agent-readiness spec](https://specification.website/spec/agent-readiness/).

The audit found one required item (stable-urls) passing and six recommended items missing. This PR closes the three highest-leverage gaps:

**Add `public/llms.txt`** — curated index per [llmstxt.org](https://llmstxt.org/) and [the spec](https://specification.website/spec/agent-readiness/llms-txt/), pointing AI agents at the canonical About, Services, Speaking, Communities, Writing, AMA, and Site entry points.

**Per-AI-crawler `robots.txt`** — explicit `Allow: /` blocks for 20 named crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-Web, Claude-SearchBot, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, GoogleOther, Applebot-Extended, Bingbot, CCBot, Meta-ExternalAgent, cohere-ai, Amazonbot, DuckAssistBot, YouBot, MistralAI-User) so the stance is unambiguous instead of an implicit `User-agent: *`. Preserves the existing `/conference-terms` and `/styleguide` disallows for every agent.

**Richer general-page JSON-LD** — `src/js/jsonLD.ts` now emits an `@graph` with both `WebSite` and a full `Person` node for Guido (jobTitle, worksFor, knowsAbout, sameAs to LinkedIn / GitHub / Bluesky / Sifa). The Person is linked by `@id` so future per-route schemas (Event on `/events/*`, BreadcrumbList, etc.) can reference the same entity.

## What's still open

Recommended items deferred for a follow-up:

- **Markdown source endpoints** — would need an Astro integration to emit `index.md` per route. Higher scope, separate PR.
- **HTTP `Link:` headers** — advertise sitemap and the future `.md` alternates.
- **Per-route Event / BreadcrumbList / BlogPosting beyond blog** — blog posts already get rich BlogPosting; events and nested pages still inherit only the general graph.

## Notes for the reviewer

- `robots/robots.production.txt` exists in the repo but nothing in the build wires it in. Updated both files for consistency, but the actually-served `robots.txt` is `public/robots.txt`. Worth deleting `robots/` or wiring it into the publish script in a separate cleanup.
- The Person data in `jsonLD.ts` mirrors `src/content/authors/gxjansen/index.mdx` — kept in sync manually because the general-page path runs before the content layer is available.

## Test plan

- [ ] Build succeeds (Netlify deploy preview)
- [ ] `curl https://<deploy-preview>/llms.txt` returns 200 with curated index
- [ ] `curl https://<deploy-preview>/robots.txt` shows all 20 named AI crawlers
- [ ] View source of `/` and `/about/` — JSON-LD contains `@graph` with both `WebSite` and `Person`
- [ ] Validate the JSON-LD with [Schema Markup Validator](https://validator.schema.org/) — no errors
- [ ] Existing blog post JSON-LD (`BlogPosting`) still renders correctly