### PR TITLE
style(bsky-comments): unify icon style, order, and spacing

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -275,7 +275,7 @@
   [class*="_statsBar_"] {
     display: flex;
     align-items: center;
-    gap: 1rem;
+    gap: 1.25rem;
     padding: 0.5rem 0;
     font-size: 0.875rem;
     font-weight: 500;
@@ -285,8 +285,17 @@
   [class*="_statItem_"] {
     display: flex;
     align-items: center;
-    gap: 0.3rem;
+    gap: 0.4rem;
     white-space: nowrap;
+  }
+
+  /* Force monochrome icons in the top stats bar — the library hardcodes
+     fill="pink" / stroke="green" / fill="#7FBADC". Override so they match
+     the per-comment action row and the rest of the muted comments section. */
+  [class*="_statsBar_"] svg {
+    fill: none !important;
+    stroke: currentColor !important;
+    opacity: 0.7;
   }
 
   /* --- Section heading & intro text --- */
@@ -383,29 +392,42 @@
     margin-top: 0.25rem;
   }
 
-  /* --- Comment actions (reply / repost / like counts) --- */
+  /* --- Comment actions (reply / repost / like counts) ---
+     Library renders 4 rows in order: replies, reposts, likes, reply-arrow.
+     We reorder to match the top stats bar (likes, reposts, replies) and hide
+     the redundant reply-arrow — the "Join the conversation on Bluesky" link
+     below the comments already covers that. */
   [class*="_actionsContainer_"] {
     margin-top: 0.35rem;
     display: flex;
-    width: 100%;
-    max-width: 14rem;
     flex-direction: row;
     align-items: center;
-    justify-content: space-between;
+    gap: 1.25rem;
   }
 
   [class*="_actionsRow_"] {
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.4rem;
     color: #797593; /* Dawn muted */
     font-size: 0.8125rem;
+  }
+
+  /* Reorder per-comment actions to match the top stats bar:
+     likes (3rd in markup) → 1st, reposts (2nd) → 2nd, replies (1st) → 3rd. */
+  [class*="_actionsRow_"]:nth-child(1) { order: 3; }
+  [class*="_actionsRow_"]:nth-child(2) { order: 2; }
+  [class*="_actionsRow_"]:nth-child(3) { order: 1; }
+
+  /* Hide the per-comment reply-arrow row (4th item, also tagged _replyAction_) */
+  [class*="_replyAction_"] {
+    display: none;
   }
 
   [class*="_actionsRow_"] svg {
     width: 1rem !important;
     height: 1rem !important;
-    opacity: 0.6;
+    opacity: 0.7;
   }
 
   /* --- Screen-reader only text --- */


### PR DESCRIPTION
## Summary
Follow-up to #217 — this commit landed on the branch *after* the merge, so it never made it to master.

- **Spacing**: replaced `justify-content: space-between` on the per-comment actions container with a real `gap: 1.25rem`. Widened the icon→count gap from `0.25rem` to `0.4rem`.
- **Order**: per-comment actions reordered (`likes, reposts, replies`) to match the top stats bar via flex `order`.
- **Hide reply-arrow**: the curly arrow at the end of each comment's action row is redundant with the "Join the conversation on Bluesky" link below.
- **Monochrome top stats**: the library hardcodes `fill="pink" / stroke="green" / fill="#7FBADC"` on the top stats icons. Overridden to `currentColor` strokes so they match the muted per-comment row and the rest of the comments section.

## Test plan
- [ ] Preview deploy: per-comment action row uses `likes, reposts, replies` order.
- [ ] Counts no longer touch the next icon.
- [ ] Curly reply-arrow no longer visible after each comment.
- [ ] Top stats bar icons render in the same muted style as per-comment icons.