### PR TITLE
feat(training): add secondary CTA to /about/ on course pages

### DIFF
--- a/src/pages/training/[course].astro
+++ b/src/pages/training/[course].astro
@@ -427,13 +427,18 @@ const ac = `--ac:var(--color-${course.accent});--ac-deep:var(--color-${course.ac
               class="text-base-800 dark:text-base-200 mt-3 max-w-3xl text-lg leading-relaxed"
               set:html={course.whyMe}
             />
-            <a
-              href="https://app.cal.eu/gxjansen/15min"
-              class="btn-ac mt-6"
-              style={ac}
-            >
-              Talk about a workshop
-            </a>
+            <div class="mt-6 flex flex-wrap gap-3">
+              <a
+                href="https://app.cal.eu/gxjansen/15min"
+                class="btn-ac"
+                style={ac}
+              >
+                Talk about a workshop
+              </a>
+              <a href="/about/" class="btn-ac-outline" style={ac}>
+                More about me
+              </a>
+            </div>
           </div>
         </section>
       )


### PR DESCRIPTION
## Summary
The "why learn this from me" block on solo course pages (e.g. `/training/atproto/`) only offered one CTA: book a workshop. This adds a secondary outline CTA to `/about/` so visitors who want background on the instructor before booking have a path to it.

- `src/pages/training/[course].astro`: wrap the closing CTA in a flex row and add a `More about me` → `/about/` button using the existing `btn-ac-outline` pattern (same style as the hero's "Other formats").

Only affects solo courses that render the `whyMe` block. Co-led courses (e.g. `agentic-engineering`) use a different closing layout and are untouched.

## Test Coverage
No new code paths — markup-only change to an existing template. Existing suite covers the page render.

## Pre-Landing Review
Frontend-only, additive. Reuses an existing button class. No new logic, no security/data surface.

## Test plan
- [x] `astro build` passes; `/training/atproto/index.html` contains the `/about/` outline link
- [x] All Vitest tests pass (110 tests)