### PR TITLE
feat: /now page with live activity feed + Bookhive reading shelf

### DIFF
--- a/src/components/Reading/ReadingCard.astro
+++ b/src/components/Reading/ReadingCard.astro
@@ -1,0 +1,299 @@
+---
+/**
+ * "Currently reading" card for /now — ingests Bookhive (non-fiction only).
+ * Three states: one active read (hero), many active reads (grid), or the
+ * "Recently read" fallback when nothing is marked reading. No progress bars
+ * (Bookhive exposes no progress).
+ */
+import { Icon } from "astro-icon/components";
+import type { ReadingData, Book } from "../../lib/bookhive";
+
+interface Props {
+  data: ReadingData;
+}
+const { data } = Astro.props as Props;
+const heading =
+  data.mode === "fallback" ? "Recently read" : "Currently reading";
+const books: Book[] = data.mode === "fallback" ? data.recent : data.active;
+
+// Nothing to show at all (e.g. a build-time fetch failure) — render a minimal note.
+const isEmpty = books.length === 0;
+---
+
+<section
+  class="reading-card bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 relative overflow-hidden rounded-2xl border p-6 shadow-sm md:p-7"
+  aria-labelledby="reading-heading"
+>
+  <div class="mb-5 flex flex-wrap items-start justify-between gap-3">
+    <div>
+      <p
+        class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.15rem] leading-none"
+      >
+        on the nightstand
+      </p>
+      <h3
+        id="reading-heading"
+        class="text-base-950 dark:text-base-50 font-display mt-1 text-[1.4rem] font-black tracking-[-0.02em]"
+      >
+        {heading}
+      </h3>
+    </div>
+    <span class="bookhive-badge">
+      <span class="bookhive-dot" aria-hidden="true"></span>
+      Bookhive
+    </span>
+  </div>
+
+  {
+    isEmpty && (
+      <p class="text-base-500 dark:text-base-400 text-[.94rem]">
+        Reading list is taking a breather.
+      </p>
+    )
+  }
+
+  {
+    data.mode === "one" && books[0] && (
+      <div class="flex flex-wrap items-stretch gap-5">
+        <div
+          class={`bk-cover bk-${books[0].accent} h-[206px] w-[138px] flex-none`}
+        >
+          {books[0].coverUrl ? (
+            <img
+              src={books[0].coverUrl}
+              alt={`Cover of ${books[0].title}`}
+              loading="lazy"
+            />
+          ) : (
+            <>
+              <span class="bk-spine" aria-hidden="true" />
+              <div class="bk-meta">
+                <div class="bk-title">{books[0].title}</div>
+                <div class="bk-author">{books[0].author}</div>
+              </div>
+            </>
+          )}
+        </div>
+        <div class="flex min-w-[200px] flex-[1_1_240px] flex-col justify-center gap-2">
+          <span class="reading-pill">
+            <span class="reading-pill-dot" aria-hidden="true" /> Reading now
+          </span>
+          <div class="text-base-950 dark:text-base-50 font-display text-[1.5rem] leading-[1.1] font-extrabold tracking-[-0.02em]">
+            {books[0].title}
+          </div>
+          <div class="text-base-700 dark:text-base-300 text-[.98rem]">
+            {books[0].author}
+          </div>
+          {books[0].startedLabel && (
+            <div class="text-base-500 dark:text-base-400 text-[.84rem]">
+              {books[0].startedLabel}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  {
+    data.mode === "many" && (
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+        {books.map((b) => (
+          <div class="flex flex-col gap-2">
+            <div class={`bk-cover bk-${b.accent} aspect-[2/3] w-full`}>
+              {b.coverUrl ? (
+                <img
+                  src={b.coverUrl}
+                  alt={`Cover of ${b.title}`}
+                  loading="lazy"
+                />
+              ) : (
+                <>
+                  <span class="bk-spine" aria-hidden="true" />
+                  <div class="bk-meta">
+                    <div class="bk-title">{b.title}</div>
+                    <div class="bk-author">{b.author}</div>
+                  </div>
+                </>
+              )}
+            </div>
+            <div class="text-love flex items-center gap-1.5 text-[.74rem] font-bold">
+              <span class="reading-pill-dot" aria-hidden="true" /> Reading now
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  {
+    data.mode === "fallback" && !isEmpty && (
+      <>
+        <p class="text-base-700 dark:text-base-300 -mt-2 mb-4 max-w-[54ch] text-[.94rem] leading-[1.5]">
+          Nothing on the nightstand right this second. Here&rsquo;s the
+          non&#8209;fiction I just finished.
+        </p>
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+          {books.map((b) => (
+            <div class="flex flex-col gap-2">
+              <div class={`bk-cover bk-${b.accent} aspect-[2/3] w-full`}>
+                {b.coverUrl ? (
+                  <img
+                    src={b.coverUrl}
+                    alt={`Cover of ${b.title}`}
+                    loading="lazy"
+                  />
+                ) : (
+                  <>
+                    <span class="bk-spine" aria-hidden="true" />
+                    <div class="bk-meta">
+                      <div class="bk-title">{b.title}</div>
+                      <div class="bk-author">{b.author}</div>
+                    </div>
+                  </>
+                )}
+              </div>
+              {typeof b.rating === "number" && (
+                <div class="text-gold-light dark:text-gold flex items-center gap-1 text-[.78rem] font-semibold">
+                  <Icon
+                    name="tabler/star"
+                    class="size-3.5"
+                    aria-hidden="true"
+                  />
+                  <span>{b.rating}/10</span>
+                </div>
+              )}
+              {b.finishedLabel && (
+                <div class="text-base-500 dark:text-base-400 text-[.74rem]">
+                  {b.finishedLabel}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+</section>
+
+<style>
+  @reference "../../styles/tailwind.css";
+
+  .bookhive-badge {
+    @apply inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[.74rem] font-semibold;
+    color: var(--color-app-bookhive);
+    background: color-mix(in oklab, var(--color-app-bookhive) 12%, transparent);
+  }
+  .bookhive-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-app-bookhive);
+  }
+
+  .reading-pill {
+    @apply inline-flex items-center gap-1.5 self-start rounded-full border px-2.5 py-1 text-[.74rem] font-bold;
+    color: var(--color-love);
+    background: color-mix(in oklab, var(--color-love) 12%, transparent);
+    border-color: color-mix(in oklab, var(--color-love) 26%, transparent);
+  }
+  .reading-pill-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-love);
+    display: inline-block;
+  }
+
+  .bk-cover {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    color: #fff;
+    box-shadow: 0 6px 16px -8px rgb(0 0 0 / 0.5);
+    flex: none;
+  }
+  .bk-cover img {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+  /* Darken only when text is overlaid (gradient-placeholder fallback). */
+  .bk-cover:not(:has(img)) .bk-meta {
+    position: relative;
+    z-index: 1;
+    padding: 0.6rem 0.65rem;
+    background: linear-gradient(180deg, transparent, rgb(0 0 0 / 0.55));
+  }
+  .bk-spine {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 5px;
+    background: rgb(255 255 255 / 0.22);
+    z-index: 1;
+  }
+  .bk-title {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 0.92rem;
+    line-height: 1.12;
+    letter-spacing: -0.01em;
+    text-shadow: 0 1px 4px rgb(0 0 0 / 0.35);
+  }
+  .bk-author {
+    font-size: 0.68rem;
+    opacity: 0.92;
+    margin-top: 0.18rem;
+    text-shadow: 0 1px 3px rgb(0 0 0 / 0.35);
+  }
+
+  /* Two-tone accent gradients for cover placeholders. */
+  .bk-pine {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-pine) 96%, #000),
+      color-mix(in oklab, var(--color-pine) 48%, #000)
+    );
+  }
+  .bk-iris {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-iris) 92%, #000),
+      color-mix(in oklab, var(--color-iris) 42%, #000)
+    );
+  }
+  .bk-gold {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-gold) 90%, #000),
+      color-mix(in oklab, var(--color-gold) 45%, #000)
+    );
+  }
+  .bk-foam {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-foam) 92%, #000),
+      color-mix(in oklab, var(--color-foam) 45%, #000)
+    );
+  }
+  .bk-love {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-love) 92%, #000),
+      color-mix(in oklab, var(--color-love) 45%, #000)
+    );
+  }
+  .bk-rose {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-rose) 90%, #000),
+      color-mix(in oklab, var(--color-rose) 45%, #000)
+    );
+  }
+</style>

--- a/src/config/en/navData.json.ts
+++ b/src/config/en/navData.json.ts
@@ -63,6 +63,11 @@ const navConfig = [
         icon: "tabler/outline/user",
       },
       {
+        text: "Now",
+        link: "/now",
+        icon: "tabler/clock",
+      },
+      {
         text: "CV",
         link: "/cv",
         icon: "tabler/outline/file-text",

--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -1,0 +1,180 @@
+/**
+ * Bookhive reading data for the /now page.
+ *
+ * Ingests Guido's `buzz.bookhive.book` records from his PDS (read-only, no auth)
+ * and resolves genres from the shared Bookhive catalog so the card can show
+ * NON-FICTION only. Fetched at build time; wrapped so a network failure yields
+ * an empty fallback rather than breaking the build.
+ *
+ * Source-of-truth stays on Bookhive/PDS — this is an ingested signal, not
+ * content gui.do owns.
+ */
+
+const GUIDO_DID = "did:plc:45uheisi25szrjvjurfpritx";
+const PDS = "https://chaga.us-west.host.bsky.network";
+const CATALOG_DID = "did:plc:enu2j5xjlqsjaylv3du4myh4";
+const CATALOG_PDS = "https://bluesky.nickthesick.com";
+
+const BOOK_COLLECTION = "buzz.bookhive.book";
+const STATUS_READING = "buzz.bookhive.defs#reading";
+const STATUS_FINISHED = "buzz.bookhive.defs#finished";
+
+// Genres that mark a title as fiction (excluded from the non-fiction card).
+const FICTION_GENRES = new Set([
+  "fiction",
+  "science fiction",
+  "fantasy",
+  "novel",
+  "novels",
+  "science fiction fantasy",
+  "fantasy fiction",
+  "literary fiction",
+  "young adult",
+  "graphic novels",
+  "comics",
+  "manga",
+  "romance",
+  "horror",
+  "mystery",
+  "thriller",
+  "space opera",
+  "poetry",
+]);
+
+const ACCENTS = ["pine", "iris", "gold", "foam", "love", "rose"] as const;
+export type BookAccent = (typeof ACCENTS)[number];
+
+export interface Book {
+  title: string;
+  author: string;
+  coverUrl?: string;
+  accent: BookAccent;
+  rating?: number; // 0–10 (finished)
+  finishedLabel?: string;
+  startedLabel?: string;
+}
+
+export interface ReadingData {
+  /** one active read · many active reads · fallback to recently finished */
+  mode: "one" | "many" | "fallback";
+  active: Book[];
+  recent: Book[];
+}
+
+interface RawBook {
+  value: {
+    title?: string;
+    authors?: string;
+    status?: string;
+    stars?: number;
+    createdAt?: string;
+    finishedAt?: string;
+    hiveId?: string;
+    cover?: { ref?: { $link?: string } };
+  };
+}
+
+const accentFor = (i: number): BookAccent => ACCENTS[i % ACCENTS.length];
+
+const monthYear = (iso?: string): string | undefined => {
+  if (!iso) return undefined;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return undefined;
+  return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+};
+
+async function listBooks(): Promise<RawBook[]> {
+  const url =
+    `${PDS}/xrpc/com.atproto.repo.listRecords` +
+    `?repo=${GUIDO_DID}&collection=${BOOK_COLLECTION}&limit=100`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`listRecords ${res.status}`);
+  const data = (await res.json()) as { records?: RawBook[] };
+  return data.records ?? [];
+}
+
+interface Enriched {
+  raw: RawBook;
+  genres: string[];
+  catalogCover?: string;
+}
+
+// Pull genres + a public cover URL from the shared catalog. Empty/undefined on
+// any failure (a metadata gap is treated as non-fiction so it never hides a real
+// read). The catalog's Goodreads cover URL loads reliably in-browser; the PDS
+// getBlob is only a last-resort fallback.
+async function catalogInfo(hiveId?: string): Promise<{
+  genres: string[];
+  cover?: string;
+}> {
+  if (!hiveId) return { genres: [] };
+  try {
+    const url =
+      `${CATALOG_PDS}/xrpc/com.atproto.repo.getRecord` +
+      `?repo=${CATALOG_DID}&collection=buzz.bookhive.catalogBook&rkey=${hiveId}`;
+    const res = await fetch(url);
+    if (!res.ok) return { genres: [] };
+    const data = (await res.json()) as {
+      value?: { genres?: string[]; cover?: string };
+    };
+    return { genres: data.value?.genres ?? [], cover: data.value?.cover };
+  } catch {
+    return { genres: [] };
+  }
+}
+
+const isNonFiction = (genres: string[]): boolean =>
+  !genres.some((g) => FICTION_GENRES.has(g.trim().toLowerCase()));
+
+async function enrichNonFiction(raw: RawBook[]): Promise<Enriched[]> {
+  const enriched = await Promise.all(
+    raw.map(async (b) => {
+      const { genres, cover } = await catalogInfo(b.value.hiveId);
+      return { raw: b, genres, catalogCover: cover };
+    }),
+  );
+  return enriched.filter((e) => isNonFiction(e.genres));
+}
+
+const mapBook = (e: Enriched, i: number): Book => ({
+  title: e.raw.value.title ?? "Untitled",
+  author: e.raw.value.authors ?? "",
+  // Only the reliable public catalog cover; without it, the card shows a
+  // tonal gradient + title overlay (the PDS blob doesn't load cross-origin).
+  coverUrl: e.catalogCover,
+  accent: accentFor(i),
+  rating: typeof e.raw.value.stars === "number" ? e.raw.value.stars : undefined,
+  finishedLabel: e.raw.value.finishedAt
+    ? `Finished ${monthYear(e.raw.value.finishedAt)}`
+    : undefined,
+  startedLabel: e.raw.value.createdAt
+    ? `Started ${monthYear(e.raw.value.createdAt)}`
+    : undefined,
+});
+
+export async function getReading(): Promise<ReadingData> {
+  try {
+    const books = await listBooks();
+
+    const reading = books.filter((b) => b.value.status === STATUS_READING);
+    const activeNF = await enrichNonFiction(reading);
+    if (activeNF.length > 0) {
+      return {
+        mode: activeNF.length === 1 ? "one" : "many",
+        active: activeNF.map(mapBook),
+        recent: [],
+      };
+    }
+
+    // Fallback: filter non-fiction across all finished, take the 4 most recent.
+    const finished = books
+      .filter((b) => b.value.status === STATUS_FINISHED)
+      .sort((a, b) =>
+        (b.value.finishedAt ?? "").localeCompare(a.value.finishedAt ?? ""),
+      );
+    const recentNF = (await enrichNonFiction(finished)).slice(0, 4);
+    return { mode: "fallback", active: [], recent: recentNF.map(mapBook) };
+  } catch {
+    return { mode: "fallback", active: [], recent: [] };
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -142,6 +142,16 @@ const ArrowRight = "→";
         </div>
 
         <ActivityFeed items={activity} />
+        <a
+          href="/now"
+          class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold"
+        >
+          See what I&rsquo;m up to
+          <span
+            class="transition-transform duration-200 group-hover:translate-x-1"
+            aria-hidden="true">&rarr;</span
+          >
+        </a>
       </div>
     </section>
 

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -1,0 +1,58 @@
+---
+// /now — a live view of what Guido is posting, reading, and building across the
+// open social web. Expanded "Right Now" activity feed (Sifa) + a Bookhive
+// "currently reading" card. Linked from the homepage activity box and the About
+// nav. See the "now page" convention: https://nownownow.com/about
+import BaseLayout from "@layouts/BaseLayout.astro";
+import ActivityFeed from "@components/Activity/ActivityFeed.astro";
+import ReadingCard from "@components/Reading/ReadingCard.astro";
+import { getActivity } from "../lib/sifaActivity";
+import { getReading } from "../lib/bookhive";
+
+// SSR + CDN stale-while-revalidate, mirroring the homepage: the feed and the
+// reading shelf stay fresh without a rebuild, queried at most ~once per window.
+export const prerender = false;
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, s-maxage=300, stale-while-revalidate=86400",
+);
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=0, must-revalidate",
+);
+
+const activity = await getActivity();
+const reading = await getReading();
+---
+
+<BaseLayout
+  title="Now"
+  description="What Guido is posting, reading, and building right now — a live view from across the open social web."
+>
+  <section class="mt-24 w-full px-4">
+    <div class="mx-auto max-w-2xl">
+      <header class="mb-8">
+        <p
+          class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.5rem] leading-none"
+        >
+          where my head&rsquo;s at
+        </p>
+        <h1 class="h1 mt-2">Now</h1>
+        <p class="text-base-500 dark:text-base-400 mt-2 text-[.85rem]">
+          updated whenever the feed moves
+        </p>
+        <p
+          class="text-base-700 dark:text-base-300 mt-4 text-lg leading-relaxed"
+        >
+          A live look at what I&rsquo;m posting, reading, and building across
+          the open social web — pulled straight from my own data on AT Protocol.
+        </p>
+      </header>
+
+      <div class="flex flex-col gap-10">
+        <ActivityFeed items={activity} />
+        <ReadingCard data={reading} />
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -44,8 +44,8 @@ const reading = await getReading();
         <p
           class="text-base-700 dark:text-base-300 mt-4 text-lg leading-relaxed"
         >
-          A live look at what I&rsquo;m posting, reading, and building across
-          the open social web — pulled straight from my own data on AT Protocol.
+          What I&rsquo;m posting, reading, and building right now, pulled
+          straight from my own data on AT Protocol.
         </p>
       </header>
 


### PR DESCRIPTION
Adds a `/now` page: a live view of what I'm posting, reading, and building, pulled from my own data on AT Protocol.

## What changed
- **`/now` route** (SSR + CDN stale-while-revalidate, like the homepage): an expanded "Right Now" activity feed (Sifa) plus a "currently reading" card. Stays fresh without a rebuild.
- **`bookhive` lib**: ingests `buzz.bookhive.book` records (read-only, no auth), filters to non-fiction via the shared Bookhive catalog's genres, and falls back to recently-finished non-fiction when nothing is marked reading. Public catalog covers with a tonal gradient + title fallback.
- **`ReadingCard`**: hero / grid / recently-read states (no progress bars — Bookhive exposes none).
- **Nav**: "Now" added under the About dropdown.
- **Homepage**: a quiet "See what I'm up to" link under the Right Now box.

## Notes
- Verified with `astro check` (0 errors) and visual QA in light + dark; non-fiction filter confirmed against real data (fiction titles correctly excluded).
- The expanded feed uses the existing single-feed ActivityFeed (a bigger version of the homepage box); a per-category bento layout is a possible follow-up.