### PR TITLE
copy(series): expand the article banner tagline

### DIFF
--- a/src/components/SeriesBanner.astro
+++ b/src/components/SeriesBanner.astro
@@ -29,7 +29,8 @@ const seriesHref = "/series/atproto/";
   <p class="text-base-700 dark:text-base-300 m-0 text-[0.92rem] leading-snug">
     <span class="font-display text-base-900 dark:text-base-100 font-bold"
       >{seriesTitle}.</span
-    > Seven pieces on quitting the rent-your-life internet.{" "}
+    > A plain-spoken series for AT Protocol-curious people; Seven pieces on quitting
+    the rent-your-life internet.{" "}
     <a
       href={seriesHref}
       class="text-pine dark:text-foam font-display font-bold underline-offset-2 hover:underline"


### PR DESCRIPTION
Banner tagline now reads: "Apps as Views, Not Vaults. A plain-spoken series for AT Protocol-curious people; Seven pieces on quitting the rent-your-life internet." One component, so it updates every episode.