### PR TITLE
feat: show up to 6 recently-read books on /now

### DIFF
--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -166,13 +166,14 @@ export async function getReading(): Promise<ReadingData> {
       };
     }
 
-    // Fallback: filter non-fiction across all finished, take the 4 most recent.
+    // Fallback: filter non-fiction across all finished, take the 6 most recent
+    // (fills a desktop row of the auto-fill cover grid).
     const finished = books
       .filter((b) => b.value.status === STATUS_FINISHED)
       .sort((a, b) =>
         (b.value.finishedAt ?? "").localeCompare(a.value.finishedAt ?? ""),
       );
-    const recentNF = (await enrichNonFiction(finished)).slice(0, 4);
+    const recentNF = (await enrichNonFiction(finished)).slice(0, 6);
     return { mode: "fallback", active: [], recent: recentNF.map(mapBook) };
   } catch {
     return { mode: "fallback", active: [], recent: [] };


### PR DESCRIPTION
The /now reading shelf fallback capped at 4 covers; on desktop the auto-fill grid has room for more. Bump to 6 so a row fills (14 non-fiction finished books are available). One-line change to the cap in the Bookhive lib.