### PR TITLE
content: reframe the /now 'thread' line (it's all my own data)

### DIFF
--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -106,9 +106,9 @@ const focusUpdated = "20 June 2026";
         <p class="mt-4">
           The thread through all of it: it&rsquo;s all my own stuff, just spread
           across places I control. The writing and the products live on my own
-          infrastructure; the posts, reviews, books and code come from my atproto
-          account. Nothing here is borrowed from anyone else. This page just
-          pulls it together.
+          infrastructure; the posts, reviews, books and code come from my
+          atproto account. Nothing here is borrowed from anyone else. This page
+          just pulls it together.
         </p>
         <p class="mt-4">
           <strong class="text-base-900 dark:text-base-100"

--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -104,9 +104,11 @@ const focusUpdated = "20 June 2026";
           </li>
         </ul>
         <p class="mt-4">
-          The thread through all of it: own what you create, ingest the rest. My
-          writing and the products live on infrastructure I control; the social
-          stuff gets pulled in.
+          The thread through all of it: it&rsquo;s all my own stuff, just spread
+          across places I control. The writing and the products live on my own
+          infrastructure; the posts, reviews, books and code come from my atproto
+          account. Nothing here is borrowed from anyone else. This page just
+          pulls it together.
         </p>
         <p class="mt-4">
           <strong class="text-base-900 dark:text-base-100"


### PR DESCRIPTION
The 'own what you create, ingest the rest' line read as if the activity is pulled in from other people. It isn't — the posts, reviews, books and code are all Guido's own, just living on his atproto account. Reframed to 'it's all my own stuff, just spread across places I control … nothing here is borrowed.'