### PR TITLE
chore: replace astro-auto-import with explicit MDX imports (Astro 7 prep)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,6 @@
 import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
 import mdx from "@astrojs/mdx";
-import AutoImport from "astro-auto-import";
 import icon from "astro-icon";
 import react from "@astrojs/react";
 import netlify from "@astrojs/netlify";
@@ -83,17 +82,6 @@ export default defineConfig({
     }
   },
   integrations: [
-    AutoImport({
-      imports: [
-        "@components/Admonition/Admonition.astro",
-        "@components/Throbber/Throbber.astro",
-        "@components/GameUI/GameUI.astro",
-        "@components/Regenerating/Regenerating.astro",
-        "@components/ManaBar/ManaBar.astro",
-        "@components/Compacting/Compacting.astro",
-        "@components/Compacting/CompactingV2.astro"
-      ]
-    }),
     mdx({
       // Configure MDX to be more lenient
       extendMarkdownConfig: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "altcha-lib": "^1.4.1",
         "animejs": "^4.4.1",
         "astro": "^6.4.8",
-        "astro-auto-import": "^0.5.1",
         "astro-embed": "^0.13.0",
         "astro-icon": "^1.1.5",
         "autoprefixer": "^10.4.27",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "altcha-lib": "^1.4.1",
     "animejs": "^4.4.1",
     "astro": "^6.4.8",
-    "astro-auto-import": "^0.5.1",
     "astro-embed": "^0.13.0",
     "astro-icon": "^1.1.5",
     "autoprefixer": "^10.4.27",

--- a/src/content/otherPages/elements/index.mdx
+++ b/src/content/otherPages/elements/index.mdx
@@ -4,6 +4,8 @@ description: Comprehensive reference guide for all MDX elements and components u
 draft: true
 ---
 
+import Admonition from "@components/Admonition/Admonition.astro";
+
 #### Heading example
 
 Here is an example of headings. You can use this heading by the following markdown rules. For example: use `#` for heading 1 and use `######` for heading 6.

--- a/src/content/post/better-not-waste-it/index.mdx
+++ b/src/content/post/better-not-waste-it/index.mdx
@@ -12,6 +12,13 @@ categories:
 blueskyUri: "at://did:plc:45uheisi25szrjvjurfpritx/app.bsky.feed.post/3mdzhdppmrk2u"
 ---
 
+import Admonition from "@components/Admonition/Admonition.astro";
+import Throbber from "@components/Throbber/Throbber.astro";
+import GameUI from "@components/GameUI/GameUI.astro";
+import Regenerating from "@components/Regenerating/Regenerating.astro";
+import ManaBar from "@components/ManaBar/ManaBar.astro";
+import CompactingV2 from "@components/Compacting/CompactingV2.astro";
+
 <GameUI />
 
 ---


### PR DESCRIPTION
First step of preparing for the Astro 7 upgrade, landed independently so it ships safely on the current Astro 6.4.8 site.

## Why
`astro-auto-import` has no Astro 7 release, and under Astro 7 + MDX 7 its auto-injection breaks at build time (`Error: Expected component GameUI to be defined`). It's one of three third-party integrations blocking the upgrade.

## What
- Removed the `AutoImport({...})` integration from `astro.config.mjs` and the direct `astro-auto-import` dependency.
- Added explicit imports to the only two MDX files that used the auto-injected components:
  - `post/better-not-waste-it/index.mdx` — Admonition, Throbber, GameUI, Regenerating, ManaBar, CompactingV2
  - `otherPages/elements/index.mdx` — Admonition
- The package stays in the tree transitively via `astro-embed` (its own internal use); only our direct dependency and integration usage are removed.

## Behaviour
No change on the current site. Explicit MDX imports resolve identically on Astro 6 and 7, so this just shrinks the Astro 7 migration surface.

## Verification
- `npm run build` (Astro 6.4.8) — exit 0, `better-not-waste-it` renders all components in the output HTML.
- `npm run typecheck` (astro check) — 0 errors, 0 warnings.

## Remaining Astro 7 blockers (separate work, deferred until the ecosystem catches up)
- Tailwind v4 PostCSS → `@tailwindcss/vite` plus `@reference` directives in ~18 scoped-style components (visual QA needed).
- `astro-embed` / `astro-icon` lack official Astro 7 support.
- Markdown remark/rehype plugins need migrating to the new unified processor under Sätteri.