### PR TITLE
feat(series): "Who this is for" block on the landing page

### DIFF
--- a/src/pages/series/atproto.astro
+++ b/src/pages/series/atproto.astro
@@ -241,6 +241,26 @@ const pageDescription =
         </div>
       </section>
 
+      {/* ============ WHO THIS IS FOR ============ */}
+      <section class="mt-1 mb-3">
+        <div
+          class="border-base-200 dark:border-base-800 bg-base-50 dark:bg-base-900 rounded-2xl border p-[clamp(1.2rem,3vw,1.7rem)]"
+        >
+          <h2 class="eyebrow">Who this is for</h2>
+          <p
+            class="text-base-700 dark:text-base-300 mt-2 max-w-[66ch] text-[1rem] leading-[1.6]"
+          >
+            People who keep hearing about Bluesky and the AT Protocol and want
+            to actually get it: web and tech folks, community builders, the
+            platform-curious. It's an on-ramp, deliberately plain-spoken, not a
+            deep technical dive. If you already run your own PDS and write
+            lexicons for fun, you're not the target reader, though the
+            honest-limits and falsifier parts (Episodes 6 and 7) might still
+            earn your time.
+          </p>
+        </div>
+      </section>
+
       {/* ============ EPISODE SPINE ============ */}
       <section id="series" class="mt-6 mb-4 scroll-mt-24">
         <div class="mb-6">


### PR DESCRIPTION
Adds a short "Who this is for" callout under the hero, before the episode spine: who the series is aimed at (web/tech folks, community builders, the platform-curious) and who it isn't (PDS-runners), with a nod that Episodes 6 and 7 might still interest them. Neutral bordered surface, DS-matched.