### PR TITLE
perf(home): render feed GIFs as WebM video (98% smaller payload)

### DIFF
--- a/src/components/Activity/ActivityFeed.astro
+++ b/src/components/Activity/ActivityFeed.astro
@@ -152,14 +152,38 @@ const fragments = (text: string) =>
                       )}
                     </p>
                   )}
-                  {item.imageUrl && (
-                    <img
+                  {item.videoWebm || item.videoMp4 ? (
+                    <video
                       class="fi-img"
-                      src={item.imageUrl}
-                      alt={item.imageAlt || ""}
-                      loading="lazy"
-                      decoding="async"
-                    />
+                      autoplay
+                      loop
+                      muted
+                      playsinline
+                      preload="none"
+                      poster={item.mediaPoster}
+                      width={item.mediaWidth}
+                      height={item.mediaHeight}
+                      aria-label={item.imageAlt || "Animated GIF"}
+                    >
+                      {item.videoWebm && (
+                        <source src={item.videoWebm} type="video/webm" />
+                      )}
+                      {item.videoMp4 && (
+                        <source src={item.videoMp4} type="video/mp4" />
+                      )}
+                    </video>
+                  ) : (
+                    item.imageUrl && (
+                      <img
+                        class="fi-img"
+                        src={item.imageUrl}
+                        alt={item.imageAlt || ""}
+                        loading="lazy"
+                        decoding="async"
+                        width={item.mediaWidth}
+                        height={item.mediaHeight}
+                      />
+                    )
                   )}
                   {(item.likes || item.replies || item.reposts) && (
                     <div class="fi-meta">

--- a/src/data/homeContent.ts
+++ b/src/data/homeContent.ts
@@ -80,6 +80,16 @@ export interface ActivityItem {
   /** Thumbnail URL for posts that embed an image. */
   imageUrl?: string;
   imageAlt?: string;
+  /** For animated GIF embeds (Klipy), the much smaller video versions so the
+   *  feed renders a looping <video> instead of a multi-MB .gif. Falls back to
+   *  imageUrl when these are absent. */
+  videoWebm?: string;
+  videoMp4?: string;
+  /** Small static thumbnail shown as the <video> poster before it plays. */
+  mediaPoster?: string;
+  /** Intrinsic media dimensions (from the embed), for explicit width/height. */
+  mediaWidth?: number;
+  mediaHeight?: number;
   /** Source URL (live items link to the original post/review/etc.). */
   url?: string;
 }

--- a/src/lib/sifaActivity.ts
+++ b/src/lib/sifaActivity.ts
@@ -44,23 +44,85 @@ interface PostMeta {
   image?: string;
   imageAlt?: string;
   isGif?: boolean;
+  videoWebm?: string;
+  videoMp4?: string;
+  poster?: string;
+  mediaWidth?: number;
+  mediaHeight?: number;
 }
 
-/** Pull the first image/GIF from a getPosts embed view. GIFs (Tenor/Klipy
- *  externals) use the animated `.gif` URL so they play; other externals use the
+/**
+ * Klipy serves a tiny WebM/MP4 alongside every animated GIF. Bluesky's GIF
+ * composer embeds the URL with the video IDs + dimensions in the query string:
+ *   .../ii/{hash}/{a}/{b}/{stem}.gif?ww=498&hh=485&webm={id}&mp4={id}
+ * The video lives at the same path with the stem swapped for the id:
+ *   .../ii/{hash}/{a}/{b}/{webmId}.webm   (≈68 KB vs ≈2 MB for the .gif)
+ * Generic by construction — reads the params off whatever klipy GIF the live
+ * feed surfaces. Returns undefined for non-klipy GIFs (e.g. Tenor) so callers
+ * fall back to rendering the .gif. */
+function klipyVideo(
+  gifUrl: string,
+):
+  | { webm?: string; mp4?: string; width?: number; height?: number }
+  | undefined {
+  try {
+    const u = new URL(gifUrl);
+    if (!u.hostname.endsWith("klipy.com")) return undefined;
+    const webmId = u.searchParams.get("webm");
+    const mp4Id = u.searchParams.get("mp4");
+    if (!webmId && !mp4Id) return undefined;
+    // Path directory up to (and including) the last slash, dropping `stem.gif`.
+    const dir = u.pathname.replace(/[^/]+\.gif$/i, "");
+    if (!dir.endsWith("/")) return undefined; // not the expected shape
+    const base = `${u.origin}${dir}`;
+    const dim = (k: string) => {
+      const n = Number(u.searchParams.get(k));
+      return Number.isFinite(n) && n > 0 ? n : undefined;
+    };
+    return {
+      webm: webmId ? `${base}${webmId}.webm` : undefined,
+      mp4: mp4Id ? `${base}${mp4Id}.mp4` : undefined,
+      width: dim("ww"),
+      height: dim("hh"),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Pull the first image/GIF from a getPosts embed view. Animated GIFs (Klipy)
+ *  get their small WebM/MP4 versions so the feed plays a lightweight <video>;
+ *  the animated `.gif` URL stays as the fallback. Other externals use the
  *  static thumbnail. */
 function extractImage(embed: any): {
   image?: string;
   imageAlt?: string;
   isGif?: boolean;
+  videoWebm?: string;
+  videoMp4?: string;
+  poster?: string;
+  mediaWidth?: number;
+  mediaHeight?: number;
 } {
   if (!embed) return {};
   const imgs = embed.images ?? embed.media?.images;
   if (imgs?.[0]?.thumb)
     return { image: imgs[0].thumb, imageAlt: imgs[0].alt || undefined };
   const ext = embed.external ?? embed.media?.external;
-  if (ext?.uri && /\.gif(\?|$)/i.test(ext.uri))
-    return { image: ext.uri, imageAlt: ext.title || "GIF", isGif: true };
+  if (ext?.uri && /\.gif(\?|$)/i.test(ext.uri)) {
+    const vid = klipyVideo(ext.uri);
+    return {
+      image: ext.uri,
+      imageAlt: ext.title || "GIF",
+      isGif: true,
+      videoWebm: vid?.webm,
+      videoMp4: vid?.mp4,
+      // Static CDN thumbnail (small) → <video> poster, not the multi-MB .gif.
+      poster: typeof ext.thumb === "string" ? ext.thumb : undefined,
+      mediaWidth: vid?.width,
+      mediaHeight: vid?.height,
+    };
+  }
   if (ext?.thumb) return { image: ext.thumb, imageAlt: ext.title || undefined };
   return {};
 }
@@ -247,6 +309,11 @@ function mapItem(raw: any, meta?: PostMeta): ActivityItem | null {
         hasImage: !!meta?.image,
         imageUrl: meta?.image,
         imageAlt: meta?.imageAlt,
+        videoWebm: meta?.videoWebm,
+        videoMp4: meta?.videoMp4,
+        mediaPoster: meta?.poster,
+        mediaWidth: meta?.mediaWidth,
+        mediaHeight: meta?.mediaHeight,
       };
     }
     case "Reviews": {

--- a/src/lib/sifaActivity.ts
+++ b/src/lib/sifaActivity.ts
@@ -67,7 +67,10 @@ function klipyVideo(
   | undefined {
   try {
     const u = new URL(gifUrl);
-    if (!u.hostname.endsWith("klipy.com")) return undefined;
+    // Exact host or a real subdomain — `.endsWith("klipy.com")` alone would
+    // also match a look-alike like `evilklipy.com`.
+    const host = u.hostname;
+    if (host !== "klipy.com" && !host.endsWith(".klipy.com")) return undefined;
     const webmId = u.searchParams.get("webm");
     const mp4Id = u.searchParams.get("mp4");
     if (!webmId && !mp4Id) return undefined;


### PR DESCRIPTION
## What

The homepage "Right now" activity feed embedded Bluesky reaction GIFs at full size — Klipy `.gif` files of ~3-4 MB each — which dominated the page payload (~7.6 MB total, GTmetrix flagged "enormous payloads" / "use video formats").

Klipy already serves a tiny WebM/MP4 alongside every GIF, with the video IDs and dimensions in the embed URL's query string. This parses those per-URL at render time and plays a looping muted `<video>` (webm source, mp4 fallback) with the small static CDN thumbnail as the poster and explicit `width`/`height`.

## Impact

For the two GIFs currently in the feed:

| | Before (.gif) | After (.webm + poster) |
|---|---|---|
| Judge Judy | 3.76 MB | 72 KB + 19 KB poster |
| Nick Zetta | 3.20 MB | 56 KB |
| **Total** | **~6.96 MB** | **~166 KB (98% smaller)** |

Also resolves the related GTmetrix items (properly-size-images, use-video-formats, most of the cache-policy weight) since they were all the same GIFs, and adds explicit media dimensions (helps CLS).

## How it stays correct for the live feed

The feed refreshes and surfaces new GIFs regularly. The converter is generic by construction: it reads `webm`/`mp4`/`ww`/`hh` straight off whatever Klipy URL appears, so any new GIF is converted automatically. Non-Klipy embeds (e.g. Tenor) or any URL missing the params fall back to the `.gif` `<img>` exactly as before — it can't break the feed.

## Verification

- Type check, build, format: pass
- axe WCAG 2 A/AA (light + dark) on `/`: pass (muted decorative video; `video-caption` is axe-incomplete, not a violation; `no-autoplay-audio` exempts muted)
- Constructed URLs verified live: webm/mp4/poster all 200
- Confirmed both feed GIFs render as `<video>` end-to-end via the live dev SSR