### PR TITLE
style(bsky-comments): keep action icons bundled, not edge-to-edge

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -399,6 +399,10 @@
      below the comments already covers that. */
   [class*="_actionsContainer_"] {
     margin-top: 0.35rem;
+    /* Override the library's `width: 100%; justify-content: space-between` so
+       the items stay bundled together instead of spreading edge-to-edge. */
+    width: auto !important;
+    justify-content: flex-start !important;
     display: flex;
     flex-direction: row;
     align-items: center;


### PR DESCRIPTION
## Summary
Follow-up to #218. The library's `bluesky-comments.css` hardcodes `width: 100%; justify-content: space-between` on `_actionsContainer_`. My earlier override added `gap: 1.25rem` but didn't reset those, so the items still spread across the full comment width — heart pinned left, refresh in the middle, reply pinned right.

Fix: explicit `width: auto !important` + `justify-content: flex-start !important` on the container. Items now sit together with the intended `gap` controlling spacing.

## Test plan
- [ ] Preview deploy: per-comment action icons bundle together at the left with consistent spacing, not pinned to opposite edges.