### PR TITLE
feat: combined subscriber count + dual subscribe box on posts

### DIFF
--- a/netlify/functions/newsletter-stats.ts
+++ b/netlify/functions/newsletter-stats.ts
@@ -1,34 +1,96 @@
 import type { Handler, HandlerEvent, HandlerContext } from "@netlify/functions";
+import { getStore } from "@netlify/blobs";
 
 /**
- * Newsletter Stats API
+ * Subscriber Stats API
  *
- * Fetches subscriber statistics from self-hosted Listmonk instance.
- * Requires LISTMONK_API_USER and LISTMONK_API_KEY environment variables.
- * Uses /subscribers endpoint which requires only subscribers:get permission.
+ * Returns a single combined subscriber count for gui.do:
+ *   Listmonk newsletter subscribers + standard.site (AT Protocol) subscribers.
+ *
+ * Each source is refreshed independently on every (uncached) invocation. If a
+ * source is unreachable, its previous value is kept — a source outage never
+ * zeroes the total. Last-known-good values are persisted in Netlify Blobs.
+ *
+ * Only the combined total is returned. The per-source breakdown is deliberately
+ * not exposed (readers discover the AT Protocol side when they subscribe).
+ *
+ * Env: LISTMONK_API_USER, LISTMONK_API_KEY, (optional) CF_BYPASS_TOKEN.
  */
 
 const LISTMONK_API_URL = "https://n.a11y.nl/api";
+const CONSTELLATION_URL = "https://constellation.microcosm.blue";
 
-interface ListmonkSubscribersResponse {
-  data: {
-    results: unknown[];
-    total: number;
-    per_page: number;
-    page: number;
-  };
+// gui.do's canonical standard.site publication ("Guido X Jansen" -> gui.do).
+// (A second publication record 3mks6auwo4i2o points at offprint and has no
+// followers — readers subscribe to this one.)
+const PUBLICATION_URI =
+  "at://did:plc:45uheisi25szrjvjurfpritx/site.standard.publication/3mgfeypogdk2r";
+
+const STORE_NAME = "subscriber-stats";
+const CACHE_KEY = "counts";
+
+interface CachedCounts {
+  listmonk: number | null;
+  atproto: number | null;
+  listmonkUpdatedAt: string | null;
+  atprotoUpdatedAt: string | null;
 }
+
+const EMPTY_CACHE: CachedCounts = {
+  listmonk: null,
+  atproto: null,
+  listmonkUpdatedAt: null,
+  atprotoUpdatedAt: null,
+};
 
 const commonHeaders: Record<string, string> = {
   "Content-Type": "application/json",
   "Access-Control-Allow-Origin": "*",
 };
 
+/** Listmonk total subscribers. Returns null when not configured; throws on error. */
+async function fetchListmonkCount(): Promise<number | null> {
+  const apiUser = process.env.LISTMONK_API_USER;
+  const apiKey = process.env.LISTMONK_API_KEY;
+  if (!apiUser || !apiKey) return null;
+
+  const authHeader = Buffer.from(`${apiUser}:${apiKey}`).toString("base64");
+  const bypassToken = process.env.CF_BYPASS_TOKEN || "";
+
+  const response = await fetch(
+    `${LISTMONK_API_URL}/subscribers?page=1&per_page=1`,
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Basic ${authHeader}`,
+        "Content-Type": "application/json",
+        "X-Bypass-Token": bypassToken,
+      },
+    }
+  );
+  if (!response.ok) throw new Error(`Listmonk API returned ${response.status}`);
+  const data = (await response.json()) as { data: { total: number } };
+  return data.data.total;
+}
+
+/** standard.site subscriber count via the constellation backlink index. Throws on error. */
+async function fetchAtprotoCount(): Promise<number> {
+  const url =
+    `${CONSTELLATION_URL}/links/count/distinct-dids` +
+    `?target=${encodeURIComponent(PUBLICATION_URI)}` +
+    `&collection=site.standard.graph.subscription&path=.publication`;
+
+  const response = await fetch(url);
+  if (!response.ok)
+    throw new Error(`Constellation API returned ${response.status}`);
+  const data = (await response.json()) as { total?: number };
+  return typeof data.total === "number" ? data.total : 0;
+}
+
 const handler: Handler = async (
   event: HandlerEvent,
   _context: HandlerContext
 ) => {
-  // Only allow GET requests
   if (event.httpMethod !== "GET") {
     return {
       statusCode: 405,
@@ -37,67 +99,69 @@ const handler: Handler = async (
     };
   }
 
-  const apiUser = process.env.LISTMONK_API_USER;
-  const apiKey = process.env.LISTMONK_API_KEY;
-
-  if (!apiUser || !apiKey) {
-    // Return a fallback when credentials aren't configured
-    return {
-      statusCode: 200,
-      headers: { ...commonHeaders, "Cache-Control": "public, max-age=3600" },
-      body: JSON.stringify({
-        success: true,
-        subscriberCount: null,
-        message: "Stats not configured",
-      }),
-    };
-  }
-
+  // Load last-known-good counts (best effort — never let a blob error break the page).
+  let store: ReturnType<typeof getStore> | null = null;
+  let cache: CachedCounts = { ...EMPTY_CACHE };
   try {
-    const authHeader = Buffer.from(`${apiUser}:${apiKey}`).toString("base64");
-    const bypassToken = process.env.CF_BYPASS_TOKEN || "";
-
-    // Use subscribers endpoint with minimal query (1 result) just to get total count
-    const response = await fetch(
-      `${LISTMONK_API_URL}/subscribers?page=1&per_page=1`,
-      {
-        method: "GET",
-        headers: {
-          Authorization: `Basic ${authHeader}`,
-          "Content-Type": "application/json",
-          "X-Bypass-Token": bypassToken,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(`Listmonk API returned ${response.status}`);
-    }
-
-    const data: ListmonkSubscribersResponse = await response.json();
-    const totalSubscribers = data.data.total;
-
-    return {
-      statusCode: 200,
-      headers: { ...commonHeaders, "Cache-Control": "public, max-age=3600" },
-      body: JSON.stringify({
-        success: true,
-        subscriberCount: totalSubscribers,
-      }),
-    };
+    store = getStore(STORE_NAME);
+    const stored = (await store.get(CACHE_KEY, {
+      type: "json",
+    })) as CachedCounts | null;
+    if (stored) cache = { ...EMPTY_CACHE, ...stored };
   } catch (error) {
-    console.error("Newsletter stats error:", error);
-
-    return {
-      statusCode: 200, // Return 200 to not break the page
-      headers: { ...commonHeaders },
-      body: JSON.stringify({
-        success: false,
-        subscriberCount: null,
-        error: "Could not fetch stats",
-      }),
-    };
+    console.warn("Subscriber stats: blob store unavailable", error);
   }
+
+  const now = new Date().toISOString();
+
+  // Refresh both sources independently and in parallel; keep the prior value on failure.
+  const [listmonkResult, atprotoResult] = await Promise.allSettled([
+    fetchListmonkCount(),
+    fetchAtprotoCount(),
+  ]);
+
+  if (listmonkResult.status === "fulfilled") {
+    if (listmonkResult.value !== null) {
+      cache.listmonk = listmonkResult.value;
+      cache.listmonkUpdatedAt = now;
+    }
+  } else {
+    console.warn("Subscriber stats: Listmonk fetch failed", listmonkResult.reason);
+  }
+
+  if (atprotoResult.status === "fulfilled") {
+    cache.atproto = atprotoResult.value;
+    cache.atprotoUpdatedAt = now;
+  } else {
+    console.warn(
+      "Subscriber stats: constellation fetch failed",
+      atprotoResult.reason
+    );
+  }
+
+  // Persist refreshed last-known-good values (best effort).
+  if (store) {
+    try {
+      await store.setJSON(CACHE_KEY, cache);
+    } catch (error) {
+      console.warn("Subscriber stats: could not persist counts", error);
+    }
+  }
+
+  // Combined total. Null only if we have never successfully read either source.
+  const haveAny = cache.listmonk !== null || cache.atproto !== null;
+  const subscriberCount = haveAny
+    ? (cache.listmonk ?? 0) + (cache.atproto ?? 0)
+    : null;
+
+  return {
+    statusCode: 200,
+    headers: { ...commonHeaders, "Cache-Control": "public, max-age=3600" },
+    body: JSON.stringify({
+      success: true,
+      subscriberCount,
+    }),
+  };
 };
 
 export { handler };

--- a/src/components/Newsletter/NewsletterForm.astro
+++ b/src/components/Newsletter/NewsletterForm.astro
@@ -24,7 +24,7 @@ const altchaChallengeUrl = "/.netlify/functions/altcha-challenge";
 
 interface Props {
   /** Display variant */
-  variant?: "inline" | "card" | "cta" | "minimal";
+  variant?: "inline" | "card" | "cta" | "minimal" | "subscribe";
   /** Form title (used in card/cta variants) */
   title?: string;
   /** Form description (used in card/cta variants) */
@@ -110,7 +110,7 @@ const signupPage = Astro.url.pathname;
               class="subscriber-count text-base-600 dark:text-base-400 mt-3 hidden text-sm"
               data-subscriber-count
             >
-              Join <span class="subscriber-number" /> newsletter subscribers
+              Join <span class="subscriber-number" /> subscribers
             </p>
           )}
 
@@ -236,6 +236,99 @@ const signupPage = Astro.url.pathname;
 }
 
 {
+  /* Bare form for embedding in SubscribeBox (pill input + ALTCHA + trust line);
+     wrapper card/heading/count are provided by the parent. */
+  variant === "subscribe" && (
+    <div class:list={["newsletter-subscribe", className]}>
+      <form
+        id={formId}
+        method="post"
+        action={actionUrl}
+        class="newsletter-form flex flex-col gap-3"
+        data-newsletter-form
+      >
+        <input type="hidden" name="nonce" />
+        <input type="hidden" name="l" value={listId} />
+        <input type="hidden" name="signupPage" value={signupPage} />
+
+        <div class="flex flex-wrap items-center gap-2">
+          <label
+            for={`${formId}-email`}
+            class="relative flex min-w-0 flex-[1_1_220px] items-center"
+          >
+            <span class="sr-only">Email address</span>
+            <Icon
+              name="tabler/outline/mail"
+              class="text-base-500 dark:text-base-400 pointer-events-none absolute left-3.5 size-[18px]"
+              aria-hidden="true"
+            />
+            <input
+              type="email"
+              name="email"
+              id={`${formId}-email`}
+              required
+              placeholder={emailPlaceholder}
+              autocomplete="email"
+              class="border-base-300 bg-base-100 text-base-900 placeholder:text-base-500 dark:border-base-600 dark:bg-base-950 dark:text-base-100 dark:placeholder:text-base-400 min-h-12 w-full rounded-full border-[1.5px] py-3 pr-4 pl-10 text-base"
+              aria-required="true"
+              aria-describedby={`${formId}-status`}
+            />
+          </label>
+
+          <Button
+            type="submit"
+            variant="primary"
+            arrow="right"
+            class="flex-shrink-0 whitespace-nowrap"
+          >
+            {buttonText}
+          </Button>
+        </div>
+
+        <div
+          class="altcha-container"
+          role="group"
+          aria-label="Spam verification"
+        >
+          <span id={`${formId}-altcha-desc`} class="sr-only">
+            Complete the verification checkbox to prove you're human
+          </span>
+          <altcha-widget
+            challengeurl={altchaChallengeUrl}
+            hidefooter
+            hidelogo
+            aria-describedby={`${formId}-altcha-desc`}
+          />
+        </div>
+
+        <div
+          id={`${formId}-status`}
+          class="newsletter-status text-sm"
+          role="status"
+          aria-live="polite"
+        />
+      </form>
+
+      <p class="text-base-500 dark:text-base-400 mt-3.5 flex flex-wrap items-center gap-2 text-[0.82rem]">
+        <span class="text-base-600 dark:text-base-300 font-semibold">
+          No spam
+        </span>
+        <span class="opacity-50" aria-hidden="true">
+          ·
+        </span>
+        <span class="text-base-600 dark:text-base-300 font-semibold">
+          No tracking
+        </span>
+        <span class="opacity-50" aria-hidden="true">
+          ·
+        </span>
+        <span>unsubscribe in one click</span>
+      </p>
+    </div>
+  )
+}
+
+{
   variant === "cta" && (
     <section class="py-10" aria-labelledby={`${formId}-heading`}>
       <div class="site-container">
@@ -279,7 +372,7 @@ const signupPage = Astro.url.pathname;
                 class="subscriber-count text-base-50 hidden font-medium"
                 data-subscriber-count
               >
-                Join <span class="subscriber-number" /> newsletter subscribers
+                Join <span class="subscriber-number" /> subscribers
               </p>
             )}
             {description && (

--- a/src/components/Newsletter/SubscribeBox.astro
+++ b/src/components/Newsletter/SubscribeBox.astro
@@ -1,0 +1,192 @@
+---
+/**
+ * Post-level subscribe box (bottom of /post/ articles, id="subscribe").
+ *
+ * "Pick how you want to follow":
+ *  - Primary: email via the existing NewsletterForm (Listmonk + ALTCHA).
+ *  - Secondary: the open social web — a referral out to Guido's publication on a
+ *    reader (Offprint/pckt/Leaflet) where the reader's own "Subscribe with
+ *    Bluesky" lives. Subscribing there writes a portable site.standard.graph.
+ *    subscription to the reader's own PDS, so it travels across every Atmosphere
+ *    app and is counted by the combined subscriber total.
+ *
+ * The combined count itself is shown in the post byline (see BlogLayoutCenter),
+ * not here.
+ */
+import { Icon } from "astro-icon/components";
+import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
+
+interface Props {
+  /** Where the open-social-web affordance points (publication on a reader). */
+  readerHref?: string;
+  class?: string;
+}
+
+const {
+  // Standard Reader — the neutral standard.site reference reader. Renders all of
+  // gui.do's posts and its "Follow" writes a site.standard.graph.subscription to
+  // the reader's own PDS (counted by the combined total, portable across apps).
+  readerHref = "https://standard-reader.app/p/did:plc:45uheisi25szrjvjurfpritx/3mgfeypogdk2r",
+  class: className,
+} = Astro.props as Props;
+---
+
+<section
+  id="subscribe"
+  class:list={[
+    "subscribe-card scroll-mt-20",
+    "bg-base-50 dark:bg-base-900",
+    "border-base-200 dark:border-base-800 rounded-3xl border",
+    "p-6 shadow-sm md:p-10",
+    className,
+  ]}
+  aria-labelledby="subscribe-heading"
+>
+  <div class="subscribe-inner">
+    <p
+      class="text-gold-light dark:text-gold font-display flex items-center gap-[.45em] text-[.72rem] font-bold tracking-[.14em] uppercase"
+    >
+      <Icon
+        name="tabler/outline/sparkles"
+        class="size-3.5"
+        aria-hidden="true"
+      />
+      Subscribe
+    </p>
+    <h2
+      id="subscribe-heading"
+      class="text-base-950 dark:text-base-50 font-display mt-[.45rem] mb-[.15rem] text-[clamp(1.6rem,3.4vw,2.1rem)] leading-[1.05] font-black tracking-[-0.03em]"
+    >
+      Subscribe
+    </h2>
+    <p
+      class="text-base-700 dark:text-base-300 max-w-[46ch] text-base leading-[1.55]"
+    >
+      New posts by email, or follow on the open social web.
+      <span class="text-base-500 dark:text-base-400"
+        >Pick how you want to follow.</span
+      >
+    </p>
+
+    <div class="mt-5">
+      <NewsletterForm
+        variant="subscribe"
+        showSubscriberCount={false}
+        buttonText="Subscribe"
+      />
+    </div>
+
+    <div
+      class="border-base-200 dark:border-base-800 mt-6 flex flex-wrap items-center justify-between gap-x-6 gap-y-4 border-t pt-5"
+    >
+      <div class="max-w-[44ch] min-w-0">
+        <div
+          class="text-base-950 dark:text-base-50 font-display flex items-center gap-[.5em] text-[1.02rem] font-extrabold"
+        >
+          <Icon
+            name="tabler/outline/world"
+            class="text-primary-600 dark:text-primary-400 size-[17px]"
+            aria-hidden="true"
+          />
+          On the open social web
+        </div>
+        <p
+          class="text-base-700 dark:text-base-300 mt-[.3rem] text-[.9rem] leading-[1.5]"
+        >
+          Read it in any Atmosphere app. Subscribe with your Bluesky account and
+          the follow travels with you across the open web.
+        </p>
+      </div>
+      <a
+        href={readerHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="atproto-cta no-random-underline"
+      >
+        <Icon
+          name="bluesky"
+          class="size-[1.15em] shrink-0"
+          aria-hidden="true"
+        />
+        <span>Subscribe with your Atmosphere account</span>
+        <span class="sr-only">(opens in new tab)</span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<style>
+  @reference "../../styles/tailwind.css";
+
+  /* The one sanctioned gradient: a faint gold corner-wash from top-right and a
+     fainter brand wash from bottom-left, behind the content. */
+  .subscribe-card {
+    position: relative;
+    overflow: hidden;
+  }
+  .subscribe-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        72% 130% at 100% 0%,
+        color-mix(in oklab, var(--color-gold) 17%, transparent),
+        transparent 58%
+      ),
+      radial-gradient(
+        60% 120% at 0% 100%,
+        color-mix(in oklab, var(--color-primary-500) 9%, transparent),
+        transparent 55%
+      );
+  }
+  .subscribe-inner {
+    position: relative;
+    z-index: 1;
+  }
+
+  /* Open-social-web affordance: outline that resolves to the brand on hover
+     (not the Button component's random per-render accent). */
+  .atproto-cta {
+    @apply inline-flex min-h-12 items-center gap-[.95em] rounded-full border-2 px-6 py-3 font-medium transition-all duration-200;
+    border-color: var(--color-foam-light);
+    color: #191724; /* Rosé Pine base — AA on every light page bg */
+    text-decoration: none;
+  }
+  :global(.dark) .atproto-cta {
+    border-color: var(--color-foam);
+    color: #e0def4; /* Rosé Pine text — AA on dark page bg */
+  }
+  .atproto-cta:hover,
+  .atproto-cta:focus-visible {
+    border-color: var(--color-primary-500);
+    color: var(--color-primary-600);
+    background-color: color-mix(
+      in oklab,
+      var(--color-primary-500) 10%,
+      transparent
+    );
+    transform: translateY(-1px);
+  }
+  :global(.dark) .atproto-cta:hover,
+  :global(.dark) .atproto-cta:focus-visible {
+    color: var(--color-primary-400);
+  }
+  .atproto-cta:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px
+      color-mix(in oklab, var(--color-primary-500) 35%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .atproto-cta {
+      transition: none;
+    }
+    .atproto-cta:hover,
+    .atproto-cta:focus-visible {
+      transform: none;
+    }
+  }
+</style>

--- a/src/layouts/BlogLayoutCenter.astro
+++ b/src/layouts/BlogLayoutCenter.astro
@@ -8,13 +8,13 @@ import BaseLayout from "./BaseLayout.astro";
 // components
 import Category from "@components/Category/Category.astro";
 import BlogNav from "@components/Blog/BlogNav.astro";
-import NewsletterForm from "@components/Newsletter/NewsletterForm.astro";
+import SubscribeBox from "@components/Newsletter/SubscribeBox.astro";
 import AuthorByline from "@components/Author/AuthorByline.astro";
 import AuthorBioBox from "@components/Author/AuthorBioBox.astro";
 import Breadcrumb from "@components/Breadcrumb/Breadcrumb.astro";
 
 // utils
-import { formatDate, humanize } from "@js/textUtils";
+import { formatDate } from "@js/textUtils";
 import { getLocaleFromUrl } from "@js/localeUtils";
 import { useTranslations } from "@js/translationUtils";
 import { filterCategoriesByCount } from "@js/blogUtils";
@@ -69,13 +69,6 @@ const authorsData =
 
 // Filter categories to only show those with 2+ posts
 const filteredCategories = filterCategoriesByCount(categories, allPosts);
-
-// Generate dynamic newsletter description based on categories
-const categoryNames = categories.map((cat) => humanize(cat)).slice(0, 3);
-const newsletterDescription =
-  categoryNames.length > 0
-    ? `Want more on ${categoryNames.join(", ")}? Subscribe for curated insights on community, AI & open tech.`
-    : "Curated insights on community, AI & open tech. No spam, no tracking pixels, unsubscribe anytime.";
 ---
 
 <BaseLayout
@@ -180,6 +173,38 @@ const newsletterDescription =
               <span class="text-base-600 dark:text-base-400">&bull;</span>
               <span aria-label="Estimated reading time">{readTime}</span>
 
+              <!-- Combined subscriber count (newsletter + AT Protocol).
+                   Filled client-side by NewsletterForm's fetchSubscriberCount()
+                   (the SubscribeBox at the foot of the post loads that script);
+                   stays hidden until the count resolves, so no layout shift.
+                   To remove from the byline, delete this block. -->
+              <span class="subscriber-count hidden" data-subscriber-count>
+                <span
+                  class="text-base-600 dark:text-base-400 mr-4"
+                  aria-hidden="true">&bull;</span
+                >
+                <a
+                  href="#subscribe"
+                  class="count-link no-random-underline group/sc relative inline-flex items-center gap-2 align-middle"
+                >
+                  <span class="count-dots" aria-hidden="true">
+                    <span class="count-dot count-dot--gold"></span>
+                    <span class="count-dot count-dot--bsky"></span>
+                  </span>
+                  <span>
+                    <span
+                      class="subscriber-number text-base-700 dark:text-base-300 font-bold"
+                    ></span>
+                    <span class="text-base-500 dark:text-base-400"
+                      >subscribers</span
+                    >
+                  </span>
+                  <span class="count-tip" role="tooltip"
+                    >Newsletter subscribers and open-web followers, combined.</span
+                  >
+                </a>
+              </span>
+
               <!-- Bluesky comment link (only if linked) -->
               {
                 blueskyUri && (
@@ -271,6 +296,12 @@ const newsletterDescription =
         <p class="article-signature" aria-hidden="true">— Guido</p>
       </div>
 
+      <!-- Subscribe: email (Listmonk) + open-social-web referral. id="subscribe"
+           is the anchor target for the byline count link. -->
+      <div class="mx-auto mt-12 max-w-2xl">
+        <SubscribeBox />
+      </div>
+
       <!-- Bluesky-powered comments (Juttu, self-hosted at comments.gui.do).
            The article<->post link lives in the site.standard.document record
            (BaseHead renders <link rel="site.standard.document">); Juttu reads
@@ -308,15 +339,6 @@ const newsletterDescription =
     </div>
   </div>
 
-  <!-- Newsletter CTA -->
-  <div class="mt-8">
-    <NewsletterForm
-      variant="card"
-      title="Enjoyed this? Get Guido's <span class='text-golden'>Golden</span> Nuggets"
-      description={newsletterDescription}
-    />
-  </div>
-
   <!-- Navigation -->
   <nav class="mx-auto max-w-2xl" aria-label="Blog post navigation">
     <BlogNav currentSlug={post.id} posts={allPosts} />
@@ -329,4 +351,82 @@ const newsletterDescription =
     import { initBskyEngagement } from "../scripts/bskyEngagement";
     initBskyEngagement();
   </script>
+
+  <style>
+    /* Combined subscriber-count link in the byline (paired-dot cue + tooltip). */
+    .count-link {
+      color: inherit;
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+    .count-link:hover,
+    .count-link:focus-visible {
+      color: var(--color-foam-light);
+    }
+    :global(.dark) .count-link:hover,
+    :global(.dark) .count-link:focus-visible {
+      color: var(--color-foam);
+    }
+    /* tint number + label to the link colour on hover (beats the base-* utils) */
+    .count-link:hover span:not(.count-tip),
+    .count-link:focus-visible span:not(.count-tip) {
+      color: inherit;
+    }
+
+    .count-dots {
+      display: inline-flex;
+      align-items: center;
+    }
+    .count-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      box-shadow: 0 0 0 2px var(--color-base-100);
+    }
+    :global(.dark) .count-dot {
+      box-shadow: 0 0 0 2px var(--color-base-950);
+    }
+    .count-dot--gold {
+      background: var(--color-gold-light);
+    }
+    :global(.dark) .count-dot--gold {
+      background: var(--color-gold);
+    }
+    .count-dot--bsky {
+      margin-left: -3px;
+      background: var(--color-app-bluesky);
+    }
+
+    .count-tip {
+      position: absolute;
+      bottom: calc(100% + 8px);
+      left: 50%;
+      transform: translateX(-50%);
+      white-space: nowrap;
+      background: var(--color-base-950);
+      color: var(--color-base-50);
+      font-size: 0.74rem;
+      line-height: 1.2;
+      padding: 0.35em 0.6em;
+      border-radius: 6px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+      z-index: 20;
+    }
+    :global(.dark) .count-tip {
+      background: var(--color-base-50);
+      color: var(--color-base-950);
+    }
+    .count-link:hover .count-tip,
+    .count-link:focus-visible .count-tip {
+      opacity: 1;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .count-link,
+      .count-tip {
+        transition: none;
+      }
+    }
+  </style>
 </BaseLayout>


### PR DESCRIPTION
Adds a post-level subscribe experience and a combined subscriber count.

## What changed
- **`newsletter-stats` function**: returns one combined total — Listmonk newsletter subscribers + standard.site (AT Protocol) followers, counted via the constellation backlink index for the gui.do publication. Each source is cached independently in Netlify Blobs with last-known-good fallback, so a single source being down never zeroes the total. Only the combined total is exposed.
- **Byline count link**: "Read by N subscribers" in the post meta row, with a paired-dot cue (newsletter + open web) and a tooltip noting it's combined. Anchor-links to the subscribe box. Hidden until the count resolves (no layout shift).
- **`SubscribeBox`** (foot of each post, `#subscribe`): two ways to follow — email (existing Listmonk form + ALTCHA, via a new `subscribe` variant) and the open social web, a referral to the publication on Standard Reader where the reader's own "Follow" lives.
- Removed the now-duplicate bottom newsletter card; updated the count copy to reflect the combined number.

## Notes
- Verified with `astro check` (0 errors) and visual QA in light + dark.
- The combined count depends on the public constellation indexer for the AT Protocol side; the cached fallback covers outages.