### PR TITLE
chore: auto-format staged files via pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Auto-format staged source files with Prettier so CI's `Format` check
+# (npm run format:check) never fails on a push. Enabled via the `prepare`
+# npm script, which sets core.hooksPath to .githooks on install.
+#
+# Scope mirrors format:check exactly: only files under src/ matching the
+# Prettier glob. Anything else is left untouched.
+
+PRETTIER="./node_modules/.bin/prettier"
+if [ ! -x "$PRETTIER" ]; then
+  echo "pre-commit: prettier not installed (run npm install) — skipping format" >&2
+  exit 0
+fi
+
+staged=$(git diff --cached --name-only --diff-filter=ACM \
+  | grep -E '^src/.*\.(astro|ts|tsx|js|jsx|mjs|css|md|mdx)$' || true)
+
+[ -z "$staged" ] && exit 0
+
+echo "$staged" | xargs "$PRETTIER" --write --log-level warn
+echo "$staged" | xargs git add
+echo "pre-commit: prettier-formatted staged src files"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "check:trailing-slashes": "node scripts/check-trailing-slashes.js",
     "optimize-images": "node scripts/optimize-images.mjs",
     "format:check": "prettier --check \"src/**/*.{astro,ts,tsx,js,jsx,mjs,css,md,mdx}\"",
+    "format": "prettier --write \"src/**/*.{astro,ts,tsx,js,jsx,mjs,css,md,mdx}\"",
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
     "typecheck": "astro check"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Stops the recurring CI **Format** failures (hit twice: PR #199 and the standard-site-card post) by formatting staged files locally before they ever reach CI.

- **`.githooks/pre-commit`** — runs `prettier --write` on staged files under `src/` matching the same glob as `format:check`, then re-stages them. Skips gracefully if `node_modules` isn't installed (prints a notice, never blocks the commit).
- **`prepare` script** — sets `core.hooksPath=.githooks` on `npm install`. Zero new dependencies, no husky. Auto-applies on both machines after a normal install.
- **`format` script** — `prettier --write` convenience command (`npm run format`).

## Why this approach
- No husky / lint-staged dependency — fits the minimal, antifragile setup.
- Committed hook + `core.hooksPath` means it syncs via git, not per-machine `.git/hooks` setup.
- Mirrors `format:check`'s glob exactly, so "hook passed locally" === "CI Format passes."

## Test
Verified manually: staged a deliberately mis-formatted `.ts` file, ran the hook → it reformatted and re-staged the file. Also confirmed the graceful skip path when `node_modules` is absent (observed on this branch's own commit).

After merge, run `npm install` once on each machine to activate (`prepare` wires the hook path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)