### PR TITLE
fix(home): request Right Now feed partial at its trailing-slash URL

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -141,7 +141,7 @@ const ArrowRight = "→";
         </div>
 
         <div>
-          <div id="activity-mount" data-activity-endpoint="/api/activity-feed">
+          <div id="activity-mount" data-activity-endpoint="/api/activity-feed/">
             <ActivityFeed items={activity} />
           </div>
           <a


### PR DESCRIPTION
## Summary

The homepage hydration script fetched the live "Right Now" feed partial from
`/api/activity-feed` (no trailing slash). With `trailingSlash: 'always'` in
astro.config.mjs, Astro only serves the slash-terminated canonical
`/api/activity-feed/` and returns its 404 page for the slashless form.

Netlify's `force = false` trailing-slash redirect does not save it: the Astro
SSR `/*` function claims the path, so Netlify skips the 301 and hands Astro the
non-canonical URL, which 404s. Result: client-side feed refresh never ran, and
every homepage load logged a console 404.

Fix: point the mount at `/api/activity-feed/`, the URL Astro actually serves.

```diff
- <div id="activity-mount" data-activity-endpoint="/api/activity-feed">
+ <div id="activity-mount" data-activity-endpoint="/api/activity-feed/">
```

## Evidence

A Lighthouse run on the latest deploy flagged the 404:

- `errors-in-console`: `Failed to load resource: 404` at `/api/activity-feed`
- `network-requests`: that request ran ~1.4s (the SSR function executed
  `getActivity()`) but resolved to status 404 and Astro's full 404 page body.
- Best Practices scored 0.92 solely because of this console error.

The static feed already renders from build-time `getActivity()`, so the page
was never broken. This restores the live post-paint refresh and clears the
console error.

## Why it is safe

The hydration script already fails safe:

```js
.then((res) => (res.ok ? res.text() : null))
.then((html) => { if (html && html.trim()) mount.innerHTML = html; })
```

If the endpoint returns anything non-OK, it keeps the statically rendered feed.
So the worst case is no change from today; the expected case is the 404 clears
and the feed hydrates.

## Test plan

- [ ] Tests/build are verified on the Netlify deploy, not locally (Node 26 +
      private SDK constraints documented in the project notes).
- [ ] After deploy: confirm `/api/activity-feed/` returns 200 with the feed
      fragment, the homepage console is clean, and the feed hydrates post-paint.

Follows #268 (static homepage + client-hydrated feed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)