### PR TITLE
content: rewrite the /now focus statement

### DIFF
--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -52,9 +52,8 @@ const focusUpdated = "20 June 2026";
         class="now-focus text-base-700 dark:text-base-300 max-w-2xl text-lg leading-relaxed"
       >
         <p>
-          I&rsquo;m heads-down building on AT Protocol, trying to make the open
-          social web feel less like a science project and more like somewhere
-          you&rsquo;d actually want to hang out.
+          Right now I&rsquo;m all in on building Sifa ID, and figuring out how
+          much of the open social web you can actually run on AT Protocol.
         </p>
         <p class="mt-4">A few things have my attention:</p>
         <ul class="mt-3 flex flex-col gap-2.5">
@@ -63,53 +62,62 @@ const focusUpdated = "20 June 2026";
               class="text-foam-light dark:text-foam no-random-underline font-semibold underline underline-offset-2"
               href="https://sifa.id/p/gui.do"
               target="_blank"
-              rel="noopener noreferrer">Sifa</a
-            >: identity and activity for the Atmosphere. It&rsquo;s what powers
-            the live feed further down this page.
+              rel="noopener noreferrer">Sifa ID</a
+            >: identity and activity for the Atmosphere. It&rsquo;s where most
+            of my energy goes, and what powers the live feed further down this
+            page.
           </li>
           <li>
+            <strong class="text-base-900 dark:text-base-100"
+              >Atproto-fying my own website</strong
+            > (you&rsquo;re looking at it): what does a personal site look like when
+            it reads straight from your own atproto data? Even the book covers below
+            are pulled live. The same itch is behind
             <a
               class="text-foam-light dark:text-foam no-random-underline font-semibold underline underline-offset-2"
               href="https://barazo.forum"
               target="_blank"
               rel="noopener noreferrer">Barazo</a
-            >: community forums where the members own their data, not the
-            platform.
-          </li>
-          <li>
+            > (community forums) and
             <a
               class="text-foam-light dark:text-foam no-random-underline font-semibold underline underline-offset-2"
               href="https://singi.dev"
               target="_blank"
               rel="noopener noreferrer">Singi Labs</a
-            >: the little studio those two live under.
+            > (the studio it all lives under).
           </li>
           <li>
-            <strong class="text-base-900 dark:text-base-100">This site</strong>:
-            my testbed for one question: what does a personal site look like
-            when it reads straight from your own atproto data? (Even the book
-            covers below are pulled live.)
+            <strong class="text-base-900 dark:text-base-100"
+              >My next role.</strong
+            >
+            I&rsquo;m open to work: community, DevRel, ecosystem, product, the kind
+            of thing I&rsquo;ve spent 20+ years on. If you&rsquo;re hiring or know
+            someone, my
+            <a
+              class="text-foam-light dark:text-foam no-random-underline font-semibold underline underline-offset-2"
+              href="/cv/">CV is here</a
+            >.
+          </li>
+          <li>
+            <strong class="text-base-900 dark:text-base-100">Family.</strong> The
+            good kind of chaos.
           </li>
         </ul>
         <p class="mt-4">
-          The idea underneath all of it: own what you create, ingest the rest.
-          My writing and the products sit on infrastructure I control; the
-          social stuff gets pulled in.
-        </p>
-        <p class="mt-4">
-          Twenty-plus years into community building and I&rsquo;m still
-          convinced it&rsquo;s the most underrated lever in tech. Right now
-          I&rsquo;m spending it on open protocols.
-        </p>
-        <p class="mt-4">
-          <strong class="text-base-900 dark:text-base-100">Where:</strong> the Netherlands
-          🇪🇺, surrounded by a few too many self-hosted boxes.
+          The thread through all of it: own what you create, ingest the rest. My
+          writing and the products live on infrastructure I control; the social
+          stuff gets pulled in.
         </p>
         <p class="mt-4">
           <strong class="text-base-900 dark:text-base-100"
             >What I&rsquo;m not doing:</strong
-          > jumping on every shiny new protocol, and staying off anything that won&rsquo;t
-          let me take my data with me.
+          > exercising on purpose 😅. It happens by accident at best, and yeah, I
+          know that&rsquo;s not great. Also spending more than someone between jobs
+          probably should.
+        </p>
+        <p class="mt-4">
+          <strong class="text-base-900 dark:text-base-100">Where:</strong> the Netherlands
+          🇪🇺.
         </p>
       </div>
 


### PR DESCRIPTION
Replaces the first-pass focus copy with Guido's actual current focus: all in on Sifa ID, atproto-fying this site (the /now page itself as the example), the job search (open to work, links to /cv), and family. Keeps the own-what-you-create-ingest-the-rest principle and an honest 'what I'm not doing'. Drops the invented lines (self-hosted boxes, etc.).

Verified light + dark; links: sifa.id, barazo.forum, singi.dev, /cv/.