### PR TITLE
feat: /now see-all links, fuller posts column, capped books

### DIFF
--- a/src/components/Activity/ActivityBento.astro
+++ b/src/components/Activity/ActivityBento.astro
@@ -18,39 +18,46 @@ interface Props {
 const { items } = Astro.props as Props;
 
 type CatKey = "posts" | "reviews" | "code" | "events";
+const SIFA = "https://sifa.id/p/gui.do/activity";
 const CATS: {
   key: CatKey;
   label: string;
   appColor: string;
   max: number;
+  seeAllHref: string;
   match: (t: ActivityItem["type"]) => boolean;
 }[] = [
+  // Posts is the tall card; show more so it fills the column next to Reviews+Code.
   {
     key: "posts",
     label: "Posts",
     appColor: "bluesky",
-    max: 10,
+    max: 12,
+    seeAllHref: "https://bsky.app/profile/gui.do",
     match: (t) => t === "post" || t === "repost",
   },
   {
     key: "reviews",
     label: "Reviews",
     appColor: "popfeed",
-    max: 12,
+    max: 6,
+    seeAllHref: SIFA,
     match: (t) => t === "review",
   },
   {
     key: "code",
     label: "Code",
     appColor: "tangled",
-    max: 12,
+    max: 6,
+    seeAllHref: SIFA,
     match: (t) => t === "code",
   },
   {
     key: "events",
     label: "Events",
     appColor: "smokesignal",
-    max: 8,
+    max: 6,
+    seeAllHref: SIFA,
     match: (t) => t === "event",
   },
 ];
@@ -95,6 +102,18 @@ const groups = CATS.map((c) => {
               <FeedItem item={item} />
             ))}
           </ul>
+          <a
+            href={g.seeAllHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="bx-more no-random-underline"
+          >
+            <span class="underline underline-offset-2">See all</span>
+            <span class="bx-more-arrow" aria-hidden="true">
+              &rarr;
+            </span>
+            <span class="sr-only">{g.label} (opens in new tab)</span>
+          </a>
         </section>
       ))
     }
@@ -151,6 +170,8 @@ const groups = CATS.map((c) => {
   .bxcard {
     @apply bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 rounded-2xl border;
     position: relative;
+    display: flex;
+    flex-direction: column;
     overflow: hidden;
     padding: 1rem 1.05rem 1.1rem;
     box-shadow: 0 1px 2px rgb(0 0 0 / 0.04);
@@ -202,6 +223,19 @@ const groups = CATS.map((c) => {
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  /* "See all" footer, pinned to the card bottom so footers line up. */
+  .bx-more {
+    @apply text-primary-600 dark:text-primary-400 mt-auto inline-flex items-center gap-1 self-start pt-3 text-[0.8rem] font-semibold;
+    text-decoration: none;
+  }
+  .bx-more-arrow {
+    transition: transform 0.2s ease;
+  }
+  .bx-more:hover .bx-more-arrow,
+  .bx-more:focus-visible .bx-more-arrow {
+    transform: translateX(2px);
   }
   /* Events spans full width; keep its rows single-column so the app badge +
      date never get squeezed onto two lines in a narrow auto-fit column. */

--- a/src/components/Reading/ReadingCard.astro
+++ b/src/components/Reading/ReadingCard.astro
@@ -10,8 +10,11 @@ import type { ReadingData, Book } from "../../lib/bookhive";
 
 interface Props {
   data: ReadingData;
+  /** Full shelf, linked from "Read more". */
+  bookhiveHref?: string;
 }
-const { data } = Astro.props as Props;
+const { data, bookhiveHref = "https://bookhive.buzz/profile/gui.do" } =
+  Astro.props as Props;
 const heading =
   data.mode === "fallback" ? "Recently read" : "Currently reading";
 const books: Book[] = data.mode === "fallback" ? data.recent : data.active;
@@ -157,6 +160,18 @@ const isEmpty = books.length === 0;
             </div>
           ))}
         </div>
+        <a
+          href={bookhiveHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="reading-more no-random-underline"
+        >
+          <span class="underline underline-offset-2">Read more</span>
+          <span class="reading-more-arrow" aria-hidden="true">
+            &rarr;
+          </span>
+          <span class="sr-only">on Bookhive (opens in new tab)</span>
+        </a>
       </>
     )
   }
@@ -164,6 +179,18 @@ const isEmpty = books.length === 0;
 
 <style>
   @reference "../../styles/tailwind.css";
+
+  .reading-more {
+    @apply text-primary-600 dark:text-primary-400 mt-4 inline-flex items-center gap-1 self-start text-[0.85rem] font-semibold;
+    text-decoration: none;
+  }
+  .reading-more-arrow {
+    transition: transform 0.2s ease;
+  }
+  .reading-more:hover .reading-more-arrow,
+  .reading-more:focus-visible .reading-more-arrow {
+    transform: translateX(2px);
+  }
 
   .bookhive-badge {
     @apply inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[.74rem] font-semibold;

--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -166,14 +166,14 @@ export async function getReading(): Promise<ReadingData> {
       };
     }
 
-    // Fallback: every finished non-fiction book, newest first. The card's
-    // auto-fill cover grid wraps to as many rows as it needs.
+    // Fallback: most-recent finished non-fiction, capped to ~2 desktop rows of
+    // the cover grid. The card links out to Bookhive for the full shelf.
     const finished = books
       .filter((b) => b.value.status === STATUS_FINISHED)
       .sort((a, b) =>
         (b.value.finishedAt ?? "").localeCompare(a.value.finishedAt ?? ""),
       );
-    const recentNF = await enrichNonFiction(finished);
+    const recentNF = (await enrichNonFiction(finished)).slice(0, 12);
     return { mode: "fallback", active: [], recent: recentNF.map(mapBook) };
   } catch {
     return { mode: "fallback", active: [], recent: [] };

--- a/src/lib/sifaActivity.ts
+++ b/src/lib/sifaActivity.ts
@@ -409,7 +409,7 @@ function mapItem(raw: any, meta?: PostMeta): ActivityItem | null {
  * failure or empty result. Never throws.
  */
 const RECENT_DAYS = 7;
-const POST_HIGHLIGHTS = 6; // top posts by engagement, then the non-post tail
+const POST_HIGHLIGHTS = 12; // top posts by engagement, then the non-post tail
 
 export async function getActivity(): Promise<ActivityItem[]> {
   try {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -145,9 +145,11 @@ const ArrowRight = "→";
           <ActivityFeed items={activity} />
           <a
             href="/now/"
-            class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold"
+            class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold no-underline"
           >
-            See what I&rsquo;m up to
+            <span class="underline underline-offset-2"
+              >See what I&rsquo;m up to</span
+            >
             <span
               class="transition-transform duration-200 group-hover:translate-x-1"
               aria-hidden="true">&rarr;</span


### PR DESCRIPTION
Follow-up polish on /now.

- **Link underline:** the homepage 'See what I'm up to' link used inline-flex, which split the underline into a text segment + a separate arrow segment. Now only the text is underlined; the arrow is clean.
- **Posts column fills:** the tall Posts card now shows up to 12 items (POST_HIGHLIGHTS 6 -> 12) so it fills the height next to Reviews + Code instead of leaving whitespace.
- **Capped categories + see-all:** Reviews / Code / Events show up to 6 recent items, each card with a 'See all' link (Posts -> Bluesky profile, the rest -> Sifa profile, which aggregates everything).
- **Books:** capped to ~2 rows (12 covers) with a 'Read more' link to the full Bookhive shelf (bookhive.buzz/profile/gui.do).

Linking out to the atproto services (Bookhive / Bluesky / Sifa) rather than building dedicated gui.do pages, since these are ingested signals. Dedicated /books etc. pages remain an option. Verified light + dark in local dev.