### PR TITLE
feat: /now bento activity layout

### DIFF
--- a/src/components/Activity/ActivityBento.astro
+++ b/src/components/Activity/ActivityBento.astro
@@ -1,0 +1,221 @@
+---
+/**
+ * /now "Right Now", pulled apart by category into a bento grid (Posts / Reviews
+ * / Code / Events), each its own card with the source app's accent. Reuses
+ * FeedItem for the rows. The homepage keeps the single scrolling ActivityFeed;
+ * this is the expanded, sectioned view for the /now page.
+ *
+ * Layout: 1 column on mobile, 2 columns from sm (posts taller, events full
+ * width), 3 columns from xl (events spans the right two columns next to posts).
+ */
+import { Icon } from "astro-icon/components";
+import { type ActivityItem } from "@data/homeContent";
+import FeedItem from "./FeedItem.astro";
+
+interface Props {
+  items: ActivityItem[];
+}
+const { items } = Astro.props as Props;
+
+type CatKey = "posts" | "reviews" | "code" | "events";
+const CATS: {
+  key: CatKey;
+  label: string;
+  appColor: string;
+  max: number;
+  match: (t: ActivityItem["type"]) => boolean;
+}[] = [
+  {
+    key: "posts",
+    label: "Posts",
+    appColor: "bluesky",
+    max: 10,
+    match: (t) => t === "post" || t === "repost",
+  },
+  {
+    key: "reviews",
+    label: "Reviews",
+    appColor: "popfeed",
+    max: 6,
+    match: (t) => t === "review",
+  },
+  {
+    key: "code",
+    label: "Code",
+    appColor: "tangled",
+    max: 6,
+    match: (t) => t === "code",
+  },
+  {
+    key: "events",
+    label: "Events",
+    appColor: "smokesignal",
+    max: 6,
+    match: (t) => t === "event",
+  },
+];
+
+const groups = CATS.map((c) => {
+  const all = items.filter((i) => c.match(i.type));
+  return { ...c, count: all.length, items: all.slice(0, c.max) };
+}).filter((g) => g.items.length > 0);
+---
+
+<section class="bento-wrap" aria-label="Activity from AT Protocol, by category">
+  <div class="bento-head">
+    <span class="bento-title">Right Now</span>
+    <span class="live" aria-hidden="true"><span class="blip"></span></span>
+    <span class="bento-src">
+      by category via
+      <a
+        href="https://sifa.id/p/gui.do/activity"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-1"
+        >Sifa ID<Icon name="sifa" class="size-3.5" aria-hidden="true" /></a
+      >
+    </span>
+  </div>
+
+  <div class="bento">
+    {
+      groups.map((g) => (
+        <section
+          class:list={["bxcard", `b-${g.key}`]}
+          style={`--bx: var(--color-app-${g.appColor})`}
+          aria-label={g.label}
+        >
+          <div class="bx-head">
+            <span class="bx-dot" aria-hidden="true" />
+            <span class="bx-label">{g.label}</span>
+            <span class="bx-count">{g.count}</span>
+          </div>
+          <ul class="bx-list" role="list">
+            {g.items.map((item) => (
+              <FeedItem item={item} />
+            ))}
+          </ul>
+        </section>
+      ))
+    }
+  </div>
+</section>
+
+<style>
+  @reference "../../styles/tailwind.css";
+
+  .bento-wrap {
+    @apply bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 rounded-3xl border shadow-sm;
+    padding: clamp(1rem, 3vw, 1.4rem);
+  }
+  .bento-head {
+    @apply mb-4 flex flex-wrap items-center gap-2.5;
+  }
+  .bento-title {
+    @apply text-base-950 dark:text-base-50 font-display text-[1.12rem] font-extrabold tracking-[-0.01em];
+  }
+  .bento-src {
+    @apply text-base-500 dark:text-base-400 ml-auto text-[0.8rem];
+  }
+  .bento-src a {
+    @apply text-primary-600 dark:text-primary-400 font-semibold no-underline;
+  }
+
+  .bento {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
+    grid-auto-rows: min-content;
+  }
+  @media (min-width: 640px) {
+    .bento {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    .b-posts {
+      grid-row: span 2;
+    }
+    .b-events {
+      grid-column: 1 / -1;
+    }
+  }
+  @media (min-width: 1280px) {
+    .bento {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+    /* posts stays tall in column 1; events fills the right two columns */
+    .b-events {
+      grid-column: 2 / -1;
+    }
+  }
+
+  .bxcard {
+    @apply bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 rounded-2xl border;
+    position: relative;
+    overflow: hidden;
+    padding: 1rem 1.05rem 1.1rem;
+    box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
+    transition:
+      box-shadow 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
+      border-color 220ms cubic-bezier(0.2, 0.7, 0.2, 1),
+      transform 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
+  }
+  .bxcard::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--bx);
+    opacity: 0.85;
+  }
+  .bxcard:hover {
+    box-shadow: 0 8px 24px -10px rgb(0 0 0 / 0.25);
+    transform: translateY(-2px);
+    border-color: color-mix(in oklab, var(--bx) 40%, var(--color-base-200));
+  }
+  :global(.dark) .bxcard:hover {
+    border-color: color-mix(in oklab, var(--bx) 40%, var(--color-base-800));
+  }
+
+  .bx-head {
+    @apply border-base-200 dark:border-base-800 mb-2 flex items-center gap-2 border-b pb-2;
+  }
+  .bx-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    flex: none;
+    background: var(--bx);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--bx) 18%, transparent);
+  }
+  .bx-label {
+    @apply text-base-950 dark:text-base-50 font-display text-[1.02rem] font-extrabold tracking-[-0.01em];
+  }
+  .bx-count {
+    @apply text-base-500 dark:text-base-400 bg-base-200 dark:bg-base-800 ml-auto rounded-full px-2 py-0.5 text-[0.74rem] font-semibold;
+  }
+
+  .bx-list {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  /* Events spans full width, so its rows flow into responsive columns. */
+  .b-events .bx-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0 1.4rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .bxcard {
+      transition: none;
+    }
+    .bxcard:hover {
+      transform: none;
+    }
+  }
+</style>

--- a/src/components/Activity/ActivityFeed.astro
+++ b/src/components/Activity/ActivityFeed.astro
@@ -1,6 +1,7 @@
 ---
 import { Icon } from "astro-icon/components";
-import { APP_REGISTRY, APP_ICON, type ActivityItem } from "@data/homeContent";
+import { type ActivityItem } from "@data/homeContent";
+import FeedItem from "./FeedItem.astro";
 
 interface Props {
   items: ActivityItem[];
@@ -21,17 +22,6 @@ const filters = [
   { cat: "code", label: "Code" },
   { cat: "event", label: "Events" },
 ].filter((f) => f.cat === "all" || catsPresent.has(f.cat));
-
-const app = (key: string) =>
-  APP_REGISTRY[key] ?? { label: key, color: "var(--color-app-fallback)" };
-
-// Highlight @handles in post text without dangerouslySetInnerHTML on raw input:
-// split into plain + mention fragments.
-const fragments = (text: string) =>
-  text.split(/(@[\w.-]+)/g).map((part) => ({
-    mention: part.startsWith("@"),
-    value: part,
-  }));
 ---
 
 <section class="feed-wrap" aria-label="Live activity from AT Protocol">
@@ -71,172 +61,7 @@ const fragments = (text: string) =>
     </div>
 
     <ul class="feed-list" role="list">
-      {
-        items.map((item) => {
-          const a = app(item.app);
-          return (
-            <li
-              class="feed-item"
-              data-cat={catOf(item.type)}
-              style={`--app-c:${a.color}`}
-            >
-              {item.type === "review" ? (
-                <div class="fi-review">
-                  <div class="poster" aria-hidden="true">
-                    {item.imageUrl ? (
-                      <img src={item.imageUrl} alt="" loading="lazy" />
-                    ) : (
-                      <span class="poster-i">{item.title?.[0] ?? "★"}</span>
-                    )}
-                  </div>
-                  <div style="min-width:0;flex:1">
-                    <div class="fi-head">
-                      <span class="app-badge">
-                        {APP_ICON[item.app] ? (
-                          <Icon
-                            name={APP_ICON[item.app]}
-                            class="size-3.5"
-                            aria-hidden="true"
-                          />
-                        ) : (
-                          <span class="app-dot" />
-                        )}
-                        {a.label}
-                      </span>
-                      <span class="fi-time">{item.time}</span>
-                    </div>
-                    <div class="fi-title">{item.title}</div>
-                    <div class="fi-sub">{item.sub}</div>
-                    {typeof item.rating === "number" && (
-                      <div class="fi-rate">
-                        <Icon
-                          name="tabler/star"
-                          class="text-gold size-4"
-                          aria-hidden="true"
-                        />
-                        <span>
-                          <b>{item.rating}</b>/10
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <>
-                  <div class="fi-head">
-                    <span class="app-badge">
-                      {APP_ICON[item.app] ? (
-                        <Icon
-                          name={APP_ICON[item.app]}
-                          class="size-3.5"
-                          aria-hidden="true"
-                        />
-                      ) : (
-                        <span class="app-dot" />
-                      )}
-                      {a.label}
-                    </span>
-                    <span class="fi-kind">{item.kind}</span>
-                    <span class="fi-time">{item.time}</span>
-                  </div>
-                  {item.title && <div class="fi-title">{item.title}</div>}
-                  {item.sub && <div class="fi-sub">{item.sub}</div>}
-                  {item.text && (
-                    <p class="fi-text">
-                      {fragments(item.text).map((fr) =>
-                        fr.mention ? (
-                          <span class="mention">{fr.value}</span>
-                        ) : (
-                          fr.value
-                        ),
-                      )}
-                    </p>
-                  )}
-                  {item.videoWebm || item.videoMp4 ? (
-                    <video
-                      class="fi-img"
-                      autoplay
-                      loop
-                      muted
-                      playsinline
-                      preload="none"
-                      poster={item.mediaPoster}
-                      width={item.mediaWidth}
-                      height={item.mediaHeight}
-                      aria-label={item.imageAlt || "Animated GIF"}
-                    >
-                      {item.videoWebm && (
-                        <source src={item.videoWebm} type="video/webm" />
-                      )}
-                      {item.videoMp4 && (
-                        <source src={item.videoMp4} type="video/mp4" />
-                      )}
-                    </video>
-                  ) : (
-                    item.imageUrl && (
-                      <img
-                        class="fi-img"
-                        src={item.imageUrl}
-                        alt={item.imageAlt || ""}
-                        loading="lazy"
-                        decoding="async"
-                        width={item.mediaWidth}
-                        height={item.mediaHeight}
-                      />
-                    )
-                  )}
-                  {(item.likes || item.replies || item.reposts) && (
-                    <div class="fi-meta">
-                      {typeof item.replies === "number" && (
-                        <span aria-label={`${item.replies} replies`}>
-                          <Icon
-                            name="tabler/outline/message-2"
-                            class="size-3.5"
-                            aria-hidden="true"
-                          />
-                          {item.replies}
-                        </span>
-                      )}
-                      {typeof item.reposts === "number" && (
-                        <span aria-label={`${item.reposts} reposts`}>
-                          <Icon
-                            name="tabler/outline/repeat"
-                            class="size-3.5"
-                            aria-hidden="true"
-                          />
-                          {item.reposts}
-                        </span>
-                      )}
-                      {typeof item.likes === "number" && (
-                        <span aria-label={`${item.likes} likes`}>
-                          <Icon
-                            name="tabler/outline/heart"
-                            class="size-3.5"
-                            aria-hidden="true"
-                          />
-                          {item.likes}
-                        </span>
-                      )}
-                    </div>
-                  )}
-                </>
-              )}
-              {item.url && (
-                <a
-                  class="fi-link"
-                  href={item.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <span class="sr-only">
-                    Open this {a.label} {item.type} in a new tab
-                  </span>
-                </a>
-              )}
-            </li>
-          );
-        })
-      }
+      {items.map((item) => <FeedItem item={item} />)}
     </ul>
   </div>
 </section>

--- a/src/components/Activity/FeedItem.astro
+++ b/src/components/Activity/FeedItem.astro
@@ -1,0 +1,184 @@
+---
+/**
+ * A single activity-feed row. Shared by ActivityFeed (homepage "Right now" box)
+ * and ActivityBento (/now per-category cards) so the item markup has one source.
+ * Styling lives in the global `.feed-item` / `.fi-*` / `.poster` rules
+ * (_home.scss, un-scoped from .home) and `.app-badge` (_redesign.scss).
+ */
+import { Icon } from "astro-icon/components";
+import { APP_REGISTRY, APP_ICON, type ActivityItem } from "@data/homeContent";
+
+interface Props {
+  item: ActivityItem;
+}
+const { item } = Astro.props as Props;
+
+const catOf = (t: ActivityItem["type"]) =>
+  t === "post" || t === "repost" ? "posts" : t;
+
+const app = (key: string) =>
+  APP_REGISTRY[key] ?? { label: key, color: "var(--color-app-fallback)" };
+
+// Highlight @handles without dangerouslySetInnerHTML: split into plain + mention.
+const fragments = (text: string) =>
+  text.split(/(@[\w.-]+)/g).map((part) => ({
+    mention: part.startsWith("@"),
+    value: part,
+  }));
+
+const a = app(item.app);
+---
+
+<li class="feed-item" data-cat={catOf(item.type)} style={`--app-c:${a.color}`}>
+  {
+    item.type === "review" ? (
+      <div class="fi-review">
+        <div class="poster" aria-hidden="true">
+          {item.imageUrl ? (
+            <img src={item.imageUrl} alt="" loading="lazy" />
+          ) : (
+            <span class="poster-i">{item.title?.[0] ?? "★"}</span>
+          )}
+        </div>
+        <div style="min-width:0;flex:1">
+          <div class="fi-head">
+            <span class="app-badge">
+              {APP_ICON[item.app] ? (
+                <Icon
+                  name={APP_ICON[item.app]}
+                  class="size-3.5"
+                  aria-hidden="true"
+                />
+              ) : (
+                <span class="app-dot" />
+              )}
+              {a.label}
+            </span>
+            <span class="fi-time">{item.time}</span>
+          </div>
+          <div class="fi-title">{item.title}</div>
+          <div class="fi-sub">{item.sub}</div>
+          {typeof item.rating === "number" && (
+            <div class="fi-rate">
+              <Icon
+                name="tabler/star"
+                class="text-gold size-4"
+                aria-hidden="true"
+              />
+              <span>
+                <b>{item.rating}</b>/10
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+    ) : (
+      <>
+        <div class="fi-head">
+          <span class="app-badge">
+            {APP_ICON[item.app] ? (
+              <Icon
+                name={APP_ICON[item.app]}
+                class="size-3.5"
+                aria-hidden="true"
+              />
+            ) : (
+              <span class="app-dot" />
+            )}
+            {a.label}
+          </span>
+          <span class="fi-kind">{item.kind}</span>
+          <span class="fi-time">{item.time}</span>
+        </div>
+        {item.title && <div class="fi-title">{item.title}</div>}
+        {item.sub && <div class="fi-sub">{item.sub}</div>}
+        {item.text && (
+          <p class="fi-text">
+            {fragments(item.text).map((fr) =>
+              fr.mention ? <span class="mention">{fr.value}</span> : fr.value,
+            )}
+          </p>
+        )}
+        {item.videoWebm || item.videoMp4 ? (
+          <video
+            class="fi-img"
+            autoplay
+            loop
+            muted
+            playsinline
+            preload="none"
+            poster={item.mediaPoster}
+            width={item.mediaWidth}
+            height={item.mediaHeight}
+            aria-label={item.imageAlt || "Animated GIF"}
+          >
+            {item.videoWebm && (
+              <source src={item.videoWebm} type="video/webm" />
+            )}
+            {item.videoMp4 && <source src={item.videoMp4} type="video/mp4" />}
+          </video>
+        ) : (
+          item.imageUrl && (
+            <img
+              class="fi-img"
+              src={item.imageUrl}
+              alt={item.imageAlt || ""}
+              loading="lazy"
+              decoding="async"
+              width={item.mediaWidth}
+              height={item.mediaHeight}
+            />
+          )
+        )}
+        {(item.likes || item.replies || item.reposts) && (
+          <div class="fi-meta">
+            {typeof item.replies === "number" && (
+              <span aria-label={`${item.replies} replies`}>
+                <Icon
+                  name="tabler/outline/message-2"
+                  class="size-3.5"
+                  aria-hidden="true"
+                />
+                {item.replies}
+              </span>
+            )}
+            {typeof item.reposts === "number" && (
+              <span aria-label={`${item.reposts} reposts`}>
+                <Icon
+                  name="tabler/outline/repeat"
+                  class="size-3.5"
+                  aria-hidden="true"
+                />
+                {item.reposts}
+              </span>
+            )}
+            {typeof item.likes === "number" && (
+              <span aria-label={`${item.likes} likes`}>
+                <Icon
+                  name="tabler/outline/heart"
+                  class="size-3.5"
+                  aria-hidden="true"
+                />
+                {item.likes}
+              </span>
+            )}
+          </div>
+        )}
+      </>
+    )
+  }
+  {
+    item.url && (
+      <a
+        class="fi-link"
+        href={item.url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <span class="sr-only">
+          Open this {a.label} {item.type} in a new tab
+        </span>
+      </a>
+    )
+  }
+</li>

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -4,7 +4,7 @@
 // "currently reading" card. Linked from the homepage activity box and the About
 // nav. See the "now page" convention: https://nownownow.com/about
 import BaseLayout from "@layouts/BaseLayout.astro";
-import ActivityFeed from "@components/Activity/ActivityFeed.astro";
+import ActivityBento from "@components/Activity/ActivityBento.astro";
 import ReadingCard from "@components/Reading/ReadingCard.astro";
 import { getActivity } from "../lib/sifaActivity";
 import { getReading } from "../lib/bookhive";
@@ -27,10 +27,10 @@ const reading = await getReading();
 
 <BaseLayout
   title="Now"
-  description="What Guido is posting, reading, and building right now — a live view from across the open social web."
+  description="What Guido is posting, reading, and building right now: a live view from across the open social web."
 >
   <section class="mt-24 w-full px-4">
-    <div class="mx-auto max-w-2xl">
+    <div class="mx-auto max-w-5xl">
       <header class="mb-8">
         <p
           class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.5rem] leading-none"
@@ -50,7 +50,7 @@ const reading = await getReading();
       </header>
 
       <div class="flex flex-col gap-10">
-        <ActivityFeed items={activity} />
+        <ActivityBento items={activity} />
         <ReadingCard data={reading} />
       </div>
     </div>


### PR DESCRIPTION
The bento layout for /now. It was authored as a second commit on #258 but landed on that branch just after the PR auto-merged, so only the styling fix reached master. This brings the bento itself.

## What changed
- Pulls "Right Now" apart by category into separate cards: **Posts** (Bluesky), **Reviews** (Popfeed), **Code** (Tangled), **Events** (Smokesignal) — each with its source-app accent bar, dot, and count chip.
- Responsive: 1 column on mobile, 2 from `sm` (posts weighted taller, events full-width), 3 from `xl` (events spans the right two columns next to posts).
- Extracts `FeedItem.astro` so the homepage feed and the bento render rows from one source; `ActivityFeed` now composes it (homepage unchanged). New `ActivityBento.astro` drives /now.

Depends on the `_home.scss` feed-style un-scoping already merged via #258.

## Verified
`astro check` 0 errors; local dev build shows all four categories at 1/2/3 columns in light + dark, homepage feed unchanged.