### PR TITLE
content: small text updates across 2025-2026 articles

### DIFF
--- a/src/content/post/4-options-to-customize-your-llm/index.mdx
+++ b/src/content/post/4-options-to-customize-your-llm/index.mdx
@@ -11,15 +11,15 @@ categories:
   - Development
 ---
 
-If you want to customize an LLM of choice with more context about you/your project/your company, you have a couple of options to do so. ✔︎
+If you want to customize an LLM of choice with more context about you/your project/your company, you have a couple of options to do so.
 
-For most people **(re)training** their own AI is **not** an option because it requires quite some hardware/resources. OpenAI has revealed that to train GPT-4 (so not even the latest models) it cost them $100M and took 100 days, utilizing 25,000 NVIDIA A100 GPUs. 😱
+For most people **(re)training** their own AI is **not** an option because it requires quite some hardware/resources. OpenAI has revealed that to train GPT-4 (so not even the latest models) it cost them $100M and took 100 days, using 25,000 NVIDIA A100 GPUs. 😱
 
 So yeah, let's not do that. But you still have some very powerful options for customizing pre-trained models that are either free or at least far below $100M... 👇
 
 ## 1. Stuff your prompts with context
 
-The most accessible way to customize LLM behavior is through prompt engineering. This involves crafting specific instructions that guide the model's responses. There are thousands of ways to structure prompts (and YouTube videos on how to do it), but specifically for enriching your LLM with context you can add/upload documents, files, or even just plain text.
+The most accessible way to customize LLM behavior is prompt engineering: crafting specific instructions that guide the model's responses. There are thousands of ways to structure prompts (and YouTube videos on how to do it), but specifically for enriching your LLM with context you can add/upload documents, files, or even just plain text.
 
 You can include any additional context in the prompt (plain text or documents). This is also what happens when you add "instructions" or "projects" with files. You store documents that the LLM will include in _every_ prompt.
 
@@ -35,9 +35,7 @@ Fine-tuning does adjust the model's weights to better align with your use case a
 
 ## 3. RAG (Retrieval-Augmented Generation)
 
-RAG retrieves relevant information from an external knowledge base and dynamically incorporates it. This allows you to go beyond context windows and doesn't require re-training when the data changes. So if your data source is up-to-date, so will your LLM responses be. However, it does require you to have a vector database and retrieval system set up.
-
-RAG combines the LLM's capabilities with external knowledge bases. It retrieves relevant information and incorporates it into the generation process.
+RAG retrieves relevant information from an external knowledge base and feeds it into the generation. This lets you go beyond context windows and doesn't require re-training when the data changes. So if your data source is up-to-date, so will your LLM responses be. But it does require you to have a vector database and retrieval system set up.
 
 ## 4. MCP (Model Context Protocol)
 

--- a/src/content/post/7-hard-learned-lessons-for-building-reliable-ai-workflows/index.mdx
+++ b/src/content/post/7-hard-learned-lessons-for-building-reliable-ai-workflows/index.mdx
@@ -20,50 +20,50 @@ I have some useful tips for you...
 
 Many of my workflows failed their initial concept, and I had to rework many (all?) of them. Adding an AI-node opens the door to many new possibilities. But let's be clear: it's not magic.
 
-This year, as I’ve rebuilt personal workflows using generative AI, clear patterns emerged: Some old guidelines that still hold true since I started building automation workflows 15 years ago, and some new ones that apply to working with AI. Both categories still very relevant today.
+This year, as I've rebuilt personal workflows using generative AI, clear patterns emerged: some old guidelines that still hold true since I started building automation workflows 15 years ago, and some new ones that apply to working with AI. Both categories still very relevant today.
 
-These aren’t corporate case studies but field notes from someone knee-deep in prototyping. Whether you’re automating client outreach or personal knowledge management, here’s what I wish I knew before my first AI workflow exploded in a RAG cloud of hallucinated notes…
+These aren't corporate case studies but field notes from someone knee-deep in prototyping. Whether you're automating client outreach or personal knowledge management, here's what I wish I knew before my first AI workflow exploded in a RAG cloud of hallucinated notes…
 
-## Tip 1. Process First, AI Second
+## Tip 1. Process first, AI second
 
 Your AI is only as good as your underlying process. If your manual workflow is chaotic, AI will amplify that chaos at scale. Map and execute your process manually before adding any automation. Solid processes + quality data = AI success. Vague processes + poor data = expensive disappointment.
 
-## Tip 2. Think Subtasks, Not Magic Solutions
+## Tip 2. Think subtasks, not magic solutions
 
 "Analyze all clients for churn risk" is a recipe for mediocre results. Instead, break it down: extract engagement metrics, identify usage pattern changes, analyze support ticket sentiment, score individual risk factors. The more specific the AI task, the better the output quality.
 
 > "If your workflow exceeds 20-25 steps, you'll probably need to rethink your workflow"
 > You may have seen some people post these excessively elaborate n8n workflows. These makes no sense to me as it will make it very hard to manage and debug your workflows. There will always be exceptions, but I think as a general rule of thumb: if your workflow exceeds 20-25 steps, you'll probably need to rethink this and break it up into sub-tasks (One neat thing about n8n is that one workflow can trigger another workflow, which is extremely useful).
 
-## Tip 3. Context is King (But Less is More)
+## Tip 3. Give AI just enough context, no more
 
-Give AI exactly what it needs to succeed, no more, no less. Analyzing one client? Don't flood it with data from all 500 customers. The Goldilocks principle applies: just right context beats information overload every time.
+Give AI exactly what it needs to succeed, no more, no less. Analyzing one client? Don't flood it with data from all 500 customers. The Goldilocks principle applies: just-right context beats information overload.
 
-## Tip 4. Skip AI for Simple Tasks
+## Tip 4. Skip AI for simple tasks
 
 Don't use AI to sort a list alphabetically. Use code. AI introduces variability where you need consistency. Reserve AI for interpretation, transcription, text summaries, pattern recognition, and other things LLMs are good at.
 
 For deterministic tasks, stick with traditional programming, it's faster, cheaper, and more reliable.
 
-## Tip 5. Specialized Tools Beat Swiss Army Knives
+## Tip 5. Specialized tools beat swiss army knives
 
-Stop trying to make ChatGPT do everything. Use Whisper for transcription, GitHub Copilot or Claude for code, Midjourney for images, Veo for video, Elevenlabs for audio. Specialized models for your specific needs. Each AI excels at particular tasks. Leverage that specialization for better results.
+Stop trying to make ChatGPT do everything. Use Whisper for transcription, GitHub Copilot or Claude for code, Midjourney for images, Veo for video, Elevenlabs for audio. Specialized models for your specific needs. Each one is built for particular tasks, so lean on that specialization for better results.
 
-💡 **Sidenote:** The shitty thing here is that the optimal model for a specific task might change weekly. I haven't yet found a definitive solution for this, but monitoring popular models in [OpenRouter](https://openrouter.ai/rankings) provides valuable insights. 💡
+Sidenote: the shitty thing here is that the optimal model for a specific task might change weekly. I haven't yet found a definitive solution for this, but watching the popular models in [OpenRouter](https://openrouter.ai/rankings) helps.
 
-## Tip 6. Start Where You Already Excel
+## Tip 6. Start where you already excel
 
 > "If you can't do the task manually with unlimited time, AI probably can't either."
-> The most successful AI implementations enhance existing strengths rather than attempting entirely new capabilities. Or at least it really helps a ton to already have the experience under your belt before you venture into new capabilities. If you can't do the task manually with unlimited time, AI probably can't either. Begin with familiar processes you understand deeply.
+> The most successful AI implementations build on existing strengths rather than attempting entirely new capabilities. Or at least it really helps a ton to already have the experience under your belt before you venture into new capabilities. If you can't do the task manually with unlimited time, AI probably can't either. Begin with familiar processes you understand deeply.
 
-## Tip 7. Human-AI Collaboration > Replacement
+## Tip 7. Human-AI collaboration beats replacement
 
-The winning formula isn't AI vs. humans, it's AI + humans. Position AI as an intelligent assistant handling data processing and pattern recognition while humans make decisions, handle exceptions, and manage relationships.
+The winning formula is AI + humans, not AI vs. humans. Position AI as an intelligent assistant handling data processing and pattern recognition while humans make decisions, handle exceptions, and manage relationships.
 
 I don't trust AI to send out any communication to anyone, so I don't. But it doesn't mean I don't let it help me with anything. What you need to do is build human-in-the-loop steps where you check the AI's work. Especially for new workflows this is invaluable. Once you trust the workflow more and more, you could remove the human-in-the-loop nodes.
 
 ## The bottom line:
 
-AI amplifies what you do well and exposes what you do poorly. Start with solid foundations, think in subtasks, and remember that the goal isn't to replace human judgment, it's to enhance it.
+AI amplifies what you do well and exposes what you do poorly. Start with solid foundations, think in subtasks, and remember the goal: support human judgment, don't replace it.
 
 What's your biggest challenge in implementing AI workflows? Or the biggest time saver you have implemented? Share your experience below, I'd love to help and learn!

--- a/src/content/post/ai-slop-reputation/index.mdx
+++ b/src/content/post/ai-slop-reputation/index.mdx
@@ -33,7 +33,7 @@ Against AI slop, this is a losing game.
 
 Volume is one part: a human moderator can review maybe 100 posts per hour, while a slop generator can produce 100 posts per minute. The math doesn't work.
 
-Then there's the quality: where early AI spam was obviously fake, current slop is harder to spot. It uses correct grammar, references real concepts, and sometimes even makes valid points. The tells are subtle, and I'd expect LLMs to only get better at this since that's quite literally what they're being designed to do.
+Then there's the quality: where early AI spam was obviously fake, current slop is harder to spot. It uses correct grammar, references real concepts, and sometimes even makes valid points. The tells are subtle, and I'd expect LLMs to only get better at this since that's what they're being designed to do.
 
 And the persistence:
 

--- a/src/content/post/bigtech-independence-update-cleaning-house-for-local-ai/index.mdx
+++ b/src/content/post/bigtech-independence-update-cleaning-house-for-local-ai/index.mdx
@@ -19,7 +19,7 @@ Three months ago I wrote about [reducing my BigTech dependencies](/post/how-i-re
 
 The short version is that I've been cleaning house. Not the most exciting stuff, but more like organizing that drawer you've been avoiding for years. Something I actually also did last week. 😅
 
-## Foundations for Local Family LLM
+## Foundations for a local family LLM
 
 I could've jumped straight to the exciting stuff like voice assistants, AI interfaces, smart automations. But a fancy AI assistant isn't very useful if it doesn't know who you are, what your preferences are, or where to find your documents. I won't convince my family to use a local LLM if it's just a slighlty worse version of ChatGPT with no added benefits.
 

--- a/src/content/post/bigtech-independence-update-cleaning-house-for-local-ai/index.mdx
+++ b/src/content/post/bigtech-independence-update-cleaning-house-for-local-ai/index.mdx
@@ -21,7 +21,7 @@ The short version is that I've been cleaning house. Not the most exciting stuff,
 
 ## Foundations for a local family LLM
 
-I could've jumped straight to the exciting stuff like voice assistants, AI interfaces, smart automations. But a fancy AI assistant isn't very useful if it doesn't know who you are, what your preferences are, or where to find your documents. I won't convince my family to use a local LLM if it's just a slighlty worse version of ChatGPT with no added benefits.
+I could've jumped straight to the exciting stuff like voice assistants, AI interfaces, smart automations. But a fancy AI assistant isn't very useful if it doesn't know who you are, what your preferences are, or where to find your documents. I won't convince my family to use a local LLM if it's just a slightly worse version of ChatGPT with no added benefits.
 
 So I've been building infrastructure.
 
@@ -31,7 +31,7 @@ One of the major additions to the stack is <a href="https://docs.paperless-ngx.c
 
 **Dedicated Home Assistant device**: Got a <a href="https://www.home-assistant.io/green/" target="_blank" rel="noopener noreferrer">Home Assistant Green</a> with a ZBT-2 for all Zigbee connections.
 
-**New (to me) laptop**: Picked up a secondhand ThinkPad X1 Carbon running <a href="https://cachyos.org/" target="_blank" rel="noopener noreferrer">CachyOS</a>. Runs incredibly smooth and is now my main laptop. It's (probably) not as indistructable as it's reputation, but this is one heck of a sturdy device!
+**New (to me) laptop**: Picked up a secondhand ThinkPad X1 Carbon running <a href="https://cachyos.org/" target="_blank" rel="noopener noreferrer">CachyOS</a>. Runs incredibly smooth and is now my main laptop. It's (probably) not as indestructible as its reputation, but this is one heck of a sturdy device!
 
 **FreshRSS is running.** This was on my "after that" list in October. I'm still recovering from the Google Reader sunset in 2013. Having RSS back feels very nice, it's such a good protocol!
 

--- a/src/content/post/ditching-one-community-idea-per-month/index.mdx
+++ b/src/content/post/ditching-one-community-idea-per-month/index.mdx
@@ -29,7 +29,7 @@ I've learned that promising to pick one idea per month (or whatever your number 
 
 _(Note that while I've applied this to a developer-community, this can also work for a non-developer community, see further below)_
 
-## The Problem with Fixed Quotas
+## The problem with fixed quotas
 
 When you promise to implement one community idea per month, you're creating a system that sounds fair but can actually work against you.
 
@@ -39,7 +39,7 @@ When you promise to implement one community idea per month, you're creating a sy
 
 You're also setting up a competitive dynamic where community members are essentially competing for limited slots and you also cap your potential upside. That's not the kind of culture and practice most of us want to build.
 
-## What We Did Instead: The Hackathon Approach
+## What we did instead: the hackathon approach
 
 We started running regular public hackathons in 2024 at our own offices and at partner or customer locations. Resulting in over 80 public projects now live on the [Spryker Community GitHub](https://github.com/spryker-community), with typically 3-5 teams participating per hackathon.
 
@@ -60,7 +60,7 @@ This meant what teams created was:
 *Hackathon team presentations at the Berlin office, September 2025, with
 multiple members from the Spryker Product and Tech teams on-site.*
 
-## The Key: Making Success Independent of Product Team Pickup
+## Making success independent of product team pickup
 
 **The biggest challenge for any hackathon participant is making sure the "what's in it for them" is clear, immediate, and not dependent on whether the product team picks up their work.**
 
@@ -85,13 +85,13 @@ This gave participants lots of freedom and resulted in a good mix of funny, inno
 it in to the project? No. Was it innovative, fun and a great learning
 experience? Heck yeah!*
 
-## The trade-off: You need some volume
+## The trade-off: you need some volume
 
-Here's the honest challenge with this approach: **To get a meaningful amount of actual product innovations, you need volume.**
+The challenge with this approach: **to get a meaningful amount of actual product innovations, you need volume.**
 
 By leaving topics open, you create space for creativity but you also accept that not every project will be product-ready or even product-relevant. Some will be experimental. Some will be quirky. Some will be brilliant but not aligned with your roadmap.
 
-That's actually fine. It's a feature, not a bug. It's a great motivational and bonding event for the participants. Who doesn't want the freedom to solve that pesky problem or to work with that cutting edge tech that no scrum master every gave the green light?
+That's actually fine. It's a feature, not a bug. It's a great motivational and bonding event for the participants. Who doesn't want the freedom to solve that pesky problem or to play with that new tech no scrum master ever gave the green light?
 
 But it does mean you can't run one small hackathon and expect five ready-to-implement features. You need enough hackathon participants over time to generate the right mix of projects.
 
@@ -128,7 +128,7 @@ Recent studies (see below for links) on open source contributions show that intr
 
 Research on hackathons specifically shows they're effective at building community, generating innovation, and creating lasting value when structured properly. The key is making the event itself rewarding, not just positioning it as a gateway to getting features implemented.
 
-Community-driven innovation works best when it empowers local expertise and creates genuine ownership. This aligns perfectly with what we saw: when community members built something themselves, they were invested in it regardless of whether it made it into the core product.
+Community-driven innovation works best when it empowers local expertise and creates genuine ownership. That matches what we saw: when community members built something themselves, they were invested in it regardless of whether it made it into the core product.
 
 ## So what's the alternative to monthly quotas?
 

--- a/src/content/post/doom-over-at-protocol/index.mdx
+++ b/src/content/post/doom-over-at-protocol/index.mdx
@@ -13,11 +13,11 @@ categories:
 blueskyUri: "at://did:plc:45uheisi25szrjvjurfpritx/app.bsky.feed.post/3miarycjd4c25"
 ---
 
-Someone ran Doom through DNS. [Adam Rice stored the entire game in TXT records](https://blog.rice.is/post/doom-over-dns/) and it actually worked. I saw that and - being at an AT Protocol conference - thought: can the AT Protocol do the same thing? Store the game and actually play it, with every player input and every rendered frame traveling through the protocol?
+Someone ran Doom through DNS. [Adam Rice stored the entire game in TXT records](https://blog.rice.is/post/doom-over-dns/) and it actually worked. I saw that and, being at an AT Protocol conference, thought: can the AT Protocol do the same thing? Store the game and actually play it, with every player input and every rendered frame traveling through the protocol?
 
 The answer is yes. Sorta. It plays terribly. No-one should want this. But it works. [You can try it yourself.](https://doom.singi.dev/)
 
-Fair warning: this is a technical post. If you're here for the details, you're in the right place.
+Fair warning: this is a technical post.
 
 ## The data flow
 
@@ -179,7 +179,7 @@ The realistic ceiling is probably ~15-20fps with favorable Jetstream latency. Fo
 
 **AT Protocol is very flexible.** Custom lexicons, blob storage, OAuth with granular scopes, federation... the building blocks for applications far beyond social media are already there. I'm building [Barazo](https://barazo.com) and [Sifa ID](https://sifa.id) as serious projects on the protocol. This was the fun side project that showed me how much room there is to experiment.
 
-**Self-host your PDS if you're building anything non-trivial.** The AT Protocol is designed for federation. Running your own PDS isn't just about avoiding rate limits, it's about being the authority for your data. The game server produces frame data, so it should host that data on its own PDS. This also eliminates dependency on relay crawling delays.
+**Self-host your PDS if you're building anything non-trivial.** The AT Protocol is designed for federation. Running your own PDS does more than dodge rate limits: it makes you the authority for your data. The game server produces frame data, so it should host that data on its own PDS. This also eliminates dependency on relay crawling delays.
 
 **Jetstream deserves more attention.** Any application built on AT Protocol records can use it for real-time event delivery. Feed generation is the obvious use case, but it works for anything. And it's what makes this game "playable".
 

--- a/src/content/post/how-i-reduced-my-bigtech-dependencies-in-2025/index.mdx
+++ b/src/content/post/how-i-reduced-my-bigtech-dependencies-in-2025/index.mdx
@@ -17,9 +17,9 @@ Have you been paying for a subscriptions, only to every year see the prices go u
 
 I don't like this situation.
 
-So in 2025 I've continued moving towards a more robust (or in some cases even antifragile) setup.
+So in 2025 I've continued moving towards a more resilient (or in some cases even antifragile) setup.
 
-And let's not sugarcoat this: I've been in it way too deep and it's taken me many evenings and weekends to get here. And I'm not done yet. But hopefully in sharing my journey I can A) inspire you to make similar moves and B) make your journey a bit shorter and easier than mine.
+And let's not sugarcoat this: I've been in it way too deep and it's taken me many evenings and weekends to get here. And I'm not done yet. But hopefully by sharing what I did I can A) inspire you to make similar moves and B) make your path a bit shorter and easier than mine.
 
 ## Why change?
 
@@ -37,7 +37,7 @@ I've been an open source user since I first came into contact with Mambo CMS in 
 - Because increasingly, the vendors that have achieved some form of lock-in just do whatever like raising prices while simultaneously making the service worse (Check this rant by [Louis Rossmann on why paying for a service nowadays often gets you a worse experience](https://www.youtube.com/watch?v=o4GZUCwVRLs)). Just being confronted with changes I didn't sign up for is not the experience I like to have.
 - Europe (where I live) is leaning more into open source and technological sovereignty because it's more secure, cost‑effective, flexible, and innovative when done right. Several roadmaps and analyses point to open technologies as a lever for digital autonomy and sustainability in Europe (something which I fully support for all (united) countries, not just Europe).
 
-## Preferences/Principles that keep the journey realistic
+## Preferences/Principles that keep this realistic
 
 - **Open source first**, open standards second: I prefer tools where I can see the code (Astro, Firefox, Immich, Obsidian) and use non-proprietary formats (Markdown, CalDAV).
 - **Data ownership**: I own my data or can export it completely. GDPR-respecting by default.
@@ -111,9 +111,9 @@ If you want to seriously improve your antifragility, start the work with freeing
 
 What might be the biggest shift of all: [Claude Code](https://claude.com/product/claude-code) + [n8n](https://www.n8n.io) + self-hosting. It gives everyone the ability to just build small tools instead of subscribing to yet another service. Or more easily re-use something you found on Github and integrate it into your stack.
 Custom scrapers, specific integrations, tiny utilities that do exactly what I need. Previously these used to require finding (and paying for) niche SaaS products or hiring developers. Now I build them myself in a couple of hours.
-This democratization of software creation might be the ultimate unlock for software sovereignty. YOU are becoming the toolmaker now.
+This democratization of software creation might be the biggest step yet towards software sovereignty. YOU are becoming the toolmaker now.
 
-I left out a lot, and I'm happy to dive into any specific area if there's interest, let me know in the comments!
+I left out a lot, and I'm happy to go deeper on any specific area if there's interest, let me know in the comments!
 
 ---
 

--- a/src/content/post/introducing-barazo-community-forums/index.mdx
+++ b/src/content/post/introducing-barazo-community-forums/index.mdx
@@ -135,6 +135,6 @@ Check it out at [barazo.forum](https://barazo.forum) (for now just a direct link
 
 What would convince you to move your community to a platform where members actually own their data?
 
-PS: I'll write about the Barazo/ATproto reputation system next. This is not necessarily a forum-specific issue, but in these days of rapidly growing AI-slop content an important one to address from the foundational level.
+PS: I'll write about the Barazo/ATproto reputation system next. This is not necessarily a forum-specific issue, but in these days of fast-growing AI-slop content an important one to address from the foundational level.
 
 PPS: If you're rethinking your own community platform or trying to design portable, antifragile community infrastructure at your company, I take on a few advisory engagements at a time. Details at [/retainer](/retainer/).

--- a/src/content/post/practical-guide-to-building-antifragile-tech-stack/index.mdx
+++ b/src/content/post/practical-guide-to-building-antifragile-tech-stack/index.mdx
@@ -85,10 +85,10 @@ These three steps give you identity independence. Once you own your identity, ev
 
 ## The point isn't purity
 
-Every system involves trade-offs. The question isn't whether you've achieved perfect digital independence. It's whether you're moving in a direction that gives you more control, more resilience, and fewer single points of failure.
+Every system involves trade-offs. The question is whether you're moving in a direction that gives you more control and fewer single points of failure.
 
 Start with one thing. Maybe it's moving your notes to Markdown. Maybe it's checking whether your smart home devices work offline. Maybe it's just asking "can I export this?" before signing up for the next shiny service. Figure out what your biggest pain point is and start there.
 
-Small steps compound. A year from now, you'll be surprised how far you've come.
+Small steps compound. A year from now, you'll probably be surprised how far you've come.
 
-What principle resonates most with your own situation?
+Which principle fits your own situation best?

--- a/src/content/post/self-hosted-github-runner-vps/index.mdx
+++ b/src/content/post/self-hosted-github-runner-vps/index.mdx
@@ -57,7 +57,7 @@ On that box I run four parallel runner agents, all registered to the same self-h
 
 The CI workflow then asks for that pool by label, and the GitHub-hosted aggregator step only kicks in at the end to fan-in the results.
 
-> **The real unlock is that "one CI job at a time" is the wrong default. Once you control the box, you can run several jobs in parallel and shard slow suites across them.**
+> Most of the speed-up comes from dropping the "one CI job at a time" default: once you control the box, you can run several jobs in parallel and shard slow suites across them.
 
 End result on my biggest repo: ~12 minutes down to ~3-4 minutes wall-clock, for about half the monthly cost.
 

--- a/src/content/post/standard-site-card-on-bluesky/index.mdx
+++ b/src/content/post/standard-site-card-on-bluesky/index.mdx
@@ -43,9 +43,7 @@ If you don't have Standard.site set up on your site at all yet, start there firs
 
 ## What about DNS TXT and `/.well-known/` files?
 
-Some community write-ups may suggest one of these is needed but they're not. The confusion doesn't come out of thin air though.
-
-None of them are needed for the Bluesky card. Here's what each one actually does:
+Some community write-ups suggest one of these is needed for the Bluesky card. They're not. The confusion doesn't come out of thin air though, so here's what each one actually does:
 
 | File / record                                         | What it does                                                                                                                                                                                                                                                                                                  |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -53,7 +51,7 @@ None of them are needed for the Bluesky card. Here's what each one actually does
 | **`/.well-known/atproto-did`** (plain-text DID)       | Same purpose as above: handle resolution. An alternative to the DNS TXT record, useful for hosts where you can't set TXT records, or for handles too long for DNS.                                                                                                                                            |
 | **`/.well-known/site.standard.publication`** (AT-URI) | [Standard.site's own verification](https://standard.site/docs/verification/): proves your domain controls the publication record, so a consumer that checks it won't trust an impersonator. The Standard.site docs call verification a best practice for production records. Bluesky's card doesn't check it. |
 
-All of these have their own jobs. DNS TXT and `atproto-did` make your domain usable as a Bluesky handle. The Standard.site verification file proves your domain controls the publication record, which is how a consumer knows the record isn't someone impersonating you. The Standard.site docs recommend verification as a best practice for production, and a strict reader can refuse to trust an unverified record. But none of them get the card to render on Bluesky. The AppView doesn't load your website at all, it only reads from the PDS.
+So all of them have their own jobs, but none of them get the card to render on Bluesky. The AppView doesn't load your website at all, it only reads from the PDS.
 
 ### What if your hosting blocks `/.well-known/`?
 
@@ -204,4 +202,4 @@ Your `site.standard.publication` record lives on your PDS as a plain AT Protocol
 
 It reads the same Standard.site records straight from the network and shows your publication in a completely different app. Same data, different readers, each taking the parts it cares about. Set the record once and you're done: that's the point of publishing to an open protocol instead of one platform's API. Interoperability FTW!
 
-Hannah Shelley wrote up [putting her Neocities blog on ATProto](https://hannahshelley.neocities.org/blog/2026_05_31_ATProto.html), a nice real-world walkthrough of the roll-your-own path on a fully static host.
+Hannah Shelley wrote up [putting her Neocities blog on atproto](https://hannahshelley.neocities.org/blog/2026_05_31_ATProto.html), a nice real-world walkthrough of the roll-your-own path on a fully static host.

--- a/src/content/post/start-building-anti-fragile-communities/index.mdx
+++ b/src/content/post/start-building-anti-fragile-communities/index.mdx
@@ -27,7 +27,7 @@ Twitter ownership changes. Reddit alters API pricing. LinkedIn tweaks the algori
 
 A lot of communities are built on platforms they don't control, optimized for engagement metrics that aim for extraction. Members spend years contributing, building relationships, creating value. Then one vendor decision wipes it away. Members deserve better. Your community deserves better.
 
-The difference between communities that fragment under stress and communities that emerge stronger isn't luck. It's architecture. And you can build it starting today.
+The difference between communities that fragment under stress and communities that emerge stronger is architecture, not luck. And you can build it starting today.
 
 ---
 
@@ -35,7 +35,7 @@ In the early 2000s, I watched developers in the Joomla! ecosystem fork the platf
 
 Today? Whatever you want to do online (websites, commerce, payments, e-mail, video calls, banking, you name it): You pick between a handful of (often USA-based) SaaS platforms. Accept their terms. And keep your fingers crossed 🤞 they don't change their API pricing, shut down your integration or worse: kick you out overnight.
 
-A lot of people seem to have stopped believing they can shape the platforms they depend on, or even that they implement (or even create) better alternatives. That's not (just) a failure of the tech market: it's a failure of vision.
+A lot of people seem to have stopped believing they can shape the platforms they depend on, or even that they implement (or even create) better alternatives. That's a failure of vision more than a failure of the tech market.
 
 And it makes every community more fragile than it needs to be.
 
@@ -59,17 +59,17 @@ The pattern repeats:
 
 Some of these platforms even greatly facilitate misinformation and harassment because engagement drives revenue. Is that what you want as a main driver for your community platform 😱? Digital strategist Deja Foxx named this in [her recent TED talk](https://www.youtube.com/watch?v=yWj33Ud8iag): "hate-for-profit business models." Communities collapse when members realize they're treated as products, not participants.
 
-The "move-fast-and-break-things" era broke trust. Communities built on extractive platforms don't survive existential challenges but fragment instead.
+The "move-fast-and-break-things" era broke trust. Communities built on extractive platforms fragment when an existential challenge hits.
 
 I've watched this cycle repeat for two decades. Different platforms. Same outcome. It's annoying. I fell in this trap myself multiple times. Don't be me 😅.
 
-Many community leaders and programs aim for growth and resilience: bounce back from crises, survive platform migrations, weather controversies. But resilience is defensive. It's "just" about withstanding shocks.
+Many community leaders and programs aim for growth and resilience: bounce back from crises, survive platform migrations, weather controversies. But resilience is defensive: it's "just" about withstanding shocks.
 
 What if we designed communities that gained from change (or even shocks) instead?
 
 ## Beyond resilience: what anti-fragility means
 
-[Nassim Taleb's framework](https://en.wikipedia.org/wiki/Antifragile_%28book%29) gives us better language: anti-fragile systems don't just survive stress: they get stronger from it.
+[Nassim Taleb's framework](https://en.wikipedia.org/wiki/Antifragile_%28book%29) gives us better language: anti-fragile systems get stronger from stress, they don't merely survive it.
 
 <Image src={image1} alt="Book cover of Antifragile by Nassim Taleb" />
 
@@ -119,7 +119,7 @@ Anti-fragile communities counter this by giving members genuine power over their
 
 When I scaled Meet Magento Netherlands from 100 to 600 attendees, the growth wasn't what mattered. What mattered: other community leaders copied the model. Modified it. Made it their own across Europe, then globally. Same at Spryker where we built whitepapers for others to organize Meetups, Unconferences and Hackathons. The true validation is not when your community team organizes these, but when others pick it up themselves (and give it their own twist). The pattern got stronger every time someone adapted it. Anti-fragile growth through decentralized participation. Not franchise control. Not brand protection. Just a good structure becoming better through variation.
 
-The strongest community lock-in isn't technical. Members believing they're building something together that elevates what's possible for individual human beings keeps them engaged, something that couldn't exist anywhere else.
+The strongest community lock-in isn't technical. It's members believing they're building something together that couldn't exist anywhere else.
 
 ## What anti-fragile architecture actually looks like
 
@@ -135,7 +135,7 @@ I'm not talking theory. I'm talking about communities operating at scale right n
 
 In general I would say all mature open source community tools would fall under this same anti-fragility umbrella making you less dependent form external sources.
 
-So clearly these are not utopian experiments but functional alternatives proving a different model works.
+So these aren't utopian experiments. They're functional alternatives, and they prove a different model works.
 
 Three principles keep showing up:
 
@@ -151,11 +151,11 @@ Deja Foxx reminds us: these platforms aren't permanent. The social media compani
 
 This year alone we've witnessed mass migrations. Twitter to [Bluesky](https://bsky.app/profile/gui.do). TikTok to RedNote (idealy, use neither...). When platforms reveal their fragility, communities scatter unless they were designed not to.
 
-AI is fracturing how we interact with technology. Chat interfaces. Autonomous agents. Distributed systems. The neat platform categories we relied on are dissolving. This isn't a threat but an amazing opportunity to rebuild with better principles.
+AI is fracturing how we interact with technology. Chat interfaces. Autonomous agents. Distributed systems. The neat platform categories we relied on are dissolving. That's an opportunity to rebuild with better principles.
 
 Platform consolidation is hitting natural limits. Regulatory pressure in Europe. User revolts everywhere. Communities demanding better terms. The cracks are showing.
 
-The next few years determine whether we get locked into centralized AI ecosystems or whether we build genuine alternatives. Real alternatives. Not just open source projects that get acquired and shut down. Sustainable ecosystems designed to enrich the lives of individual human beings through decentralized participation.
+The next few years determine whether we get locked into centralized AI ecosystems or whether we build genuine alternatives. Real alternatives, not open source projects that get acquired and shut down. Sustainable ecosystems that enrich the lives of individual people through decentralized participation.
 
 There's energy for alternatives that actually promote human dignity and individual expression. Open source AI models challenging closed systems. Women-led platforms like Sunroom (creator-owned monetization) and Lore (community-governed search) proving different architectures work.
 

--- a/src/content/post/the-collapse-of-traditional-commerce-why-innovation-is-no-longer-optional/index.mdx
+++ b/src/content/post/the-collapse-of-traditional-commerce-why-innovation-is-no-longer-optional/index.mdx
@@ -39,17 +39,17 @@ All leading to the overall question: is the classic model of value creation in c
   height={450}
 />
 
-In the rapidly evolving landscape of global commerce, a truly seismic shift is underway that threatens to topple the foundations of traditional business models. As the CEO of a commerce company, you might find yourself standing on increasingly shaky ground. The pillars that once supported the construction of retail success are crumbling, and the tremors are impossible to ignore. Let's examine why the old ways of creating value are becoming obsolete and why innovation is now a matter of survival.
+Global commerce is shifting fast, and a lot of traditional business models look shaky because of it. If you're running a commerce company, the things that used to guarantee retail success aren't holding up the way they used to. So let's look at why the old ways of creating value are becoming obsolete, and why innovation is now a matter of survival.
 
 ---
 
-## A) The End of Operations as We Know It
+## A) The end of operations as we know it
 
-Remember when mastering your supply chain was the key to victory? Those days are fading fast.
+Remember when getting your supply chain right was the key to winning? Those days are fading fast.
 
-Businesses are increasingly challenged to adapt to technological advancements, such as artificial intelligence (AI) and automation, which are reshaping traditional workflows and operational paradigms [[1](https://blog.hubspot.com/marketing/biggest-consumer-behavior-shifts)][[5](https://www.aspen.edu/altitude/the-future-of-work-how-ai-and-automation-are-changing-business/)].
+Businesses are increasingly challenged to adapt to technological advancements, such as artificial intelligence (AI) and automation, which are reshaping traditional workflows and operations [[1](https://blog.hubspot.com/marketing/biggest-consumer-behavior-shifts)][[5](https://www.aspen.edu/altitude/the-future-of-work-how-ai-and-automation-are-changing-business/)].
 
-Companies like TEMU and SHEIN have rewritten the rulebook, achieving exponential growth by prioritizing speed and adaptability over operational perfection. TEMU's meteoric rise from launch to 100 million active users in the US in just six months—demonstrates the power of this new paradigm. Their ability to rapidly expand into 48 countries while maintaining growth underscores a fundamental shift: agility trumps efficiency in today's market.
+Companies like TEMU and SHEIN have rewritten the rulebook, growing fast by prioritizing speed and adaptability over operational perfection. TEMU went from launch to 100 million active users in the US in just six months, and expanded into 48 countries while keeping that growth going. The shift is pretty clear: agility beats efficiency in today's market.
 
 <Image
   src={image3}
@@ -58,9 +58,9 @@ Companies like TEMU and SHEIN have rewritten the rulebook, achieving exponential
   height={450}
 />
 
-## B) The Price & Sustainability Paradox
+## B) The price & sustainability paradox
 
-Conventional wisdom dictated that competitive pricing was the path to market dominance. However, the success of players like SHEIN challenges this notion. Despite offering rock-bottom prices, SHEIN's growth has outpaced established giants like Zalando and Zara. SHEIN's true competitive advantage isn't just low prices (like other competitors have as well), but their incredibly fast turnaround from design to market. This suggests that while price remains important, it's no longer the sole determinant of success. The new currency is speed-to-market and trend alignment, forcing traditional retailers to rethink their entire approach to product development and pricing strategies.
+The old wisdom said competitive pricing was the path to market dominance. SHEIN complicates that. They offer rock-bottom prices, sure, but their growth has outpaced established giants like Zalando and Zara, and the real edge isn't the low prices (plenty of competitors have those too), it's how fast they go from design to market. So price still matters, but it's no longer the only thing that decides who wins. The new currency is speed-to-market and trend alignment, which pushes traditional retailers to rethink how they do product development and pricing.
 
 <Image
   src={image2}
@@ -70,19 +70,19 @@ Conventional wisdom dictated that competitive pricing was the path to market dom
 />
 *Source: excitingcommerce.de / April 2024*
 
-A counter trend is the growing consumer consciousness regarding corporate responsibility, forcing businesses to increasingly align with ethical standards, focusing on sustainability, diversity, and inclusivity. A significant majority of consumers—70%— say they are willing to pay a premium for ethically sourced and sustainable products, while 66% expect brands to understand their needs and preferences [[3](https://www.deloitte.com/global/en/Industries/consumer/research/future-of-consumer-industry.html)].
+There's a counter trend though: consumers care more about corporate responsibility, which pushes businesses toward sustainability, diversity, and inclusivity. 70% of consumers say they're willing to pay a premium for ethically sourced and sustainable products, and 66% expect brands to understand their needs and preferences [[3](https://www.deloitte.com/global/en/Industries/consumer/research/future-of-consumer-industry.html)].
 
-This shift from profit-driven motives to socially responsible practices is becoming imperative, as modern consumers prioritize companies that reflect their values [[2](https://businessnes.com/future-business-trends/)]. Companies will be compelled to integrate sustainability into their core strategies, engaging in eco-friendly practices and circular economy models to maintain competitiveness [[1](https://blog.hubspot.com/marketing/biggest-consumer-behavior-shifts)].
+That move from purely profit-driven to socially responsible is becoming hard to ignore, because consumers increasingly prefer companies that reflect their values [[2](https://businessnes.com/future-business-trends/)]. So companies will need to build sustainability into their core strategy, with eco-friendly practices and circular economy models, to stay competitive [[1](https://blog.hubspot.com/marketing/biggest-consumer-behavior-shifts)].
 
 So research shows consumers making sustainable choices, but the (SHEIN/TEMU) numbers show us that price and fast turnaround are still winning... On which strategy will you place your bets?
 
 RIP ❌ Inbound Logistics & RIP ❌ Classic Operations
 
-## C) Marketing: From Cost Center to Profit Engine
+## C) Marketing: from cost center to profit engine
 
-The traditional view of marketing as a necessary expense is obsolete. Techniques such as hyper-personalization, driven by real-time data and artificial intelligence, allow businesses to deliver tailored marketing and product recommendations based on individual consumer behavior. This shift helps mitigate issues related to choice overload and enhances customer satisfaction [[8](https://www.artefact.com/blog/ai-and-competitiveness-five-predictions-for-retail-by-2030/)][[9](https://www.forbes.com/councils/forbestechcouncil/2023/07/03/the-future-of-ai-powered-personalization-the-potential-of-choices/)].
+Treating marketing as a necessary expense is outdated. Hyper-personalization, driven by real-time data and AI, lets businesses serve marketing and product recommendations based on individual consumer behavior, which helps with choice overload and keeps customers happier [[8](https://www.artefact.com/blog/ai-and-competitiveness-five-predictions-for-retail-by-2030/)][[9](https://www.forbes.com/councils/forbestechcouncil/2023/07/03/the-future-of-ai-powered-personalization-the-potential-of-choices/)].
 
-Amazon's transformation of its marketing division into a revenue powerhouse is a wake-up call for the industry. With advertising revenues skyrocketing to rival its core retail business, Amazon has effectively turned a cost center into a profit engine. This shift demands a fundamental reevaluation of how commerce companies view and leverage their marketing capabilities.
+Amazon turned its marketing division into a revenue machine, and that should be a wake-up call for the industry. Its advertising revenues have grown to rival the core retail business, so a cost center became a profit engine. That kind of shift means commerce companies have to seriously rethink how they use their marketing.
 
 <Image
   src={image4}
@@ -91,17 +91,17 @@ Amazon's transformation of its marketing division into a revenue powerhouse is a
   height={450}
 />
 
-## D) The Attention Economy
+## D) The attention economy
 
-In the new commerce landscape, attention is the most valuable commodity. The ability to aggregate and monetize user attention has become a primary source of value creation. This explains the success of platforms that excel not just in selling products, but in capturing and retaining user engagement across multiple channels. More than 60% of consumers are engaging in "phygital" shopping, which combines both physical and digital shopping environments [[4](https://www.forbes.com/councils/forbestechcouncil/2024/01/26/the-data-driven-future-how-technology-is-impacting-customer-buying-habits-and-market-research/)]. This demand for convenience and seamless experiences underscores the necessity for businesses to provide integrated and coherent shopping journeys across various platforms.
+In the new commerce world, attention is the most valuable thing you can have. Being able to aggregate and monetize user attention has become a primary source of value, which is why the platforms doing well aren't just good at selling products, they're good at capturing and keeping user engagement across multiple channels. More than 60% of consumers now do "phygital" shopping, mixing physical and digital environments [[4](https://www.forbes.com/councils/forbestechcouncil/2024/01/26/the-data-driven-future-how-technology-is-impacting-customer-buying-habits-and-market-research/)]. That demand for convenience means businesses have to offer connected, coherent shopping across platforms.
 
-The implications are clear: commerce companies must evolve from mere product sellers to attention brokers, or risk irrelevance.
+So the takeaway is pretty clear: commerce companies have to go from being product sellers to attention brokers, or risk becoming irrelevant.
 
 RIP ❌ Classic Marketing & Sales
 
-## E) The Workforce Crisis
+## E) The workforce crisis
 
-The global workforce crisis adds another layer of complexity to this changing landscape. While automation may streamline repetitive tasks, it simultaneously opens avenues for new roles focused on managing and improving automated systems. This creates a need for workers skilled in data analysis, AI programming, and system management, thereby redefining the workforce landscape [[5](https://www.aspen.edu/altitude/the-future-of-work-how-ai-and-automation-are-changing-business/)][[6](https://www.encora.com/insights/e-commerce-4.0-the-emerging-world-of-immersive-commerce)]. This shift necessitates a complete overhaul of human resource strategies, focusing on continuous learning and skill development to remain competitive.
+The global workforce crisis adds another complication. Automation handles repetitive tasks, but it also creates new roles focused on managing and improving those automated systems. So now you need workers skilled in data analysis, AI programming, and system management [[5](https://www.aspen.edu/altitude/the-future-of-work-how-ai-and-automation-are-changing-business/)][[6](https://www.encora.com/insights/e-commerce-4.0-the-emerging-world-of-immersive-commerce)]. That means rethinking HR strategy around continuous learning and skill development to stay competitive.
 
 <Image src={image5} alt="Global Workforce Crisis" width={800} height={450} />
 
@@ -124,12 +124,12 @@ The above trends lead to a complete breakdown of the primary activities of the c
 
 # The Path Forward: Commerce 3.0
 
-To survive and thrive in this new era, commerce companies must embrace a radically different model of value creation. As Alex mention in his talk, the future belongs to those who can master:
+To survive in this new era, commerce companies need a very different model of value creation. As Alex mentioned in his talk, the future belongs to those who can master:
 
-- Offer Aggregation: Curating a diverse, rapidly evolving product mix that keeps pace with consumer trends.
-- Attention Flywheel: Building platforms that not only sell products but capture and monetize user attention.
-- User Insights: Leveraging data to understand and predict consumer behavior at an unprecedented level.
-- Seller/Buyer Matchmaking: Creating ecosystems that efficiently connect supply with demand.
+- Offer aggregation: curating a diverse, fast-moving product mix that keeps up with consumer trends.
+- Attention flywheel: building platforms that sell products and capture and monetize user attention.
+- User insights: using data to understand and predict consumer behavior at a level we haven't seen before.
+- Seller/buyer matchmaking: building ecosystems that connect supply with demand efficiently.
 
 <Image
   src={image7}
@@ -138,15 +138,15 @@ To survive and thrive in this new era, commerce companies must embrace a radical
   height={450}
 />
 
-The market is still characterized by a high growth stage, driven by rapid technological innovation and increasing demand across various sectors [[7](https://www.grandviewresearch.com/industry-analysis/immersive-technology-market-report)]. Companies are exploring innovative strategies, such as digitizing supply chain functions and fostering collaboration between human and automated systems, to mitigate talent scarcity and turnover rates [[7](https://www.grandviewresearch.com/industry-analysis/immersive-technology-market-report)].
+The market is still in a high-growth stage, driven by fast technological innovation and rising demand across sectors [[7](https://www.grandviewresearch.com/industry-analysis/immersive-technology-market-report)]. Companies are trying new strategies, like digitizing supply chain functions and getting human and automated systems to work together, to deal with talent scarcity and turnover [[7](https://www.grandviewresearch.com/industry-analysis/immersive-technology-market-report)].
 
 ## But is it enough?
 
-The stakes couldn't be higher. Those who cling to outdated models of value creation face the very real risk of obsolescence. The rapid rise of new players and the transformation of established giants prove that no company is too big to fail—or too small to disrupt.
+Companies that hang on to outdated models of value creation risk becoming obsolete. The fast rise of new players and the reinvention of established giants shows that no company is too big to fail, or too small to disrupt.
 
-Innovation is no longer a luxury or a side project; it's the very essence of survival in the new commerce landscape. The question is not whether you should innovate, but how quickly you can transform your entire business model to thrive in this new reality.
+Innovation isn't a luxury or a side project anymore, it's how you survive in the new commerce world. So the question isn't whether you should innovate, but how quickly you can change your whole business model to thrive.
 
-The collapse of traditional commerce models is not a distant threat: it's happening now. Will your company be a casualty of this seismic shift, or will you seize the opportunity to turn this volatility into value? The choice is yours, but the clock is ticking.
+The collapse of traditional commerce models isn't a distant threat: it's happening now. Will your company be a casualty of it, or will you turn the volatility into value? The choice is yours, but the clock is ticking.
 
 ---
 


### PR DESCRIPTION
Small copy refresh across 13 blog posts published in 2025-2026, plus a few spelling fixes.

What changed:
- Tightened phrasing and cut filler/stock constructions
- Lowercased a few title-case headings to match the site style
- Removed stray dashes and a couple of redundant restatements
- Fixed spelling typos in the bigtech-independence post (slightly, indestructible, possessive its)

What did NOT change:
- No edits to facts, numbers, links, images, code blocks, or frontmatter
- 3 posts needed no changes and are untouched
- The ATmosphere Conf 2026 post was intentionally excluded (handled separately)

Commits:
- content: small text updates across 2025-2026 articles
- content: fix spelling typos in bigtech-independence post

Verification: MDX prose scan clean (no raw JSX tags or stray brace expressions introduced); base branch merged with no conflicts.