### PR TITLE
copy(series): reword series banner tagline + link

### DIFF
--- a/src/components/SeriesBanner.astro
+++ b/src/components/SeriesBanner.astro
@@ -29,11 +29,11 @@ const seriesHref = "/series/atproto/";
   <p class="text-base-700 dark:text-base-300 m-0 text-[0.92rem] leading-snug">
     <span class="font-display text-base-900 dark:text-base-100 font-bold"
       >{seriesTitle}.</span
-    > A series on the AT Protocol; each part stands on its own.{" "}
+    > Seven pieces on quitting the rent-your-life internet.{" "}
     <a
       href={seriesHref}
       class="text-pine dark:text-foam font-display font-bold underline-offset-2 hover:underline"
-      >See the whole shelf</a
+      >See the whole series</a
     >
   </p>
 </aside>


### PR DESCRIPTION
Banner copy tweak: tagline becomes "Seven pieces on quitting the rent-your-life internet." and the hub link reads "See the whole series". Lives in the one SeriesBanner component, so it updates every episode.