### PR TITLE
content: link self-hosted-runner post to Bluesky thread

### DIFF
--- a/src/content/post/self-hosted-github-runner-vps/index.mdx
+++ b/src/content/post/self-hosted-github-runner-vps/index.mdx
@@ -6,6 +6,7 @@ authors:
   - gxjansen
 pubDate: 2026-06-01
 heroImage: ../self-hosted-github-runner-vps/heroImage.png
+blueskyUri: "https://bsky.app/profile/did:plc:45uheisi25szrjvjurfpritx/post/3mnawzncoh22b"
 categories:
   - Technology
   - DevOps


### PR DESCRIPTION
## Summary
Adds `blueskyUri` frontmatter to the self-hosted-github-runner-vps post so the comment section loads the linked Bluesky thread.

- Post: `/post/self-hosted-github-runner-vps/`
- Thread: https://bsky.app/profile/did:plc:45uheisi25szrjvjurfpritx/post/3mnawzncoh22b

## Test plan
- [ ] Preview deploy renders the Bluesky thread in the comments section