### PR TITLE
style(training): keep agentic-engineering lead thesis on one line

### DIFF
--- a/src/pages/training/[course].astro
+++ b/src/pages/training/[course].astro
@@ -112,9 +112,7 @@ const ac = `--ac:var(--color-${course.accent});--ac-deep:var(--color-${course.ac
               The shift
             </span>
             <p class="font-display text-base-900 dark:text-base-50 mt-4 max-w-4xl text-[clamp(1.35rem,2.6vw,1.8rem)] leading-snug font-extrabold tracking-[-0.02em]">
-              {course.intro[0].split(/(?<=\.)\s+(?=[A-Z])/).map((line) => (
-                <span class="block">{line}</span>
-              ))}
+              {course.intro[0]}
             </p>
             <div
               class:list={[


### PR DESCRIPTION
On `/training/agentic-engineering/`, the "The shift" lead split `intro[0]` on sentence boundaries into stacked `<span class="block">` lines, which forced *"It's a different way to build software."* onto its own line.

Render the lead as a single paragraph so *"This isn't a prompting workshop. It's a different way to build software."* reads as one thought (still wraps naturally on narrow viewports).

Only the agentic-engineering course uses `intro`, so this touches just that lead.

Verified: build + format pass; built HTML for the page now contains the full thesis in one paragraph with zero `block` spans.