### PR TITLE
fix(a11y): meet WCAG AA contrast on homepage feed link + retainer CTA

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,7 +84,15 @@ const rest = posts.slice(1, 4);
 // `accent: "gold"`. Normalise any gold card accent to foam at render time.
 const cardAccent = (accent: Accent): Accent =>
   accent === "gold" ? "foam" : accent;
-const ac = (accent: Accent) => `--ac:var(--color-${cardAccent(accent)})`;
+// Pine is a mid-dark teal: dark text on it fails WCAG AA (3.4:1) and the lavender
+// light text only reaches 3.9:1. Only near-white clears 4.5:1, so the pine card's
+// button takes light text while the pastel accents keep their dark text.
+const cardAccentFg = (accent: Accent): string =>
+  cardAccent(accent) === "pine"
+    ? "var(--color-base-50)"
+    : "var(--color-base-950)";
+const ac = (accent: Accent) =>
+  `--ac:var(--color-${cardAccent(accent)});--ac-fg:${cardAccentFg(accent)}`;
 const ArrowRight = "→";
 ---
 
@@ -145,7 +153,7 @@ const ArrowRight = "→";
           <ActivityFeed items={activity} />
           <a
             href="/now/"
-            class="no-random-underline text-foam-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold no-underline"
+            class="no-random-underline text-pine-light dark:text-foam group mt-4 inline-flex items-center gap-1.5 text-[0.92rem] font-bold no-underline"
           >
             <span class="underline underline-offset-2"
               >See what I&rsquo;m up to</span

--- a/src/styles/components/_home.scss
+++ b/src/styles/components/_home.scss
@@ -385,8 +385,9 @@
   }
   .home .wwm-card .wbtn {
     @apply font-display inline-flex items-center gap-1.5 self-start rounded-full px-4 py-2.5 text-[0.9rem] font-bold no-underline;
-    /* Dark text: the per-card accent is a bright pastel, so white fails WCAG. */
-    color: var(--color-base-950);
+    /* Foreground is set per accent in index.astro (ac()): dark text on the bright
+       pastels, light text on the darker pine accent, so both clear WCAG AA. */
+    color: var(--ac-fg, var(--color-base-950));
     background: var(--ac, var(--color-primary-600));
     transition:
       border-color,


### PR DESCRIPTION
## Why

The Lighthouse run on the recent deploy preview flagged two homepage elements failing WCAG AA contrast (Accessibility 98 — these two are what's keeping it off 100):

1. **"See what I'm up to"** link under the Right Now feed — `foam-light` (#56949f) on the cream background = **3.13:1** (needs 4.5).
2. **"Talk about a retainer"** button in the "Work with me" cards — dark text on the pine accent (#31748f) = **3.38:1**.

## What changed

- **Feed link:** swap the light-mode colour from `foam-light` to `pine-light` (#286983) → **5.6:1**. Dark mode keeps `foam`.
- **Card buttons:** the buttons hard-coded dark text, which is correct on the iris/rose pastel accents but fails on the darker pine. Pine is a worst-case mid-tone where dark text (3.4:1) *and* the lavender light text (3.9:1) both fail — only near-white clears 4.5. So `ac()` now sets the button foreground per accent: dark text on the pastels, `base-50` near-white on pine → **4.8:1**. Iris/rose are visually unchanged.

## Notes

- Independent of PRs #265 and #268 (different regions of `index.astro`; no conflicts).
- Local build can't validate here (Node 26 vite bug + private `@singi-labs/sifa-sdk` not installed locally), so confirm on the Netlify preview: re-run the Lighthouse Accessibility audit and check both elements clear contrast, and eyeball that the pine retainer button now reads with light text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)