### PR TITLE
fix(author): serve sharp 2x avatar in post byline

### DIFF
--- a/src/components/Author/AuthorByline.astro
+++ b/src/components/Author/AuthorByline.astro
@@ -27,6 +27,7 @@ const authorUrl = `/authors/${author.id}`;
           alt={`${name}'s avatar`}
           width={variant === "compact" ? 48 : 64}
           height={variant === "compact" ? 48 : 64}
+          densities={[2]}
           quality="high"
           loading="eager"
           class={`rounded-full object-cover ${variant === "compact" ? "h-12 w-12" : "h-16 w-16"}`}


### PR DESCRIPTION
## What

Follow-up to #236. The post byline avatar (the prominent one at the top of each article) had the same retina issue as the bio box: it rendered a 1× 48px (compact) / 64px avatar into a slot displayed at exactly that CSS size, so on 2× screens it was upscaled and soft.

Added `densities={[2]}` to `AuthorByline.astro` so Astro emits a 2× variant + `srcset`.

## Verification

- `astro build` passes; rendered post HTML now carries `srcset="...avatar...96px 2x"` for the byline (96px = 2× the 48px compact size).