### PR TITLE
fix(social): correct Signal link and unify social order across footer and contact

### DIFF
--- a/src/data/socialLinks.ts
+++ b/src/data/socialLinks.ts
@@ -24,8 +24,19 @@ export interface SocialLink {
 export const socialLinks: SocialLink[] = [
   {
     name: "Signal",
-    href: "https://signal.me/#eu/-unUEm2N_tIpI5lcvxWOfJ2NeMRZ2KJ_etky02xAzQiKdoxJ4P9Nxqgl05zJBEMd",
+    href: "https://signal.me/#eu/Lr-tiA5w5oQBnfHkPvjGDdy3JeWbjeWgORleaaX5-PdIlTGL8uFFjpYLP5cauaCT",
     icon: "signal",
+    visibility: {
+      footer: true,
+      hero: true,
+      about: true,
+      contact: true,
+    },
+  },
+  {
+    name: "BlueSky",
+    href: "https://bsky.app/profile/gui.do",
+    icon: "bluesky",
     visibility: {
       footer: true,
       hero: true,
@@ -56,17 +67,6 @@ export const socialLinks: SocialLink[] = [
     },
   },
   {
-    name: "YouTube",
-    href: "https://www.youtube.com/@gxjansen",
-    icon: "tabler/filled/brand-youtube",
-    visibility: {
-      footer: true,
-      hero: true,
-      about: true,
-      contact: false,
-    },
-  },
-  {
     name: "GitHub",
     href: "https://github.com/gxjansen",
     icon: "tabler/filled/brand-github",
@@ -78,14 +78,14 @@ export const socialLinks: SocialLink[] = [
     },
   },
   {
-    name: "BlueSky",
-    href: "https://bsky.app/profile/gui.do",
-    icon: "bluesky",
+    name: "YouTube",
+    href: "https://www.youtube.com/@gxjansen",
+    icon: "tabler/filled/brand-youtube",
     visibility: {
       footer: true,
       hero: true,
       about: true,
-      contact: true,
+      contact: false,
     },
   },
   {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,12 +7,14 @@ const CAL = "https://app.cal.eu/gxjansen/30min";
 
 // Inline social row for the contact page only — explicit order and set,
 // independent of the shared <SocialCards> component used elsewhere.
-// Order: Bluesky, Sifa, Signal, LinkedIn (GitHub intentionally dropped).
+// Order: Signal, Bluesky, Sifa, LinkedIn (GitHub intentionally dropped —
+// footer-only). Matches the footer's social order.
 const byIcon = (icon: string) => socialLinks.find((s) => s.icon === icon);
 
 // Missing platforms (no resolvable href) simply don't render — no dead "#"
 // links. Bluesky and Sifa carry hardcoded hrefs, so they always survive.
 const socials = [
+  { icon: "signal", name: "Signal", href: byIcon("signal")?.href },
   {
     icon: "bluesky",
     name: "Bluesky",
@@ -23,7 +25,6 @@ const socials = [
     name: "Sifa ID",
     href: byIcon("sifa")?.href ?? "https://sifa.id/p/gui.do",
   },
-  { icon: "signal", name: "Signal", href: byIcon("signal")?.href },
   {
     icon: "linkedin",
     name: "LinkedIn",


### PR DESCRIPTION
## What

1. **Fixes the broken Signal link.** The old `signal.me` handle (`#eu/-unUEm2N…`) was replaced with the correct one (`#eu/Lr-tiA5w…`). This URL lives once in `src/data/socialLinks.ts` and feeds both the footer and the contact page body.

2. **Unifies the social link order** so the footer and the `/contact/` selection match:
   - **Footer:** Signal → Bluesky → Sifa ID → LinkedIn → GitHub → YouTube → RSS
   - **Contact:** Signal → Bluesky → Sifa ID → LinkedIn
   - GitHub, YouTube and RSS remain footer-only.

## How

- Reordered the `socialLinks` array in `src/data/socialLinks.ts` (footer renders this array filtered by `visibility.footer`, in array order). Instagram stays hidden at the end.
- Reordered the hard-coded `socials` array in `src/pages/contact.astro` and updated its ordering comment.

## Testing

- `vitest run src/data/__tests__/validateUrls.test.ts` — 5/5 pass, including `socialLinks` URL validation.
- `prettier --check` clean on both files.