### PR TITLE
content: link standard-site-card post to Bluesky thread

### DIFF
--- a/src/content/post/standard-site-card-on-bluesky/index.mdx
+++ b/src/content/post/standard-site-card-on-bluesky/index.mdx
@@ -6,6 +6,7 @@ authors:
   - gxjansen
 pubDate: 2026-05-31
 heroImage: ../standard-site-card-on-bluesky/heroImage.png
+blueskyUri: "https://bsky.app/profile/gui.do/post/3mn5q6wtovs2l"
 categories:
   - Technology
   - AT Protocol


### PR DESCRIPTION
## Summary
Adds `blueskyUri` frontmatter to the standard-site-card-on-bluesky post so the comment section loads the linked Bluesky thread.

- Post: `/post/standard-site-card-on-bluesky/`
- Thread: https://bsky.app/profile/gui.do/post/3mn5q6wtovs2l

## Test plan
- [ ] Preview deploy renders the Bluesky thread in the comments section