### PR TITLE
fix: paginate Bookhive, show currently-reading + recently-read

### DIFF
--- a/src/components/Reading/ReadingCard.astro
+++ b/src/components/Reading/ReadingCard.astro
@@ -1,12 +1,11 @@
 ---
 /**
- * "Currently reading" card for /now — ingests Bookhive (non-fiction only).
- * Three states: one active read (hero), many active reads (grid), or the
- * "Recently read" fallback when nothing is marked reading. No progress bars
+ * Reading card for /now — ingests Bookhive. Shows what's currently being read
+ * (any genre) and a "Recently read" non-fiction shelf. No progress bars
  * (Bookhive exposes no progress).
  */
 import Stars from "./Stars.astro";
-import type { ReadingData, Book } from "../../lib/bookhive";
+import type { ReadingData } from "../../lib/bookhive";
 
 interface Props {
   data: ReadingData;
@@ -15,32 +14,20 @@ interface Props {
 }
 const { data, bookhiveHref = "https://bookhive.buzz/profile/gui.do" } =
   Astro.props as Props;
-const heading =
-  data.mode === "fallback" ? "Recently read" : "Currently reading";
-const books: Book[] = data.mode === "fallback" ? data.recent : data.active;
-
-// Nothing to show at all (e.g. a build-time fetch failure) — render a minimal note.
-const isEmpty = books.length === 0;
+const { active, recent } = data;
+const nothing = active.length === 0 && recent.length === 0;
 ---
 
 <section
   class="reading-card bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 relative overflow-hidden rounded-2xl border p-6 shadow-sm md:p-7"
-  aria-labelledby="reading-heading"
+  aria-label="Reading"
 >
   <div class="mb-5 flex flex-wrap items-start justify-between gap-3">
-    <div>
-      <p
-        class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.15rem] leading-none"
-      >
-        on the nightstand
-      </p>
-      <h3
-        id="reading-heading"
-        class="text-base-950 dark:text-base-50 font-display mt-1 text-[1.4rem] font-black tracking-[-0.02em]"
-      >
-        {heading}
-      </h3>
-    </div>
+    <p
+      class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.15rem] leading-none"
+    >
+      on the nightstand
+    </p>
     <span class="bookhive-badge">
       <span class="bookhive-dot" aria-hidden="true"></span>
       Bookhive
@@ -48,91 +35,102 @@ const isEmpty = books.length === 0;
   </div>
 
   {
-    isEmpty && (
+    nothing && (
       <p class="text-base-500 dark:text-base-400 text-[.94rem]">
         Reading list is taking a breather.
       </p>
     )
   }
 
+  {/* ── Currently reading (any genre) ── */}
   {
-    data.mode === "one" && books[0] && (
-      <div class="flex flex-wrap items-stretch gap-5">
-        <div
-          class={`bk-cover bk-${books[0].accent} h-[206px] w-[138px] flex-none`}
-        >
-          {books[0].coverUrl ? (
-            <img
-              src={books[0].coverUrl}
-              alt={`Cover of ${books[0].title}`}
-              loading="lazy"
-            />
-          ) : (
-            <>
-              <span class="bk-spine" aria-hidden="true" />
-              <div class="bk-meta">
-                <div class="bk-title">{books[0].title}</div>
-                <div class="bk-author">{books[0].author}</div>
-              </div>
-            </>
-          )}
-        </div>
-        <div class="flex min-w-[200px] flex-[1_1_240px] flex-col justify-center gap-2">
-          <span class="reading-pill">
-            <span class="reading-pill-dot" aria-hidden="true" /> Reading now
-          </span>
-          <div class="text-base-950 dark:text-base-50 font-display text-[1.5rem] leading-[1.1] font-extrabold tracking-[-0.02em]">
-            {books[0].title}
-          </div>
-          <div class="text-base-700 dark:text-base-300 text-[.98rem]">
-            {books[0].author}
-          </div>
-          {books[0].startedLabel && (
-            <div class="text-base-500 dark:text-base-400 text-[.84rem]">
-              {books[0].startedLabel}
-            </div>
-          )}
-        </div>
-      </div>
-    )
-  }
-
-  {
-    data.mode === "many" && (
-      <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
-        {books.map((b) => (
-          <div class="flex flex-col gap-2">
-            <div class={`bk-cover bk-${b.accent} aspect-[2/3] w-full`}>
-              {b.coverUrl ? (
-                <img
-                  src={b.coverUrl}
-                  alt={`Cover of ${b.title}`}
-                  loading="lazy"
-                />
-              ) : (
-                <>
-                  <span class="bk-spine" aria-hidden="true" />
-                  <div class="bk-meta">
-                    <div class="bk-title">{b.title}</div>
-                    <div class="bk-author">{b.author}</div>
-                  </div>
-                </>
-              )}
-            </div>
-            <div class="text-love flex items-center gap-1.5 text-[.74rem] font-bold">
-              <span class="reading-pill-dot" aria-hidden="true" /> Reading now
-            </div>
-          </div>
-        ))}
-      </div>
-    )
-  }
-
-  {
-    data.mode === "fallback" && !isEmpty && (
+    active.length === 1 && (
       <>
+        <h3 class="reading-h">Currently reading</h3>
+        <div class="flex flex-wrap items-stretch gap-5">
+          <div
+            class={`bk-cover bk-${active[0].accent} h-[206px] w-[138px] flex-none`}
+          >
+            {active[0].coverUrl ? (
+              <img
+                src={active[0].coverUrl}
+                alt={`Cover of ${active[0].title}`}
+                loading="lazy"
+              />
+            ) : (
+              <>
+                <span class="bk-spine" aria-hidden="true" />
+                <div class="bk-meta">
+                  <div class="bk-title">{active[0].title}</div>
+                  <div class="bk-author">{active[0].author}</div>
+                </div>
+              </>
+            )}
+          </div>
+          <div class="flex min-w-[200px] flex-[1_1_240px] flex-col justify-center gap-2">
+            <span class="reading-pill">
+              <span class="reading-pill-dot" aria-hidden="true" /> Reading now
+            </span>
+            <div class="text-base-950 dark:text-base-50 font-display text-[1.5rem] leading-[1.1] font-extrabold tracking-[-0.02em]">
+              {active[0].title}
+            </div>
+            <div class="text-base-700 dark:text-base-300 text-[.98rem]">
+              {active[0].author}
+            </div>
+            {active[0].startedLabel && (
+              <div class="text-base-500 dark:text-base-400 text-[.84rem]">
+                {active[0].startedLabel}
+              </div>
+            )}
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  {
+    active.length > 1 && (
+      <>
+        <h3 class="reading-h">Currently reading</h3>
         <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
-          {books.map((b) => (
+          {active.map((b) => (
+            <div class="flex flex-col gap-2">
+              <div class={`bk-cover bk-${b.accent} aspect-[2/3] w-full`}>
+                {b.coverUrl ? (
+                  <img
+                    src={b.coverUrl}
+                    alt={`Cover of ${b.title}`}
+                    loading="lazy"
+                  />
+                ) : (
+                  <>
+                    <span class="bk-spine" aria-hidden="true" />
+                    <div class="bk-meta">
+                      <div class="bk-title">{b.title}</div>
+                      <div class="bk-author">{b.author}</div>
+                    </div>
+                  </>
+                )}
+              </div>
+              <div class="text-love flex items-center gap-1.5 text-[.74rem] font-bold">
+                <span class="reading-pill-dot" aria-hidden="true" /> Reading now
+              </div>
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+
+  {/* ── Recently read (non-fiction) ── */}
+  {
+    recent.length > 0 && (
+      <>
+        <h3 class:list={["reading-h", active.length > 0 && "mt-7"]}>
+          Recently read
+        </h3>
+        <div class="grid grid-cols-[repeat(auto-fill,minmax(150px,1fr))] gap-4">
+          {recent.map((b) => (
             <div class="flex flex-col gap-2">
               <div class={`bk-cover bk-${b.accent} aspect-[2/3] w-full`}>
                 {b.coverUrl ? (
@@ -179,6 +177,10 @@ const isEmpty = books.length === 0;
 
 <style>
   @reference "../../styles/tailwind.css";
+
+  .reading-h {
+    @apply text-base-950 dark:text-base-50 font-display mb-3 text-[1.4rem] font-black tracking-[-0.02em];
+  }
 
   .reading-more {
     @apply text-primary-600 dark:text-primary-400 mt-4 inline-flex items-center gap-1 self-start text-[0.85rem] font-semibold;

--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -55,9 +55,9 @@ export interface Book {
 }
 
 export interface ReadingData {
-  /** one active read · many active reads · fallback to recently finished */
-  mode: "one" | "many" | "fallback";
+  /** Books marked "reading" right now (any genre). */
   active: Book[];
+  /** Recently-finished non-fiction, capped to ~2 rows. */
   recent: Book[];
 }
 
@@ -83,14 +83,24 @@ const monthYear = (iso?: string): string | undefined => {
   return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
 };
 
+// All book records, following the cursor (listRecords pages at 100). Capped at
+// a few pages so a huge shelf can't run away.
 async function listBooks(): Promise<RawBook[]> {
-  const url =
-    `${PDS}/xrpc/com.atproto.repo.listRecords` +
-    `?repo=${GUIDO_DID}&collection=${BOOK_COLLECTION}&limit=100`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`listRecords ${res.status}`);
-  const data = (await res.json()) as { records?: RawBook[] };
-  return data.records ?? [];
+  const all: RawBook[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < 6; page++) {
+    const url =
+      `${PDS}/xrpc/com.atproto.repo.listRecords` +
+      `?repo=${GUIDO_DID}&collection=${BOOK_COLLECTION}&limit=100` +
+      (cursor ? `&cursor=${encodeURIComponent(cursor)}` : "");
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`listRecords ${res.status}`);
+    const data = (await res.json()) as { records?: RawBook[]; cursor?: string };
+    all.push(...(data.records ?? []));
+    cursor = data.cursor;
+    if (!cursor || !data.records?.length) break;
+  }
+  return all;
 }
 
 interface Enriched {
@@ -126,14 +136,14 @@ async function catalogInfo(hiveId?: string): Promise<{
 const isNonFiction = (genres: string[]): boolean =>
   !genres.some((g) => FICTION_GENRES.has(g.trim().toLowerCase()));
 
-async function enrichNonFiction(raw: RawBook[]): Promise<Enriched[]> {
-  const enriched = await Promise.all(
+// Fetch genres + cover for each book. No genre filter here — callers decide.
+async function enrich(raw: RawBook[]): Promise<Enriched[]> {
+  return Promise.all(
     raw.map(async (b) => {
       const { genres, cover } = await catalogInfo(b.value.hiveId);
       return { raw: b, genres, catalogCover: cover };
     }),
   );
-  return enriched.filter((e) => isNonFiction(e.genres));
 }
 
 const mapBook = (e: Enriched, i: number): Book => ({
@@ -152,30 +162,32 @@ const mapBook = (e: Enriched, i: number): Book => ({
     : undefined,
 });
 
+const RECENT_CAP = 14; // ~2 rows of the cover grid
+const FINISHED_CANDIDATES = 36; // bound catalog lookups while still yielding 14 NF
+
 export async function getReading(): Promise<ReadingData> {
   try {
     const books = await listBooks();
 
+    // Currently reading — shown regardless of genre (it's THE current read).
     const reading = books.filter((b) => b.value.status === STATUS_READING);
-    const activeNF = await enrichNonFiction(reading);
-    if (activeNF.length > 0) {
-      return {
-        mode: activeNF.length === 1 ? "one" : "many",
-        active: activeNF.map(mapBook),
-        recent: [],
-      };
-    }
+    const active = (await enrich(reading)).map(mapBook);
 
-    // Fallback: most-recent finished non-fiction, capped to ~2 desktop rows of
-    // the cover grid. The card links out to Bookhive for the full shelf.
-    const finished = books
+    // Recently read — most-recent finished, filtered to non-fiction. Only the
+    // newest handful are enriched so the catalog isn't hit hundreds of times.
+    const finishedCandidates = books
       .filter((b) => b.value.status === STATUS_FINISHED)
       .sort((a, b) =>
         (b.value.finishedAt ?? "").localeCompare(a.value.finishedAt ?? ""),
-      );
-    const recentNF = (await enrichNonFiction(finished)).slice(0, 12);
-    return { mode: "fallback", active: [], recent: recentNF.map(mapBook) };
+      )
+      .slice(0, FINISHED_CANDIDATES);
+    const recent = (await enrich(finishedCandidates))
+      .filter((e) => isNonFiction(e.genres))
+      .slice(0, RECENT_CAP)
+      .map(mapBook);
+
+    return { active, recent };
   } catch {
-    return { mode: "fallback", active: [], recent: [] };
+    return { active: [], recent: [] };
   }
 }


### PR DESCRIPTION
Two book bugs from review.

- **Currently-reading wasn't showing.** `listBooks` fetched only the first 100 records and never followed the cursor — with 178 books, the 2 'reading' ones (Inspired, Reset) were on a later page. Now paginated.
- **Only 12 of 14 shown / current read hidden.** The card used to show *either* current reads *or* recently-read. It now shows **both**: a 'Currently reading' section (any genre) and a 'Recently read' non-fiction shelf (14, ~2 rows) with Read more -> Bookhive.

Catalog lookups are bounded (only the newest ~36 finished are enriched for the non-fiction filter, not all 150+). Verified in dev: 'Currently reading' (2) + 'Recently read' (14).