### PR TITLE
fix(social): scope scrollbars to footer so author/hero/contact icons don't scroll

### DIFF
--- a/src/components/SocialLinks/SocialLinks.astro
+++ b/src/components/SocialLinks/SocialLinks.astro
@@ -36,8 +36,15 @@ const navLabel = labelMap[location] ?? "Social media links";
 <nav class:list={["relative", className]} aria-label={navLabel}>
   <ul
     class:list={[
-      "pointer-events-auto flex items-center gap-2 overflow-x-auto whitespace-nowrap sm:gap-3 md:gap-4 [&::-webkit-scrollbar]:hidden",
-      context === "footer" ? "pr-6" : "px-4 sm:px-0",
+      "pointer-events-auto flex items-center gap-2 sm:gap-3 md:gap-4",
+      // Only the footer is a cramped, single-line scroll container. Setting
+      // overflow-x to auto makes the browser compute overflow-y to auto too,
+      // so the tooltip (rendered below the icon) and the webkit-only scrollbar
+      // hider would otherwise produce stray scrollbars in Firefox elsewhere.
+      // Non-footer placements have room, so let icons wrap instead.
+      context === "footer"
+        ? "overflow-x-auto pr-6 whitespace-nowrap [&::-webkit-scrollbar]:hidden"
+        : "flex-wrap px-4 sm:px-0",
     ]}
     role="list"
   >


### PR DESCRIPTION
## Summary

The "About the Author" box on post pages rendered its Sifa/Bluesky icons inside what looked like a tiny scrollable iframe, with both horizontal and vertical scrollbars in Firefox.

Root cause is in the shared `SocialLinks.astro`: the icon `<ul>` always got `overflow-x-auto whitespace-nowrap [&::-webkit-scrollbar]:hidden`.

- The scrollbar hider is webkit-only, so Firefox ignored it and showed the **horizontal** bar.
- Setting `overflow-x: auto` while `overflow-y` stays `visible` makes CSS compute `overflow-y` to `auto` too. The hover tooltip is positioned below each icon (`top-full`), overflows downward, and triggered the **vertical** bar as well.

The scroll container only makes sense for the cramped footer. This scopes that behavior to `context === "footer"`; every other placement now wraps (`flex-wrap`) with no overflow.

**Same component, same bug in 4 places — all fixed by this one change:**
- Post pages — About the Author (`AuthorBioBox.astro`)
- Homepage hero (`HeroSideImage.astro`)
- Contact page (`contact.astro`)
- Author profile pages (`authors/[slug].astro`)

Footer keeps its single-line scroll container by design.

## Test Coverage

Template CSS-class change only — no new application code paths to audit.

## Pre-Landing Review

No issues. No SQL/LLM/auth surface. Tooltips (absolute + group-hover) and footer scroll behavior unaffected.

## Test plan
- [x] Vitest: 110 tests pass (19 files)
- [x] `astro check`: 0 errors
- [x] `astro build`: passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)