### PR TITLE
ci(lighthouse): don't audit the SSR homepage from the static build

### DIFF
--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,7 +3,6 @@
     "collect": {
       "staticDistDir": "./dist",
       "url": [
-        "/",
         "/about/",
         "/presentations/"
       ],


### PR DESCRIPTION
## Why
Lighthouse CI has been failing on every PR with `ERRORED_DOCUMENT_REQUEST` (404) when auditing `/`.

The homepage is intentionally `export const prerender = false` so the live "Right now" feed stays fresh (server-rendered on demand + Netlify `stale-while-revalidate`). Because of that, `astro build` emits **no `dist/index.html`**, and LHCI audits `staticDistDir: ./dist` — so `/` 404s.

Re-enabling prerender is **not** an option: it would bake the activity feed in at build time.

## Change
Remove `/` from the audited URL list; keep the representative static routes (`/about/`, `/presentations/`). This unblocks the recurring Lighthouse failure.

## Follow-up (optional)
To restore homepage CWV coverage in CI, point LHCI at the deployed SSR URL (e.g. the Netlify deploy-preview) instead of the static `dist/`. Out of scope here.