### PR TITLE
fix: /now recently-read shows 14 books, not 12

### DIFF
--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -168,7 +168,10 @@ const mapBook = (e: Enriched, i: number): Book => ({
 });
 
 const RECENT_CAP = 14; // ~2 rows of the cover grid
-const FINISHED_CANDIDATES = 36; // bound catalog lookups while still yielding 14 NF
+// Enrich enough of the newest finished books to reliably yield RECENT_CAP
+// non-fiction (the recent shelf skews fairly fiction-heavy), while still
+// bounding the catalog lookups. ~50 newest finished currently yields ~24 NF.
+const FINISHED_CANDIDATES = 50;
 
 export async function getReading(): Promise<ReadingData> {
   try {


### PR DESCRIPTION
The shelf cap was already 14, but the non-fiction filter only looked at the newest 36 finished books — and those happened to contain just 12 non-fiction (the rest fiction). Widened the candidate window to 50 (currently ~24 non-fiction), so the shelf fills its 14. Catalog lookups stay bounded. Verified in dev: 14 covers.