### PR TITLE
fix(series): newsletter copy + move diagram below timeline

### DIFF
--- a/src/components/Newsletter/NewsletterForm.astro
+++ b/src/components/Newsletter/NewsletterForm.astro
@@ -29,6 +29,8 @@ interface Props {
   title?: string;
   /** Form description (used in card/cta variants) */
   description?: string;
+  /** Hand-lettered cadence accent under the title (card variant). Pass "" to hide. */
+  cadence?: string;
   /** Optional note below form (e.g., frequency, unsubscribe info) */
   note?: string;
   /** Listmonk list ID (integer) */
@@ -53,6 +55,7 @@ const {
   variant = "card",
   title = "Stay in the loop",
   description = "Curated insights on community, experimentation, AI & open tech. No spam, no tracking pixels, unsubscribe anytime.",
+  cadence = "a few times a year",
   note = "You'll receive a confirmation email. No spam, unsubscribe anytime.",
   listId = 3, // Guido's Golden Nuggets
   actionUrl = "/.netlify/functions/newsletter-subscribe",
@@ -101,9 +104,11 @@ const signupPage = Astro.url.pathname;
             />
           )}
 
-          <p class="text-gold-light dark:text-gold font-hand inline-block origin-left -rotate-2 text-[1.5rem] leading-none">
-            a few times a year
-          </p>
+          {cadence && (
+            <p class="text-gold-light dark:text-gold font-hand inline-block origin-left -rotate-2 text-[1.5rem] leading-none">
+              {cadence}
+            </p>
+          )}
 
           {showSubscriberCount && (
             <p

--- a/src/pages/series/atproto.astro
+++ b/src/pages/series/atproto.astro
@@ -241,18 +241,6 @@ const pageDescription =
         </div>
       </section>
 
-      {/* ============ SERIES DIAGRAM ============ */}
-      <figure class="mt-2 mb-9">
-        <Image
-          src={appsAsViews}
-          alt="The apps-as-views model: one personal data cabinet with labelled compartments (posts, photos, films, a professional profile, a code repo, events, and a private one), read by many atproto apps as different views. Your cabinet, your data, one per person; swap the app, the cabinet stays."
-          widths={[640, 960, 1280, 2400]}
-          sizes="(min-width: 1024px) 1024px, 100vw"
-          class="border-base-200 dark:border-base-800 w-full rounded-2xl border"
-          loading="lazy"
-        />
-      </figure>
-
       {/* ============ EPISODE SPINE ============ */}
       <section id="series" class="mt-6 mb-4 scroll-mt-24">
         <div class="mb-6">
@@ -423,11 +411,24 @@ const pageDescription =
         </ol>
       </section>
 
+      {/* ============ SERIES DIAGRAM ============ */}
+      <figure class="mt-2 mb-9">
+        <Image
+          src={appsAsViews}
+          alt="The apps-as-views model: one personal data cabinet with labelled compartments (posts, photos, films, a professional profile, a code repo, events, and a private one), read by many atproto apps as different views. Your cabinet, your data, one per person; swap the app, the cabinet stays."
+          widths={[640, 960, 1280, 2400]}
+          sizes="(min-width: 1024px) 1024px, 100vw"
+          class="border-base-200 dark:border-base-800 w-full rounded-2xl border"
+          loading="lazy"
+        />
+      </figure>
+
       {/* ============ NEWSLETTER ============ */}
       <section id="subscribe" class="my-8 scroll-mt-24" aria-label="Newsletter">
         <NewsletterForm
           variant="card"
-          title="Get each episode in your inbox <span class='text-golden'>weekly, for 7 weeks</span>"
+          title="Get each episode in your inbox"
+          cadence="weekly, for 7 weeks"
           description="I'll send each part the morning it goes live, no checking back. After the series it settles into a periodic newsletter. If this resonates, you'll probably like the rest."
           note="No spam, no tracking, unsubscribe in one click."
         />


### PR DESCRIPTION
Two landing-page fixes.

**Newsletter copy made coherent.** The card variant hard-codes a "a few times a year" cadence line under the title, so the series block read "...weekly, for 7 weeks **a few times a year**". Promoted that line to a `cadence` prop on NewsletterForm (default unchanged, every other page identical) and set the series title to "Get each episode in your inbox" with the cadence accent carrying "weekly, for 7 weeks".

**Diagram moved** from above the spine to below it, just above the newsletter.

Verified: build clean, series shows no "a few times a year" / has "weekly, for 7 weeks", diagram now ordered after the last episode and before #subscribe, /post/ index newsletter unchanged.