### PR TITLE
chore(deps): upgrade Astro to 6.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/react-dom": "^19.0.0",
         "altcha-lib": "^1.4.1",
         "animejs": "^4.4.1",
-        "astro": "^6.4.6",
+        "astro": "^6.4.8",
         "astro-auto-import": "^0.5.1",
         "astro-embed": "^0.13.0",
         "astro-icon": "^1.1.5",
@@ -52,7 +52,7 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
-        "@astrojs/check": "^0.9.7",
+        "@astrojs/check": "^0.9.9",
         "@axe-core/playwright": "^4.11.3",
         "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.6.4",
@@ -6970,9 +6970,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.6.tgz",
-      "integrity": "sha512-48OBTBKR9ctbf+DQxpOuxGl8ebfn59zTuNQMBzptmG/Mi/H8IdfMSbJgGuX1I/4U6g9yazG1p4BHlf4+2hWU4Q==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.8.tgz",
+      "integrity": "sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/react-dom": "^19.0.0",
     "altcha-lib": "^1.4.1",
     "animejs": "^4.4.1",
-    "astro": "^6.4.6",
+    "astro": "^6.4.8",
     "astro-auto-import": "^0.5.1",
     "astro-embed": "^0.13.0",
     "astro-icon": "^1.1.5",
@@ -72,7 +72,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
-    "@astrojs/check": "^0.9.7",
+    "@astrojs/check": "^0.9.9",
     "@axe-core/playwright": "^4.11.3",
     "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.6.4",


### PR DESCRIPTION
Bumps the core Astro toolchain to the latest v6 release.

## Changes
- `astro` `^6.4.6` → `^6.4.8` (installed 6.4.8)
- `@astrojs/check` `^0.9.7` → `^0.9.9` (installed 0.9.9)

The integration packages (@astrojs/mdx 6.0.3, netlify 7.0.13, react 5.0.7, rss 4.0.18, sitemap 3.7.3) were already at their latest on master, so no change needed there.

## Verification
- `npm run build` — exit 0, full SSR build completes, 286 .md endpoints + llms-full.txt generated.
- `npm run typecheck` (astro check) — 0 errors, 0 warnings.
- Build warnings present are pre-existing and unrelated (missing optional content dirs, duplicate event route ids).