### PR TITLE
fix(home): mobile viewport overflow & overlap in 2026 redesign

### DIFF
--- a/src/pages/styleguide.astro
+++ b/src/pages/styleguide.astro
@@ -701,7 +701,11 @@ const arrowExamples = [
       <!-- Dropdown Menu -->
       <div id="dropdown-menu" class="mb-8">
         <h3 class="h3">Dropdown Menu</h3>
-        <div class="flex gap-4">
+        <!-- overflow-x-clip: the second demo dropdown's absolutely-positioned
+             menu extends ~9px past a 375px viewport and would otherwise add a
+             horizontal scroll to the whole page. Clip the X overhang only;
+             the menu still opens downward (overflow-y stays visible). -->
+        <div class="flex gap-4 overflow-x-clip">
           <NavDropdown
             navItem={{
               text: "Products",

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -28,7 +28,11 @@
     transform-origin: left center;
   }
   .home .hero-h1 {
-    @apply font-display text-[clamp(2.6rem,6.2vw,4.6rem)] leading-[0.98] font-black tracking-[-0.035em];
+    /* Floor lowered from 2.6rem so the nowrap "community functions" phrase
+       (the .u span) fits one line on phones without forcing the layout
+       viewport wider than the screen. Only affects widths < ~540px; the
+       fluid range and desktop max are unchanged. */
+    @apply font-display text-[clamp(2.05rem,6.2vw,4.6rem)] leading-[0.98] font-black tracking-[-0.035em];
     @apply my-[0.1em] mb-[0.35em];
   }
   .home .hero-h1 .u {
@@ -311,7 +315,13 @@
     border-color: color-mix(in oklab, var(--ac, var(--color-primary-600)) 40%, var(--color-base-200));
   }
   .home .tcourse .tlevel {
-    @apply mb-3 self-start rounded-full px-2.5 py-1 text-[0.72rem] font-bold tracking-[0.07em] whitespace-nowrap uppercase;
+    /* whitespace-normal (not just dropping nowrap) is required to override the
+       global `.tlevel` rule in _redesign.scss, which sets nowrap at lower
+       specificity. The longest home label ("For engineering teams of 5–12 ·
+       Workshop · in-company or cohort") otherwise clips inside the card's
+       overflow-hidden box on mobile. rounded-2xl reads better than a pill once
+       the eyebrow wraps to two lines. */
+    @apply mb-3 self-start rounded-2xl px-2.5 py-1 text-[0.72rem] font-bold tracking-[0.07em] whitespace-normal uppercase;
     color: var(--ac, var(--color-primary-600));
     background: color-mix(in oklab, var(--ac, var(--color-primary-600)) 12%, transparent);
   }
@@ -412,7 +422,11 @@
 
   /* ---- live activity feed ---- */
   .home .feed-wrap {
-    @apply relative;
+    /* On stacked (sub-lg) layouts the feed sits below the stats, and the
+       absolutely-positioned "this is live ↓" note (top: -2.7rem) would ride
+       up into the stats row above it. Reserve space so the note clears the
+       stats. Reset at lg where the feed moves into its own column. */
+    @apply relative mt-12 lg:mt-0;
   }
   .home .feed-note {
     @apply text-love-light dark:text-love absolute left-4 z-[1] inline-flex items-center gap-1 font-hand text-[1.05rem] leading-none font-bold;

--- a/src/styles/components/_redesign.scss
+++ b/src/styles/components/_redesign.scss
@@ -34,7 +34,10 @@
      Used bare (outside .tcourse) on the course detail hero. Picks up the
      per-page `--ac` accent, falling back to primary. */
   .tlevel {
-    @apply font-display inline-flex items-center self-start rounded-full px-3 py-1 text-[0.72rem] font-bold tracking-[0.07em] whitespace-nowrap uppercase;
+    /* whitespace-normal: long combined labels ("For engineering teams of 5–12
+       · Workshop · in-company or cohort") must wrap inside narrow mobile cards
+       instead of clipping against the card's overflow-hidden box. */
+    @apply font-display inline-flex items-center self-start rounded-2xl px-3 py-1 text-[0.72rem] font-bold tracking-[0.07em] whitespace-normal uppercase;
     /* Small uppercase pill: darken the dawn accent a touch more so the small
        text clears AA on the light tinted background. */
     color: color-mix(


### PR DESCRIPTION
## What

Mobile tweaks for the 2026 redesign. Three reported homepage issues plus findings from a full-site mobile scan.

### Homepage (verified at 375px)
1. **"community functions" pushed the page wider than the viewport.** The `.u` highlight span was `white-space: nowrap` at 404px, stretching the layout viewport to 420px. Lowered the `.hero-h1` clamp floor `2.6rem → 2.05rem` so the phrase fits one line on phones. Only affects screens < ~540px; the rotated highlight bar and desktop sizing are unchanged.
2. **"this is live ↓" note overlapped the "...presented in" stat.** The note is `position: absolute; top: -2.7rem`; on the stacked mobile layout it rode up into the stats row. Added `mt-12 lg:mt-0` to `.feed-wrap` — now a 42px gap, reset on desktop.
3. **(found by scan) Training-card eyebrow clipped.** The long label "For engineering teams of 5–12 · Workshop · in-company or cohort" was `nowrap` (477px) and got cut off by the card's `overflow-hidden`. Switched `.tlevel` to `whitespace-normal` + `rounded-2xl` (home rule + global rule so `/training/` and course pages get it). This was clipping on **desktop** `/training/` too.

### Styleguide
- `overflow-x-clip` on the `NavDropdown` component demo so its `invisible absolute` menu no longer adds ~9px of horizontal scroll to the page.

## Full-site mobile scan
Ran a Playwright scan (375px, 22 routes) flagging layout-viewport expansion, document overflow, and off-screen elements. After these fixes everything is clean. The off-screen content on `/about/` and `/events/` is the intentional infinite-scroll logo marquee (contained in `overflow-hidden`), and `/services/` 404s by design (dynamic `[...slug]` route, no index, unlinked).

## Note
The global `.tlevel` went from `rounded-full` (pill) to `rounded-2xl` so the wrapped two-line label reads as a tidy tag; single-line eyebrows site-wide now have slightly less-round corners. Confirmed still clean on desktop.