### PR TITLE
content(series): publish Ep1 on Jun 24 + landing-page polish

### DIFF
--- a/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
+++ b/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "You don't own your network"
 description: "Three communities, three platforms, three rounds of starting over. The platforms come and go; the architecture is why. Part of 'Apps as Views, Not Vaults': your data is the bookshelf, apps are the views, you own it."
-pubDate: 2026-06-16T08:00:00+02:00
+pubDate: 2026-06-24T08:00:00+02:00
 heroImage: ./heroImage.jpg
 heroImageAlt: "Apps as Views, Not Vaults series card, part 01 (Ownership): 'Who actually owns your network?'"
 ogImage: hero

--- a/src/pages/series/atproto.astro
+++ b/src/pages/series/atproto.astro
@@ -163,7 +163,7 @@ const pageDescription =
   description={pageDescription}
 >
   <div class="home">
-    <div id="top" class="mx-auto w-full max-w-[860px]">
+    <div id="top" class="mx-auto w-full max-w-5xl">
       {/* ============ HERO ============ */}
       <section
         class="relative z-10 pt-[clamp(3.5rem,8vw,5.5rem)] pb-[clamp(1.4rem,3vw,2rem)]"
@@ -242,7 +242,6 @@ const pageDescription =
       {/* ============ EPISODE SPINE ============ */}
       <section id="series" class="mt-6 mb-4 scroll-mt-24">
         <div class="mb-6">
-          <span class="hand-note">the whole shelf</span>
           <h2
             class="font-display text-[clamp(1.7rem,3.4vw,2.4rem)] font-black tracking-[-0.03em]"
           >
@@ -443,18 +442,19 @@ const pageDescription =
               Second: I've been working on the internet for 25+ years, across
               open source communities, SaaS platforms, and social tools. After
               watching that many open protocols get swallowed by platforms, I
-              think this one has a real shot. That's not neutrality, and I'm not
-              pretending it is.
+              think this one has a real shot. So no, this isn't a neutral take
+              (claiming I'm neutral while building two products on it would be a
+              bit much).
             </p>
             <p>
               Per Taleb: writers without skin in the game produce theory;
-              writers with skin in the game produce signal. Read accordingly. If
-              you want a neutral take, you can find one. This isn't that.
+              writers with skin in the game produce signal. If you'd rather have
+              a neutral overview, there are good ones out there. This one comes
+              with a point of view, and now you know where it's pointing.
             </p>
             <p>
               Part 7 (the final episode) lists the concrete conditions by 2028
-              that would prove me wrong. Bookmark that paragraph when you get
-              there. Hold me to it.
+              that would prove me wrong.
             </p>
           </div>
         </div>

--- a/src/pages/series/atproto.astro
+++ b/src/pages/series/atproto.astro
@@ -25,7 +25,7 @@ const MANIFEST = [
     title: "You don't own your network",
     gloss:
       "If a platform vanished tomorrow, your network wouldn't survive the move. Someone chose that, and it can be unmade.",
-    plannedDate: "2026-06-16T08:00:00+02:00",
+    plannedDate: "2026-06-24T08:00:00+02:00",
   },
   {
     episode: 2,
@@ -34,7 +34,7 @@ const MANIFEST = [
     title: "Your identity isn't your username",
     gloss:
       "Change your handle, keep every follower. Why atproto splits who you are from what you're called.",
-    plannedDate: "2026-06-23T08:00:00+02:00",
+    plannedDate: "2026-06-30T08:00:00+02:00",
   },
   {
     episode: 3,
@@ -43,7 +43,7 @@ const MANIFEST = [
     title: "Where your posts actually live",
     gloss:
       "When an app shuts down, what happens to five years of your stuff? Depends who's holding it.",
-    plannedDate: "2026-06-30T08:00:00+02:00",
+    plannedDate: "2026-07-07T08:00:00+02:00",
   },
   {
     episode: 4,
@@ -52,7 +52,7 @@ const MANIFEST = [
     title: "Apps that don't need permission",
     gloss:
       "A new app can already know your network: no partnership deals, no API keys, no “log in with X” tax.",
-    plannedDate: "2026-07-07T08:00:00+02:00",
+    plannedDate: "2026-07-14T08:00:00+02:00",
   },
   {
     episode: 5,
@@ -61,7 +61,7 @@ const MANIFEST = [
     title: "You don't have to like the algorithm",
     gloss:
       "When a feed decides your reach, you don't get a vote. There's an architecture where you do.",
-    plannedDate: "2026-07-21T08:00:00+02:00",
+    plannedDate: "2026-07-28T08:00:00+02:00",
   },
   {
     episode: 6,
@@ -70,7 +70,7 @@ const MANIFEST = [
     title: "What atproto can't do (yet)",
     gloss:
       "The gaps the hype skips. Plus: your whole identity can run on a Raspberry Pi, or hosted free.",
-    plannedDate: "2026-07-28T08:00:00+02:00",
+    plannedDate: "2026-08-04T08:00:00+02:00",
   },
   {
     episode: 7,
@@ -79,7 +79,7 @@ const MANIFEST = [
     title: "Bigger than social media",
     gloss:
       "I ran Doom over the AT Protocol at five frames per second. Nobody needs that, but it proved what the protocol really is.",
-    plannedDate: "2026-08-04T08:00:00+02:00",
+    plannedDate: "2026-08-11T08:00:00+02:00",
   },
 ] as const;
 


### PR DESCRIPTION
Follow-up tweaks to the atproto series landing page (post-launch).

**Episode 1 date**
- `pubDate` → its real launch day, 2026-06-24. Article and landing card now read "Jun 24, 2026". Verified it's in the past (12:19 CEST), so Ep1 stays live and on the blog index + RSS.

**Placeholder schedule**
- Shifted "Coming" dates for episodes 2-7 forward to upcoming weekly Tuesdays (Jun 30, Jul 7, Jul 14, intermission, Jul 28, Aug 4, Aug 11) so none reads as a past date now that the 23rd has passed.

**Layout**
- Removed the "the whole shelf" hand-note kicker above "The series" (it crowded the heading).
- Widened the page (860px → `max-w-5xl`) so the newsletter `card` stops rendering as a cramped two-column box. Text blocks are `ch`-capped, so the reading measure stays comfortable.

**Disclosure copy**
- Softened the skin-in-the-game block: less edge, a bit of humour, same point. Dropped "That's not neutrality, and I'm not pretending it is", the "Read accordingly / This isn't that" lines, and "Bookmark that paragraph when you get there. Hold me to it." Ran it through the voice humanizer.

Verified: build clean, landing shows 1 released + 6 scheduled, "Part 1 of 7 published", no past Coming dates.