### PR TITLE
content(now): add Big Tech independence focus item, refresh closers

### DIFF
--- a/src/pages/now.astro
+++ b/src/pages/now.astro
@@ -26,7 +26,7 @@ const reading = await getReading();
 
 // Hand-written focus statement (the actual "/now" bit). Bump this date whenever
 // you edit the copy below.
-const focusUpdated = "20 June 2026";
+const focusUpdated = "21 June 2026";
 ---
 
 <BaseLayout
@@ -90,6 +90,17 @@ const focusUpdated = "20 June 2026";
           </li>
           <li>
             <strong class="text-base-900 dark:text-base-100"
+              >Getting off Big Tech.</strong
+            > Swapping proprietary services for open source and self-hosted ones,
+            one at a time. It&rsquo;s slow and probably never finished, but
+            <a
+              class="text-foam-light dark:text-foam no-random-underline font-semibold underline underline-offset-2"
+              href="/post/how-i-reduced-my-bigtech-dependencies-in-2025/"
+              >here&rsquo;s how far I got in 2025</a
+            >.
+          </li>
+          <li>
+            <strong class="text-base-900 dark:text-base-100"
               >My next role.</strong
             >
             I&rsquo;m open to work: community, DevRel, ecosystem, product, the kind
@@ -106,18 +117,11 @@ const focusUpdated = "20 June 2026";
           </li>
         </ul>
         <p class="mt-4">
-          The thread through all of it: it&rsquo;s all my own stuff, just spread
-          across places I control. The writing and the products live on my own
-          infrastructure; the posts, reviews, books and code come from my
-          atproto account. Nothing here is borrowed from anyone else. This page
-          just pulls it together.
-        </p>
-        <p class="mt-4">
           <strong class="text-base-900 dark:text-base-100"
             >What I&rsquo;m not doing:</strong
           > exercising on purpose 😅. It happens by accident at best, and yeah, I
-          know that&rsquo;s not great. Also spending more than someone between jobs
-          probably should.
+          know that&rsquo;s not great. Time to dust off that smart bike trainer parked
+          next to my desk.
         </p>
         <p class="mt-4">
           <strong class="text-base-900 dark:text-base-100">Where:</strong> the Netherlands


### PR DESCRIPTION
Copy edits to the /now focus statement:

- New **"Getting off Big Tech"** bullet — open source + self-hosting as an ongoing effort, linking to [how-i-reduced-my-bigtech-dependencies-in-2025](/post/how-i-reduced-my-bigtech-dependencies-in-2025/).
- Removed the redundant wrap-up paragraph ("The thread through all of it…").
- Replaced the spending aside in "What I'm not doing" with a nudge about the smart bike trainer next to the desk.
- Bumped the "Updated" date.

Verified locally: renders correctly, the linked post resolves (200).