### PR TITLE
fix(seo): emit JPEG og:image instead of WebP

### DIFF
--- a/src/components/Seo/Seo.astro
+++ b/src/components/Seo/Seo.astro
@@ -92,9 +92,13 @@ const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
 const isImageMetadata =
   image && typeof image === "object" && "src" in image && "format" in image;
 if (isImageMetadata) {
+  // og:image must be PNG/JPEG, not WebP. Many social/link-preview scrapers
+  // (X/Twitter, plus various embed tools) silently fail to render WebP
+  // og:image, leaving a blank card. JPEG keeps photographic hero images
+  // small while staying universally supported.
   optimizedImage = await getImage({
     src: image,
-    format: "webp",
+    format: "jpeg",
     quality: "high",
     width: 1200,
     height: 630,


### PR DESCRIPTION
## Problem

Blog post link-preview cards render blank in many social/embed tools (reported via thesocialwire.app). Root cause: every page's `og:image` was generated as **WebP** by `getImage({ format: \"webp\" })` in `Seo.astro`. Numerous scrapers (X/Twitter and various embed tools) silently fail to render WebP og:image.

The homepage looked fine only because it falls back to a static `og-default.png`; posts served their hero image as WebP.

## Fix

Switch the generated og:image to **JPEG** — universally supported by scrapers, compact for photographic hero images. Dimensions (1200×630) and absolute-URL handling unchanged.

## Verify

On the Netlify deploy preview, confirm a post's `og:image` ends in `.jpeg` and returns `content-type: image/jpeg`:

\`\`\`
curl -s <preview-url>/post/ai-slop-reputation/ | grep 'og:image'
\`\`\`

## Out of scope

The separate "This site blocks embedding" message is the embed tool relying on iframing the live site, which is correctly blocked by our `X-Frame-Options`/CSP `frame-ancestors`. That's feedback for the tool author (read og: tags / fetch server-side instead), not a change to our security headers.