### PR TITLE
chore(spec): P1 site-spec fixes — HSTS preload, security.txt, /favicon.ico

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -66,6 +66,13 @@
   to = "/.well-known/:splat"
   status = 200
 
+# Legacy /favicon.ico at site root — browsers and many crawlers request this
+# path unconditionally. Source of truth lives in /favicons/.
+[[redirects]]
+  from = "/favicon.ico"
+  to = "/favicons/favicon.ico"
+  status = 200
+
 # SSR routing is handled by the @astrojs/netlify adapter via its v2
 # function in .netlify/v1/functions/ssr (declared path: "/*",
 # preferStatic: true). A previous catch-all here pointed at a
@@ -195,6 +202,10 @@
     # (grep eval(/new Function( across dist/_astro/*.js) confirmed nothing in the
     # shipped browser bundle relies on it.
     Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://u.a11y.nl https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' https://u.a11y.nl https://public.api.bsky.app; media-src 'self' https:; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://share.transistor.fm https://open.spotify.com; frame-ancestors 'self'; base-uri 'self'; form-action 'self' https://share.transistor.fm; object-src 'none'; worker-src 'self' blob:; upgrade-insecure-requests;"
+    # HSTS: includeSubDomains + preload prepares the domain for the HSTS preload
+    # list (https://hstspreload.org/). Submit after deploy to lock all gui.do
+    # subdomains to HTTPS at the browser level.
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"
     X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,7 @@
+# Security contact for gui.do — RFC 9116
+# https://www.rfc-editor.org/rfc/rfc9116
+
+Contact: mailto:x@gui.do
+Expires: 2027-05-31T00:00:00.000Z
+Preferred-Languages: en, nl
+Canonical: https://gui.do/.well-known/security.txt


### PR DESCRIPTION
## Summary

Top-priority gaps from the specification.website full-site audit. Three small, reversible changes.

- **HSTS preload-ready** — was `max-age=31536000`, now `max-age=63072000; includeSubDomains; preload`. After this deploys, submit gui.do on https://hstspreload.org/ to lock all subdomains to HTTPS at the browser level.
- **`/.well-known/security.txt`** — RFC 9116 contact file at the standard location. Was 404. Contact `x@gui.do`, expires 2027-05-31.
- **`/favicon.ico` at root** — was 404. Added a Netlify 200-rewrite to `/favicons/favicon.ico` where the file already lives, for legacy crawlers and browsers that request the root path unconditionally.

## Test plan

- [ ] Deploy preview: `curl -sI <preview>/  | grep -i strict-transport` returns `max-age=63072000; includeSubDomains; preload`
- [ ] `curl -s <preview>/.well-known/security.txt` returns the file with `Content-Type: text/plain`
- [ ] `curl -sI <preview>/favicon.ico` returns 200 (not 404)
- [ ] After merge + deploy to prod: submit https://gui.do at https://hstspreload.org/