### PR TITLE
fix: /now link, events layout, and copy polish

### DIFF
--- a/src/components/Activity/ActivityBento.astro
+++ b/src/components/Activity/ActivityBento.astro
@@ -203,12 +203,8 @@ const groups = CATS.map((c) => {
     margin: 0;
     padding: 0;
   }
-  /* Events spans full width, so its rows flow into responsive columns. */
-  .b-events .bx-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 0 1.4rem;
-  }
+  /* Events spans full width; keep its rows single-column so the app badge +
+     date never get squeezed onto two lines in a narrow auto-fit column. */
 
   @media (prefers-reduced-motion: reduce) {
     .bxcard {

--- a/src/components/Reading/ReadingCard.astro
+++ b/src/components/Reading/ReadingCard.astro
@@ -128,10 +128,6 @@ const isEmpty = books.length === 0;
   {
     data.mode === "fallback" && !isEmpty && (
       <>
-        <p class="text-base-700 dark:text-base-300 -mt-2 mb-4 max-w-[54ch] text-[.94rem] leading-[1.5]">
-          Nothing on the nightstand right this second. Here&rsquo;s the
-          non&#8209;fiction I just finished.
-        </p>
         <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
           {books.map((b) => (
             <div class="flex flex-col gap-2">

--- a/src/config/en/navData.json.ts
+++ b/src/config/en/navData.json.ts
@@ -64,7 +64,7 @@ const navConfig = [
       },
       {
         text: "Now",
-        link: "/now",
+        link: "/now/",
         icon: "tabler/clock",
       },
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -141,17 +141,19 @@ const ArrowRight = "→";
           </div>
         </div>
 
-        <ActivityFeed items={activity} />
-        <a
-          href="/now"
-          class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold"
-        >
-          See what I&rsquo;m up to
-          <span
-            class="transition-transform duration-200 group-hover:translate-x-1"
-            aria-hidden="true">&rarr;</span
+        <div>
+          <ActivityFeed items={activity} />
+          <a
+            href="/now/"
+            class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold"
           >
-        </a>
+            See what I&rsquo;m up to
+            <span
+              class="transition-transform duration-200 group-hover:translate-x-1"
+              aria-hidden="true">&rarr;</span
+            >
+          </a>
+        </div>
       </div>
     </section>
 

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -45,7 +45,7 @@ const reading = await getReading();
           class="text-base-700 dark:text-base-300 mt-4 text-lg leading-relaxed"
         >
           What I&rsquo;m posting, reading, and building right now, pulled
-          straight from my own data on AT Protocol.
+          straight from my Atmosphere account.
         </p>
       </header>
 


### PR DESCRIPTION
Five small /now fixes from review.

- **Homepage link** 'See what I'm up to' pointed at `/now` (no trailing slash) — the SSR route 404s without it. Now `/now/`. It was also a third child of the 2-col hero grid, so it landed under the hero stats; wrapped it with the feed so it sits directly under the Right Now box. Nav 'Now' link also `/now/`.
- **/now lead** now reads 'pulled straight from my Atmosphere account' (was 'my own data on AT Protocol').
- **Events card** is single-column, so the Smoke Signal badge + date no longer wrap onto two lines in a narrow column.
- **Reading fallback** drops the 'Nothing on the nightstand' line — no need to call out an empty state.

Verified in local dev: homepage link under the feed, events one line each, copy updated.