### PR TITLE
chore(deps): bump 5 in-range minor/patch dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,12 @@
         "@astrojs/react": "^5.0.7",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.3",
-        "@atproto/api": "^0.20.16",
+        "@atproto/api": "^0.20.18",
         "@iconify-json/tabler": "^1.2.35",
         "@netlify/blobs": "^10.7.9",
         "@resvg/resvg-js": "^2.6.2",
-        "@singi-labs/sifa-sdk": "^0.11.1",
+        "@rollup/rollup-linux-x64-gnu": "^4.62.2",
+        "@singi-labs/sifa-sdk": "^0.11.6",
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/postcss": "^4.3.1",
         "@tailwindcss/typography": "^0.5.20",
@@ -28,7 +29,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "altcha-lib": "^1.4.1",
-        "animejs": "^4.4.1",
+        "animejs": "^4.5.0",
         "astro": "^6.4.8",
         "astro-embed": "^0.13.0",
         "astro-icon": "^1.1.5",
@@ -36,7 +37,7 @@
         "csv-parse": "^6.1.0",
         "csv-stringify": "^6.8.0",
         "date-fns": "^4.4.0",
-        "fast-xml-parser": "^5.9.2",
+        "fast-xml-parser": "^5.9.3",
         "gray-matter": "^4.0.3",
         "marked": "^17.0.3",
         "node-html-parser": "^7.0.2",
@@ -68,7 +69,7 @@
         "vitest": "^4.1.9"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "^4.62.2",
         "lightningcss-linux-x64-gnu": "^1.30.1"
       }
     },
@@ -604,9 +605,9 @@
       }
     },
     "node_modules/@atproto/api": {
-      "version": "0.20.16",
-      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.20.16.tgz",
-      "integrity": "sha512-hKgBgZS9K+ia6AMKo26q75EiDRqvSabpo0SmpeuYRHVGTV+7y35lJVgHtuwGhVXNphyQ0Q9TIg8A5YnRVARXNw==",
+      "version": "0.20.18",
+      "resolved": "https://registry.npmjs.org/@atproto/api/-/api-0.20.18.tgz",
+      "integrity": "sha512-JaU5uCvfusHD88uBFBtYpdKIhSo7AWx2NscRAPHdDJP6pLKhzPAJ4sVPOunrXahr0/f37QmPlFToajqV5XpPTw==",
       "license": "MIT",
       "dependencies": {
         "@atproto/common-web": "^0.5.1",
@@ -5159,9 +5160,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
-      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
       "cpu": [
         "x64"
       ],
@@ -5382,9 +5383,9 @@
       }
     },
     "node_modules/@singi-labs/sifa-sdk": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@singi-labs/sifa-sdk/-/sifa-sdk-0.11.1.tgz",
-      "integrity": "sha512-2p5kQ0x12H4IGbxuHSL7vJfVlw6oChEnU//2jkSoveypnvNUWuWqR6lajed+VdNI9huThS3NEmVRl2aYSMkZAQ==",
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/@singi-labs/sifa-sdk/-/sifa-sdk-0.11.6.tgz",
+      "integrity": "sha512-5V4uiRFf3DJNCO+Lgk986SIA+jVVNUGexOh/9yoq2ryCq6o4pVthX9Zjy+irE0WZFje3FCWDVGdIjdGLPi5vrA==",
       "license": "MIT",
       "dependencies": {
         "zod": "4.4.3"
@@ -6749,13 +6750,25 @@
       "license": "MIT"
     },
     "node_modules/animejs": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.4.1.tgz",
-      "integrity": "sha512-XimhJw4vPb6tAd6Zaoa6BaspJ8UteQMKvL7Pvrt6MW/6u2UvJs0TB/LLqR1sigaiYvpVPC3Tokr9emcCMhWFhw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-4.5.0.tgz",
+      "integrity": "sha512-NQimYX+lz8WaXonGS9zVVoviCIAjONeJayxacUditaivYLqyXgGjFKjuyl0aUUhFKm5MriX9ty1TGovNzoJQWA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/juliangarnier"
+      },
+      "peerDependencies": {
+        "@types/three": ">=0.150.0",
+        "three": ">=0.150.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/three": {
+          "optional": true
+        },
+        "three": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -9872,9 +9885,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.2.tgz",
-      "integrity": "sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
       "funding": [
         {
           "type": "github",
@@ -9887,7 +9900,7 @@
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^1.0.1",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.4.0",
+        "strnum": "^2.4.1",
         "xml-naming": "^0.1.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "@astrojs/react": "^5.0.7",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",
-    "@atproto/api": "^0.20.16",
+    "@atproto/api": "^0.20.18",
     "@iconify-json/tabler": "^1.2.35",
     "@netlify/blobs": "^10.7.9",
     "@resvg/resvg-js": "^2.6.2",
-    "@singi-labs/sifa-sdk": "^0.11.1",
+    "@singi-labs/sifa-sdk": "^0.11.6",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/postcss": "^4.3.1",
     "@tailwindcss/typography": "^0.5.20",
@@ -48,7 +48,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "altcha-lib": "^1.4.1",
-    "animejs": "^4.4.1",
+    "animejs": "^4.5.0",
     "astro": "^6.4.8",
     "astro-embed": "^0.13.0",
     "astro-icon": "^1.1.5",
@@ -56,7 +56,7 @@
     "csv-parse": "^6.1.0",
     "csv-stringify": "^6.8.0",
     "date-fns": "^4.4.0",
-    "fast-xml-parser": "^5.9.2",
+    "fast-xml-parser": "^5.9.3",
     "gray-matter": "^4.0.3",
     "marked": "^17.0.3",
     "node-html-parser": "^7.0.2",
@@ -88,7 +88,7 @@
     "vitest": "^4.1.9"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.62.0",
+    "@rollup/rollup-linux-x64-gnu": "^4.62.2",
     "lightningcss-linux-x64-gnu": "^1.30.1"
   },
   "overrides": {


### PR DESCRIPTION
Item #3 from the 2026-06-22 tech-debt scan — refresh the top-level deps sitting behind their caret ranges. Surgical (only the 5 packages + minimal lockfile churn), not a full `npm update` (which churned the whole transitive tree).

## Bumps (all same-major)
| Package | From | To |
|---|---|---|
| `@atproto/api` | 0.20.16 | 0.20.18 |
| `@singi-labs/sifa-sdk` | 0.11.1 | 0.11.6 |
| `animejs` | 4.4.1 | 4.5.0 |
| `fast-xml-parser` | 5.9.2 | 5.9.3 |
| `@rollup/rollup-linux-x64-gnu` (optional) | 4.62.0 | 4.62.2 |

## Intentionally deferred
Astro 7 (tracked separately) and other majors — `typescript` 6, `svgo` 4, `jsdom` 29, `csv-parse` 7, `marked` 18, `node-html-parser` 8, `altcha-lib` 2 — are left for deliberate upgrades.

## Verification
- `astro check` — 0 errors, 0 warnings
- `npm run build` — exit 0, `Complete!`
- Lockfile churn: +34 / −21 lines (vs ~2,900 for a blanket update).