### PR TITLE
fix(layout): clear fixed navbar on mobile (hero/kicker overlap)

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -12,7 +12,7 @@ const currLocale = getLocaleFromUrl(Astro.url);
 <BaseLayout title="404" description="Error 404 page not found." noindex={true}>
   <div class="home error-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
     >
       <div
         class="grid grid-cols-1 items-center gap-[clamp(1.5rem,4vw,3rem)] md:grid-cols-2"

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -41,7 +41,7 @@ const { Content } = await render(page);
 <BaseLayout title={title} description={description}>
   <div class="home other-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="mx-auto max-w-3xl text-center">
         <h1

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -95,7 +95,7 @@ const card =
   <div class="home about-page">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div
         class="grid grid-cols-1 items-center gap-[clamp(1.5rem,4vw,3rem)] md:grid-cols-[1.2fr_0.8fr]"

--- a/src/pages/ama.astro
+++ b/src/pages/ama.astro
@@ -28,7 +28,7 @@ const description =
   <div class="home ama-page">
     <!-- Hero -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="mx-auto max-w-2xl text-center">
         <span class="hand-note">ask away</span>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -92,7 +92,7 @@ const description = `Articles categorized under ${originalCategory}`;
 <BaseLayout title={title} description={description}>
   <div class="home">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <Breadcrumb
         class="mb-8"

--- a/src/pages/communities.astro
+++ b/src/pages/communities.astro
@@ -105,7 +105,7 @@ const communities = [
   <div class="home communities-page">
     <!-- Hero -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-[60ch]">
         <span class="hand-note">where I've built</span>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -39,7 +39,7 @@ const socials = [
   <div class="home contact-page">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
     >
       <div class="max-w-2xl">
         <span class="hand-note">say hello</span>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -94,7 +94,7 @@ const awards = split(cv.awards);
 >
   <div class="home cv-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <!-- ===== Identity header ===== -->
       <div class="flex flex-col gap-6 sm:flex-row sm:items-start">

--- a/src/pages/events/[id].astro
+++ b/src/pages/events/[id].astro
@@ -84,7 +84,7 @@ const metaDescription = descriptionParts.filter(Boolean).join(" ");
   <div class="home events-detail-page">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-[60ch]">
         <span class="hand-note">on the road</span>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -88,7 +88,7 @@ const sprykerIcon = await getEventIcon("spryker.png");
   <div class="home events-page">
     {/* Hero */}
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-[60ch]">
         <span class="hand-note">where you'll find me</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -92,7 +92,7 @@ const ArrowRight = "→";
   <div class="home">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,4vw,3.5rem)]"
+      class="relative z-10 pt-[clamp(6.5rem,9vw,7rem)] pb-[clamp(2rem,4vw,3.5rem)]"
       aria-label="Introduction"
     >
       <div

--- a/src/pages/newsletter.astro
+++ b/src/pages/newsletter.astro
@@ -14,7 +14,7 @@ import { yearsBuilding } from "@data/siteStats";
 >
   <div class="home newsletter-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(1.5rem,4vw,2.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(1.5rem,4vw,2.5rem)]"
     >
       <div class="mx-auto max-w-2xl text-center">
         <span class="hand-note">the full story</span>

--- a/src/pages/overview.astro
+++ b/src/pages/overview.astro
@@ -21,7 +21,7 @@ const linkClass =
 >
   <div class="home overview-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
     >
       <div class="mx-auto max-w-4xl text-center">
         <span class="hand-note">overview</span>

--- a/src/pages/podcasts.astro
+++ b/src/pages/podcasts.astro
@@ -35,7 +35,7 @@ const podcasts = [
 >
   <div class="home podcasts-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-[60ch]">
         <span class="hand-note">on the mic</span>

--- a/src/pages/post/index.astro
+++ b/src/pages/post/index.astro
@@ -82,7 +82,7 @@ const categories = [...counts.entries()]
 >
   <div class="home">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="mb-10 max-w-3xl">
         <span class="hand-note">the writing</span>

--- a/src/pages/presentations/[slug].astro
+++ b/src/pages/presentations/[slug].astro
@@ -62,7 +62,7 @@ const metaImage = image ? new URL(image, Astro.site) : undefined;
 
   <div class="home presentation-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
     >
       <div class="mx-auto max-w-3xl">
         <Breadcrumb

--- a/src/pages/presentations/index.astro
+++ b/src/pages/presentations/index.astro
@@ -44,7 +44,7 @@ const grid = "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3";
 >
   <div class="home presentations-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <span class="hand-note">speaking</span>
       <h1

--- a/src/pages/press.astro
+++ b/src/pages/press.astro
@@ -104,7 +104,7 @@ const firstVideoIds = videos
 
   <div class="home press-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="mb-12 max-w-2xl">
         <span class="hand-note">in the press</span>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -15,7 +15,7 @@ import BaseLayout from "@layouts/BaseLayout.astro";
   <div class="home privacy-page">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-2xl">
         <span class="hand-note">your data</span>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -10,7 +10,7 @@ import { indieProjects } from "@data/indieProjects";
 >
   <div class="home projects-page">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(3rem,7vw,5.5rem)]"
     >
       <div class="max-w-[60ch]">
         <span class="hand-note">things I'm building</span>

--- a/src/pages/retainer.astro
+++ b/src/pages/retainer.astro
@@ -195,7 +195,7 @@ const testimonials = [
     <section
       id="hero"
       aria-labelledby="hero-heading"
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div
         class="grid items-center gap-[clamp(1.5rem,4vw,3rem)] lg:grid-cols-[7fr_5fr]"

--- a/src/pages/speaker.astro
+++ b/src/pages/speaker.astro
@@ -186,7 +186,7 @@ const headshots = [
   <div class="home speaker-page">
     <!-- ============ HERO ============ -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-3xl">
         <div class="sec-head">

--- a/src/pages/training.astro
+++ b/src/pages/training.astro
@@ -9,7 +9,7 @@ import { courses } from "@data/training";
 >
   <div class="home">
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,5vw,4rem)]"
     >
       <div class="max-w-3xl">
         <span class="hand-note">learn by building</span>

--- a/src/pages/training/[course].astro
+++ b/src/pages/training/[course].astro
@@ -27,7 +27,7 @@ const ac = `--ac:var(--color-${course.accent});--ac-deep:var(--color-${course.ac
   <div class="home">
     <!-- Hero -->
     <section
-      class="relative z-10 pt-[clamp(4.5rem,9vw,7rem)] pb-[clamp(2rem,4vw,3rem)]"
+      class="relative z-10 pt-[clamp(6rem,9vw,7rem)] pb-[clamp(2rem,4vw,3rem)]"
       style={ac}
     >
       <a


### PR DESCRIPTION
## Problem
On mobile, the fixed navbar (`.navbar--initial`, ~75px tall = `py-2` + `h-14` row + border) overlapped page content. The homepage kicker "Hi, I'm Guido" (rotated script + wave) overlapped by ~19px; `/about/`, `/retainer/`, `/training/`, `/contact/`, etc. touched or overlapped too. Every page's first section reserved only `pt-[clamp(4.5rem,9vw,7rem)]` (74px floor) — essentially zero clearance for a 75px nav.

This was invisible in local dev because the "Preview Environment" banner shifted the layout; it only appeared in production.

## Fix
Raised the universal top-of-page section floor `4.5rem → 6rem` (24 pages), and `6.5rem` on the homepage hero specifically since its rotated kicker overhangs more than a plain eyebrow.

- Only affects widths **< ~1067px** — desktop spacing is unchanged (the `9vw` fluid range and `7rem` ceiling are untouched).
- Verified against a **production-mode build (banner off)** with Playwright:
  - Homepage: −19px overlap → **+14px** gap above the navbar.
  - Inner pages: **12–26px** gaps.
  - No horizontal overflow at 360 / 375 / 390 / 414px.

## Notes
- Unrelated: Lighthouse CI fails pre-existing (the homepage is `prerender = false`, so the static LHCI server 404s on `/`) — same as recent merged PRs.
- Observed but out of scope: the nav "Work with me" CTA (`hidden md:block`) is actually visible on mobile in production. It's in the current design and wasn't flagged, so left as-is — happy to follow up if it should be desktop-only.