### PR TITLE
feat(atproto): serve /.well-known/atproto-did for Standard.site discovery

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -78,6 +78,13 @@
   [headers.values]
     Content-Type = "text/markdown; charset=utf-8"
 
+# Serve the AT Protocol DID well-known file as text/plain so consumers
+# (e.g. Bluesky's Standard.site discovery) parse it verbatim.
+[[headers]]
+  for = "/.well-known/atproto-did"
+  [headers.values]
+    Content-Type = "text/plain; charset=utf-8"
+
 # Content negotiation: browsers/agents that send Accept: text/markdown
 # are redirected to the pre-built .md file for that route.
 # These must appear BEFORE the trailing-slash splat and the SSR catch-all.

--- a/public/.well-known/atproto-did
+++ b/public/.well-known/atproto-did
@@ -1,0 +1,1 @@
+did:plc:45uheisi25szrjvjurfpritx


### PR DESCRIPTION
## Summary
- Adds `public/.well-known/atproto-did` containing the gui.do DID (`did:plc:45uheisi25szrjvjurfpritx`, no trailing newline) so Bluesky's Standard.site discovery can resolve the domain → DID → publication record.
- Adds a Netlify `[[headers]]` rule so the file is served as `text/plain; charset=utf-8`.
- The existing `/.well-known/*` redirect (netlify.toml:64) already passes the path through, and DNS TXT `_atproto.gui.do` stays as a parallel resolver path.

Closes #196

## Test plan
- [ ] After deploy: `curl -sI https://gui.do/.well-known/atproto-did` returns 200 with `Content-Type: text/plain; charset=utf-8`.
- [ ] `curl -s https://gui.do/.well-known/atproto-did` prints exactly `did:plc:45uheisi25szrjvjurfpritx` (32 bytes, no trailing newline).
- [ ] Post a `https://gui.do/...` link on Bluesky and confirm the Standard.site publication card renders with Subscribe/View affordances.