### PR TITLE
feat(agent-readiness): /llms-full.txt, robots Content-Signal, homepage .md, refreshed llms.txt bio

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,10 +1,11 @@
 # Guido X Jansen — gui.do
 
-> Community strategist and DevRel leader with 20+ years building technical
-> ecosystems around open-source platforms. Founded communities around
-> Joomla! and Magento (Meet Magento NL, 600+ attendees), created the
-> CRO.CAFE podcast (200+ episodes, 4 languages), and built the community
-> function at Spryker. Based in the Netherlands.
+> Guido X Jansen builds community functions for tech products. 20+ years
+> turning open-source platforms into working ecosystems: he founded
+> communities around Joomla! and Magento (Meet Magento NL, 600+ attendees),
+> created the CRO.CAFE podcast (200+ episodes across 4 languages), and built
+> the community function at Spryker from zero. Cognitive psychologist by
+> training. Based in the Netherlands.
 
 This file follows the llms.txt convention (https://llmstxt.org/) and the
 specification.website agent-readiness spec

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,11 @@ User-agent: *
 Allow: /
 Disallow: /conference-terms
 Disallow: /styleguide
+# Content Signals — declare permitted content usage per
+# https://specification.website/spec/agent-readiness/content-signals/
+# This is a public personal-brand site: search, AI answers, and training are
+# all welcome, matching the explicit allow rules for named AI crawlers below.
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 # Named AI crawlers — explicit allow per
 # https://specification.website/spec/agent-readiness/robots-for-ai-crawlers/

--- a/robots/robots.production.txt
+++ b/robots/robots.production.txt
@@ -1,6 +1,11 @@
 User-agent: *
 Disallow: /conference-terms
 Disallow: /styleguide
+# Content Signals — declare permitted content usage per
+# https://specification.website/spec/agent-readiness/content-signals/
+# This is a public personal-brand site: search, AI answers, and training are
+# all welcome, matching the explicit allow rules for named AI crawlers below.
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 # Named AI crawlers — explicit allow per
 # https://specification.website/spec/agent-readiness/robots-for-ai-crawlers/

--- a/src/integrations/markdown-endpoints.ts
+++ b/src/integrations/markdown-endpoints.ts
@@ -371,7 +371,9 @@ function writeLlmsFullFile(
     "> /llms.txt. Per-page markdown is also available at <page>.md.\n\n" +
     "---\n";
 
-  const sections = sorted.map((p) => `\n# Source: ${p.url}\n\n${p.md.trim()}\n`);
+  const sections = sorted.map(
+    (p) => `\n# Source: ${p.url}\n\n${p.md.trim()}\n`,
+  );
 
   const out = header + sections.join("\n---\n");
 

--- a/src/integrations/markdown-endpoints.ts
+++ b/src/integrations/markdown-endpoints.ts
@@ -9,7 +9,11 @@
  *   dist/<route>/index.md  — served at /<route>/index.md
  *   dist/<route>.md        — served at /<route>.md  (flat alias)
  *
- * Excluded: homepage, /ama, /api/*, *.xml, *.json, nav-data, rss,
+ * The homepage is included; its markdown lives at /index.md (no flat alias,
+ * since "/.md" is meaningless). All generated markdown is additionally
+ * concatenated into dist/llms-full.txt (llmstxt.org full companion).
+ *
+ * Excluded: /ama, /api/*, *.xml, *.json, nav-data, rss,
  * 404, /styleguide, /categories/*, /authors/*, /examples/*,
  * /internal/*, /overview, /newsletter, /privacy, /conference-terms.
  *
@@ -87,9 +91,11 @@ function isContentPage(pathname: string): boolean {
   // Must be an HTML file
   if (!p.endsWith(".html")) return false;
 
+  // Homepage is included; its .md is served at /index.md (no flat alias).
+  if (p === "index.html") return true;
+
   // Exact exclusions (resolved to their index.html form)
   const excluded = new Set([
-    "index.html", // homepage – skip
     "404.html",
     "404/index.html",
     "styleguide/index.html",
@@ -234,6 +240,10 @@ export function markdownEndpoints(): AstroIntegration {
         const headerRoutes: { urlPath: string; mdAlternate: string | null }[] =
           [];
 
+        // Collected for dist/llms-full.txt: the full markdown of every content
+        // page, keyed by canonical URL so the companion file is deterministic.
+        const fullParts: { url: string; md: string }[] = [];
+
         // Walk the dist directory recursively looking for index.html files
         const htmlFiles = findHtmlFiles(distDir);
 
@@ -247,8 +257,11 @@ export function markdownEndpoints(): AstroIntegration {
           const urlPath = routeSegment === "." ? "/" : `/${routeSegment}/`;
 
           const isContent = isContentPage(rel);
-          const mdAlternate =
-            isContent && routeSegment !== "." ? `/${routeSegment}.md` : null;
+          const mdAlternate = isContent
+            ? routeSegment === "."
+              ? "/index.md"
+              : `/${routeSegment}.md`
+            : null;
 
           // Record every static page for the _headers file (content or not).
           headerRoutes.push({ urlPath, mdAlternate });
@@ -267,6 +280,9 @@ export function markdownEndpoints(): AstroIntegration {
           }
 
           const md = extractMarkdown(html, rel);
+
+          // Collect for the llms-full.txt companion (full content concat).
+          fullParts.push({ url: `https://gui.do${urlPath}`, md });
 
           // Write dist/<route>/index.md  (sibling to index.html)
           const indexMdPath = path.join(path.dirname(absPath), "index.md");
@@ -288,6 +304,7 @@ export function markdownEndpoints(): AstroIntegration {
           `markdown-endpoints: wrote ${written} .md files (${skipped} pages skipped).`,
         );
 
+        writeLlmsFullFile(distDir, fullParts, logger);
         writeHeadersFile(distDir, headerRoutes, logger);
       },
     },
@@ -331,6 +348,36 @@ function writeHeadersFile(
   fs.writeFileSync(headersPath, existing + generated, "utf-8");
   logger.info(
     `markdown-endpoints: wrote _headers with ${sorted.length} Link rules.`,
+  );
+}
+
+/**
+ * Writes dist/llms-full.txt — the llmstxt.org "full" companion that
+ * concatenates the complete markdown of every content page into one file,
+ * each section prefixed with its source URL. Deterministic ordering (by URL)
+ * keeps deploy diffs stable.
+ */
+function writeLlmsFullFile(
+  distDir: string,
+  parts: { url: string; md: string }[],
+  logger: { info(msg: string): void },
+): void {
+  const sorted = [...parts].sort((a, b) => a.url.localeCompare(b.url));
+
+  const header =
+    "# Guido X Jansen — gui.do (full content)\n\n" +
+    "> Concatenated markdown of every content page on gui.do, following the\n" +
+    "> llms.txt convention (https://llmstxt.org/). For the curated index see\n" +
+    "> /llms.txt. Per-page markdown is also available at <page>.md.\n\n" +
+    "---\n";
+
+  const sections = sorted.map((p) => `\n# Source: ${p.url}\n\n${p.md.trim()}\n`);
+
+  const out = header + sections.join("\n---\n");
+
+  fs.writeFileSync(path.join(distDir, "llms-full.txt"), out, "utf-8");
+  logger.info(
+    `markdown-endpoints: wrote llms-full.txt (${sorted.length} pages).`,
   );
 }
 


### PR DESCRIPTION
## Summary
Closes the cheap, high-ROI Optional items from the agent-readiness review and adds homepage markdown coverage.

**Agent-readiness — Optional items (was 0/9, now 2/9):**
- **`/llms-full.txt`** — the markdown-endpoints integration now concatenates every content page's markdown into `dist/llms-full.txt` (llmstxt.org full companion), deterministically ordered by source URL.
- **Content Signals** — `Content-Signal: search=yes, ai-input=yes, ai-train=yes` added to the default user-agent group in `public/robots.txt`, matching the existing allow-all posture for named AI crawlers. Template `robots/robots.production.txt` kept in sync.

**Homepage `.md`:**
- Homepage is now included in the integration, served at `/index.md` and advertised via its `Link` header. No flat `/.md` alias (meaningless). `/about.md` and `/retainer.md` already existed via the allowlist.

**Copy:**
- Refreshed the `llms.txt` bio: replaced the generic title-stack opener with Guido's own homepage positioning ("community functions", "built from zero"), added the cognitive-psychology differentiator, dropped abstract filler. Third person kept (correct register for agent-read index metadata).

## Test Coverage
No new application logic beyond the integration changes, which are validated by the build:
- `astro build` generates `dist/index.md` (homepage) + `dist/llms-full.txt` (284 pages) + per-page `Link` headers in `dist/_headers`.
- Homepage `Link` header confirmed to advertise `/index.md`.

## Pre-Landing Review
Self-reviewed the one logic file (`markdown-endpoints.ts`):
- Homepage guard matches exact `index.html` only; nested `*/index.html` still routed via allowlist.
- `mdAlternate` → `/index.md` for homepage; flat-alias correctly skipped for `routeSegment === "."` (no bogus `/.md`).
- `llms-full.txt` deterministically sorted, no non-deterministic calls.
No issues found.

## Tests
- [x] robots.txt validation passed (`node scripts/test-robots.js`)
- [x] Vitest: 19 files, 110 tests passed
- [x] `astro build` succeeded, markdown endpoints + llms-full + headers generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)