### PR TITLE
feat(series): per-episode orientation banner

### DIFF
--- a/src/components/SeriesBanner.astro
+++ b/src/components/SeriesBanner.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * Slim "part of a series" orientation banner, dropped near the top of each
+ * atproto-series episode so a cold reader knows it's part of a set and can jump
+ * to the hub. All series wording lives here so it's defined in one place; the
+ * episode only passes its number.
+ */
+interface Props {
+  /** Which episode this is (1-based). */
+  part: number;
+}
+
+const { part } = Astro.props as Props;
+
+const total = 7;
+const seriesTitle = "Apps as Views, Not Vaults";
+const seriesHref = "/series/atproto/";
+---
+
+<aside
+  aria-label="Part of a series"
+  class="not-prose border-base-200 dark:border-base-800 bg-base-50 dark:bg-base-900 my-6 flex flex-col gap-x-3 gap-y-1 rounded-xl border px-4 py-3 sm:flex-row sm:items-baseline"
+>
+  <span
+    class="font-display text-pine dark:text-foam shrink-0 text-[0.72rem] font-bold tracking-[0.08em] uppercase"
+  >
+    Part {part} of {total}
+  </span>
+  <p class="text-base-700 dark:text-base-300 m-0 text-[0.92rem] leading-snug">
+    <span class="font-display text-base-900 dark:text-base-100 font-bold"
+      >{seriesTitle}.</span
+    > A series on the AT Protocol; each part stands on its own.{" "}
+    <a
+      href={seriesHref}
+      class="text-pine dark:text-foam font-display font-bold underline-offset-2 hover:underline"
+      >See the whole shelf</a
+    >
+  </p>
+</aside>

--- a/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
+++ b/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
@@ -18,6 +18,8 @@ series:
 draft: false
 ---
 
+import SeriesBanner from "@components/SeriesBanner.astro";
+
 If your LinkedIn account vanished tomorrow, your contacts wouldn't survive the move. And it didn't have to be this way.
 
 I've moved communities and networks between platforms more times than I'd like: Slack, Facebook Groups, LinkedIn, Meetup, forums, Twitter, sometimes as the main channel, sometimes a side tool. Every move charged a tax on the way out: the people who didn't follow to the new place, the years of conversations stranded in a database neither I nor the members controlled. Realistically, half the audience never makes the jump.
@@ -25,6 +27,8 @@ I've moved communities and networks between platforms more times than I'd like: 
 It's built that way on purpose. Platforms like LinkedIn don't want you to leave, and wanting to keep people around is fair enough. But making it impossible to leave with your contacts and your content is less a happy relationship than a hostage situation.
 
 Platforms come and go. However big one looks today, there's a new hype tomorrow. What keeps costing you, and your contacts, is the lock-in architecture underneath them all.
+
+<SeriesBanner part={1} />
 
 ## The tax is built in
 


### PR DESCRIPTION
A cold reader landing on any episode doesn't know it's part of a 7-part series. This adds a slim 'Part N of 7' banner near the top that links to the hub.

- New `src/components/SeriesBanner.astro` (prop: `part`). Total (7), series title, and hub link are hardcoded in the component, so the wording lives in one place.
- `<aside aria-label="Part of a series">`, one real anchor, no nested interactive elements. DS-matched: slim callout, pine-teal link, no side-stripe border, no dark-mode shadow, `not-prose` so article prose styles don't bleed in.
- Placed in Episode 1 after the intro, before the first H2. The bottom full-series footer stays (top = orientation, bottom = CTA).

Only Episode 1 exists so far; episodes 2-7 get `<SeriesBanner part={N} />` when they're written.

One deviation: the dictated copy had an em dash ("Part N of 7 — Apps as Views..."). Kept every word but dropped the dash per the brand no-em-dash rule; the eyebrow + display-font title do the separating.