### PR TITLE
content: add ATmosphereConf, note Sifa unconference sessions

### DIFF
--- a/src/data/events.json
+++ b/src/data/events.json
@@ -8,7 +8,19 @@
     "country": "GB",
     "url": "https://experimentationelite.com/?utm_source=gui.do&utm_medium=events&utm_campaign=space-academy-2026",
     "workshop": false,
-    "role": "Advisor & Podcast host",
+    "role": "Advisor & Podcast host · Sifa unconference session",
+    "topic": "",
+    "relatedPresentationSlugs": []
+  },
+  {
+    "id": "atmosphereconf-2026",
+    "name": "ATmosphereConf",
+    "date": "2026-03-28",
+    "city": "Vancouver",
+    "country": "CA",
+    "url": "https://atmosphereconf.org/",
+    "workshop": false,
+    "role": "Unconference session on Sifa",
     "topic": "",
     "relatedPresentationSlugs": []
   },


### PR DESCRIPTION
Adds **ATmosphereConf 2026** (Vancouver, Mar 28) as a new event where I ran a Sifa unconference session, and updates the existing **Space Academy 2026** entry to note its Sifa unconference session alongside the Advisor/Podcast host role.

- Pure data change in `src/data/events.json` (validated, 203 events).
- Both are past events (today 2026-06-12), so they render in the 2026 past-events group.
- ATmosphereConf uses the default calendar icon (no logo asset).