### PR TITLE
perf(home): static homepage + client-hydrated Right Now feed

### DIFF
--- a/src/components/Activity/ActivityFeed.astro
+++ b/src/components/Activity/ActivityFeed.astro
@@ -67,27 +67,31 @@ const filters = [
 </section>
 
 <script>
-  function initActivityFilters() {
-    document.querySelectorAll<HTMLElement>(".feed-wrap").forEach((wrap) => {
-      const buttons = wrap.querySelectorAll<HTMLButtonElement>(".fbtn");
-      const items = wrap.querySelectorAll<HTMLElement>(".feed-item");
-      buttons.forEach((btn) => {
-        btn.addEventListener("click", () => {
-          const cat = btn.dataset.cat;
-          buttons.forEach((b) => {
-            const active = b === btn;
-            b.classList.toggle("active", active);
-            b.setAttribute("aria-selected", active ? "true" : "false");
-          });
-          items.forEach((item) => {
-            const show = cat === "all" || item.dataset.cat === cat;
-            item.style.display = show ? "" : "none";
-          });
-        });
+  // Delegated on document so filtering keeps working after the homepage swaps in
+  // the freshly-fetched feed fragment (and across view-transition swaps) without
+  // any re-init. Guard against binding twice if this script loads more than once.
+  interface ActivityWindow extends Window {
+    __activityFiltersBound?: boolean;
+  }
+  const w = window as ActivityWindow;
+  if (!w.__activityFiltersBound) {
+    w.__activityFiltersBound = true;
+    document.addEventListener("click", (event) => {
+      const target = event.target as HTMLElement | null;
+      const btn = target?.closest<HTMLButtonElement>(".feed-wrap .fbtn");
+      if (!btn) return;
+      const wrap = btn.closest<HTMLElement>(".feed-wrap");
+      if (!wrap) return;
+      const cat = btn.dataset.cat;
+      wrap.querySelectorAll<HTMLButtonElement>(".fbtn").forEach((b) => {
+        const active = b === btn;
+        b.classList.toggle("active", active);
+        b.setAttribute("aria-selected", active ? "true" : "false");
+      });
+      wrap.querySelectorAll<HTMLElement>(".feed-item").forEach((item) => {
+        const show = cat === "all" || item.dataset.cat === cat;
+        item.style.display = show ? "" : "none";
       });
     });
   }
-
-  initActivityFilters();
-  document.addEventListener("astro:after-swap", initActivityFilters);
 </script>

--- a/src/pages/api/activity-feed.astro
+++ b/src/pages/api/activity-feed.astro
@@ -1,0 +1,25 @@
+---
+import ActivityFeed from "@components/Activity/ActivityFeed.astro";
+import { getActivity } from "../../lib/sifaActivity";
+
+// Partial: returns only the <ActivityFeed> fragment (no layout), fetched by the
+// homepage after first paint so the static HTML never blocks on Sifa/Bluesky.
+export const partial = true;
+export const prerender = false;
+
+// CDN-cache the fragment with stale-while-revalidate so the upstream AppView is
+// queried at most ~once per window, not per visitor. Mirrors the policy the
+// homepage itself used to carry before it became static.
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, s-maxage=300, stale-while-revalidate=86400",
+);
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=0, must-revalidate",
+);
+
+const activity = await getActivity();
+---
+
+<ActivityFeed items={activity} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -32,25 +32,16 @@ import {
 import { getActivity } from "../lib/sifaActivity";
 import { readingTimeShort } from "../utils/readingTime";
 
-// Render the homepage on demand so the live "Right now" feed stays fresh
-// without a rebuild, but cache the rendered page at the Netlify CDN with
-// stale-while-revalidate: Sifa is queried at most ~once per window (not per
-// visitor), visitors get a fast CDN-cached page, and the feed refreshes itself
-// every few minutes. The getActivity() fallback covers Sifa being unreachable.
-export const prerender = false;
-Astro.response.headers.set(
-  "Netlify-CDN-Cache-Control",
-  "public, s-maxage=300, stale-while-revalidate=86400",
-);
-Astro.response.headers.set(
-  "Cache-Control",
-  "public, max-age=0, must-revalidate",
-);
-
+// The homepage is statically generated so the HTML never blocks on the live
+// "Right now" feed (Sifa/Bluesky). getActivity() runs here at BUILD time, so the
+// static page ships with real recent data baked in; the client then swaps in a
+// fresh fragment after first paint (see the activity-mount script below and
+// /api/activity-feed). This keeps TTFB at CDN-static speed while the feed stays
+// live. getActivity() falls back to the seed if Sifa is unreachable at build.
 const currLocale = getLocaleFromUrl(Astro.url);
 const siteData = getTranslatedData("siteData", currLocale);
 
-// Live gui.do activity from the Sifa AppView (falls back to seed on failure).
+// Build-time gui.do activity from the Sifa AppView (falls back to seed on failure).
 const activity = await getActivity();
 
 // Recent articles from the post collection (real data, working links).
@@ -142,7 +133,9 @@ const ArrowRight = "→";
         </div>
 
         <div>
-          <ActivityFeed items={activity} />
+          <div id="activity-mount" data-activity-endpoint="/api/activity-feed">
+            <ActivityFeed items={activity} />
+          </div>
           <a
             href="/now/"
             class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold no-underline"
@@ -483,3 +476,21 @@ const ArrowRight = "→";
     </section>
   </div>
 </BaseLayout>
+
+<script>
+  // Hydrate the "Right now" feed after first paint. The static page ships with
+  // build-time data; this swaps in a fresh fragment without ever blocking the
+  // document. Filters keep working via the delegated handler in ActivityFeed.
+  const mount = document.getElementById("activity-mount");
+  const endpoint = mount?.dataset.activityEndpoint;
+  if (mount && endpoint) {
+    fetch(endpoint, { headers: { accept: "text/html" } })
+      .then((res) => (res.ok ? res.text() : null))
+      .then((html) => {
+        if (html && html.trim()) mount.innerHTML = html;
+      })
+      .catch(() => {
+        /* keep the statically-rendered feed on failure */
+      });
+  }
+</script>


### PR DESCRIPTION
## Why

The Lighthouse run on the #265 deploy preview scored Performance 76. The cause wasn't images or CSS — it was the **HTML document itself taking 8.46s to respond** (`server-response-time: 8,464 ms`), which pushed Speed Index to 13.1s and real first paint to ~8.8s. Nothing on the page can start until the document returns.

Root cause: the homepage set `export const prerender = false` and then `await getActivity()` (Sifa AppView + a serial Bluesky AppView call) **before sending any HTML**. There's no timeout, so a slow-but-successful upstream just makes the page wait. The existing `stale-while-revalidate` CDN header hid this for warm visitors, but every cache miss (cold deploy, post-SWR expiry, and the Lighthouse preview run) paid the full blocking cost.

## What changed

Take the live feed off the HTML critical path:

- **Homepage is now statically generated.** `getActivity()` runs at **build time**, so the static HTML ships with real recent activity baked in (good for no-JS visitors and crawlers). TTFB drops to static-CDN speed.
- **New partial route `/api/activity-feed`** (`partial = true`, `prerender = false`) renders the exact same `<ActivityFeed>` fragment with live data, CDN-cached with `stale-while-revalidate` so the upstream is hit at most ~once per window, not per visitor.
- **Client hydration**: a small script swaps the fresh fragment into a stable `#activity-mount` after first paint. On fetch failure it keeps the statically-rendered feed.
- **Feed filters** move to document-level event delegation, so they keep working after the fragment is swapped in (and across view-transition swaps) with no re-init.

Net: the feed stays live, but it can never again block the document.

## Verification

Local build can't validate this here: the machine runs Node 26 (a vite virtual-module bug breaks `astro build` on pristine `master` too) and the private `@singi-labs/sifa-sdk` package isn't installed locally, so `getActivity()` can't run. `astro check` passes clean on the changed files (the only errors are the pre-existing animejs + sifa-sdk type-resolution ones that `master` shares).

**The Netlify deploy preview is the real check.** Please re-run Lighthouse against this preview and confirm `server-response-time` / TTFB drops to CDN-static and Performance recovers, and that the "Right now" box still renders + filters work after it hydrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)