### PR TITLE
test(a11y): wait for domcontentloaded, not networkidle

### DIFF
--- a/tests/a11y/wcag.spec.ts
+++ b/tests/a11y/wcag.spec.ts
@@ -41,7 +41,13 @@ async function gotoThemed(page: Page, route: string, theme: string) {
       localStorage.setItem("colorTheme", t);
     } catch {}
   }, theme);
-  await page.goto(route, { waitUntil: "networkidle" });
+  // Use domcontentloaded, not networkidle. Pages like /podcasts/ keep the
+  // network busy (media embeds, players, analytics beacons), so networkidle
+  // never settles and the audit times out — the flake that intermittently
+  // blocked merges. axe samples the rendered DOM and computed CSS, which is
+  // complete once the document parses and fonts load (handled below), so full
+  // network idle buys nothing here.
+  await page.goto(route, { waitUntil: "domcontentloaded" });
   // Sanity: the <html> element should carry the dark class in dark mode.
   if (theme === "dark") {
     await expect(page.locator("html")).toHaveClass(/dark/);


### PR DESCRIPTION
## Summary
The WCAG axe accessibility gate (`tests/a11y/wcag.spec.ts`) navigated with `waitUntil: "networkidle"`. Media-heavy pages — notably `/podcasts/` (players, embeds, analytics beacons) — keep the network busy, so `networkidle` never settled within the timeout and the audit failed intermittently. This flake blocked merges on unrelated PRs twice in the last day and forced manual re-runs.

axe only samples the rendered DOM and computed CSS, which is fully present at `domcontentloaded` plus the test's existing `document.fonts.ready` + settle wait. Full network idle bought nothing here.

- `tests/a11y/wcag.spec.ts`: `gotoThemed()` now navigates with `waitUntil: "domcontentloaded"`.

## Verification
- `/podcasts/` (light + dark): timed out before → **~6.5s each, pass**.
- Full suite (30 tests, all routes × light/dark): **30 passed in 48s**, no false violations from earlier sampling.

## Notes
- Test-only change. No production output affected.