### PR TITLE
fix(home): live feed cut off beside hero on desktop laptops

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -96,7 +96,7 @@ const ArrowRight = "→";
       aria-label="Introduction"
     >
       <div
-        class="grid grid-cols-1 items-center gap-[clamp(1.5rem,4vw,3.5rem)] lg:grid-cols-[1.02fr_0.98fr]"
+        class="grid grid-cols-1 items-center gap-[clamp(1.5rem,4vw,3.5rem)] lg:grid-cols-[minmax(0,1.02fr)_minmax(0,0.98fr)]"
       >
         <div>
           <span class="kicker">{heroCopy.kicker}</span>

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -35,16 +35,22 @@
     @apply font-display text-[clamp(2.05rem,6.2vw,4.6rem)] leading-[0.98] font-black tracking-[-0.035em];
     @apply my-[0.1em] mb-[0.35em];
   }
+  /* Highlight rendered as a per-line background bar (box-decoration-break:
+     clone) instead of a single absolute ::after rect, so the phrase can WRAP
+     on narrow desktop columns without the highlight smearing across the whole
+     bounding box. Removing nowrap also stops the phrase from forcing the hero
+     grid's left track wide enough to push the live feed off-screen. */
   .home .hero-h1 .u {
-    @apply text-primary-600 dark:text-primary-400 relative whitespace-nowrap;
-  }
-  .home .hero-h1 .u::after {
-    content: "";
-    @apply absolute inset-x-0 -z-10;
-    bottom: 0.04em;
-    height: 0.42em;
-    background: color-mix(in oklab, var(--color-primary-600) 18%, transparent);
-    transform: rotate(-1deg);
+    @apply text-primary-600 dark:text-primary-400 relative;
+    background-image: linear-gradient(
+      to top,
+      transparent 0.04em,
+      color-mix(in oklab, var(--color-primary-600) 18%, transparent) 0.04em,
+      color-mix(in oklab, var(--color-primary-600) 18%, transparent) 0.46em,
+      transparent 0.46em
+    );
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
   }
   .home .lead {
     @apply text-base-600 dark:text-base-400 mb-6 max-w-[46ch] text-[clamp(1.05rem,1.6vw,1.25rem)] leading-[1.55];


### PR DESCRIPTION
## Problem
On laptop widths (e.g. 1440×900) the hero's live "Right now" feed was clipped at the right edge, and at ~1280px it produced a horizontal scrollbar.

**Cause:** the h1 highlight span `.u` ("community functions") was `white-space: nowrap` and ~847px wide at the desktop font. As a grid item with the default `min-width: auto`, it forced the left track that wide, so the two-column hero grid overflowed its container and pushed the feed past the edge (at 1440 the grid computed `846.6px + 505.5px + 57.6px gap = 1410px` inside a 1395px container).

## Fix (Option A — chosen with @gxjansen)
- **Hero grid** → `lg:grid-cols-[minmax(0,1.02fr)_minmax(0,0.98fr)]` so tracks size to the available space instead of being forced by the headline's min-content. The feed column can no longer overflow.
- **`.u` highlight** → drop `nowrap`; render the marker as a per-line background bar via `box-decoration-break: clone` instead of a single absolute `::after` rectangle. The phrase now wraps cleanly with the highlight following each word. Only visual change: the marker is no longer tilted ~1°.

The big bold headline and the feed-beside-hero layout are preserved; "community functions" wraps to two lines on laptop columns.

## Verification
Playwright across **360–1920px**: zero feed overhang and **no horizontal scroll at any width**. Mobile and dark mode unaffected.

## Note
Lighthouse CI fails pre-existing (homepage is `prerender = false`, so the static LHCI server 404s on `/`) — unrelated, same as recent merged PRs.