### PR TITLE
content(blog): point book links to Bookhive instead of Amazon/author pages

### DIFF
--- a/src/content/post/data-driven-decisions-meets-psychology/index.mdx
+++ b/src/content/post/data-driven-decisions-meets-psychology/index.mdx
@@ -64,13 +64,13 @@ Video where I talk about our experiments with running multivariate tests with Ma
 
 **Books you should read:**
 
-- [Thinking, Fast and Slow](https://www.amazon.com/Thinking-Fast-Slow-Daniel-Kahneman/dp/0374533555) - Daniel Kahneman
+- [Thinking, Fast and Slow](https://bookhive.buzz/books/bk_lymQD4PAS4QzUhlPhMYT) - Daniel Kahneman
 
-- [Influence](https://www.amazon.com/Influence-Psychology-Persuasion-Robert-Cialdini/dp/0688128165) - Robert Cialdini
+- [Influence](https://bookhive.buzz/books/bk_cZ07xDAyoVccvZGGA3y2) - Robert Cialdini
 
-- [Predictably Irrational](https://www.amazon.com/Predictably-Irrational-Revised-Expanded-Decisions/dp/0061353248/ref=pd_sim_14_3?_encoding=UTF8&pd_rd_i=0061353248&pd_rd_r=WDV9RH10E2TE3P0D9YFR&pd_rd_w=WtZcK&pd_rd_wg=VTWnC&psc=1&refRID=WDV9RH10E2TE3P0D9YFR) - Dan Ariely
+- [Predictably Irrational](https://bookhive.buzz/books/bk_wNmQZx7MGgIn1hng1yJT) - Dan Ariely
 
-- [Nudge](https://www.amazon.com/Nudge-Improving-Decisions-Health-Happiness/dp/014311526X/) - Richard Thaler
+- [Nudge](https://bookhive.buzz/books/bk_cakv6Mrb42m9vLPLCgpZ) - Richard Thaler
 
 ## Part 2: Building an Optimization Dream Team
 
@@ -102,7 +102,7 @@ Also see my posts [The CRO Process](/post/the-cro-process/).
 
 **Further reading:**
 
-- [The Culture Map: Breaking Through the Invisible Boundaries of Global Business](https://www.amazon.com/Culture-Map-Breaking-Invisible-Boundaries/dp/1610392507)
+- [The Culture Map: Breaking Through the Invisible Boundaries of Global Business](https://bookhive.buzz/books/bk_qscKoRQRi6xbmO10JAcZ)
 
 ### Left with questions?
 

--- a/src/content/post/how-to-build-an-online-b2b-community/index.mdx
+++ b/src/content/post/how-to-build-an-online-b2b-community/index.mdx
@@ -215,8 +215,8 @@ If you made it this far down then A) I'm impressed and B) you might be eager to 
    - [The SPACES model for defining community's business value](https://cmxhub.com/the-spaces-model/), by [David Spinks](https://www.linkedin.com/in/davidspinks/)
 
 2. Books:
-   - [The Art of Community](https://www.jonobacon.com/books/artofcommunity/) and [People Powered](https://www.jonobacon.com/books/peoplepowered/) by [Jono Bacon](https://www.linkedin.com/in/jonobacon/)
-   - [The Businesss of Belonging](https://www.davidspinks.com/) by [David Spinks](https://www.linkedin.com/in/davidspinks/)
+   - [The Art of Community](https://bookhive.buzz/books/bk_Pqcq0sjg22AJAzijNFqq) and [People Powered](https://bookhive.buzz/books/bk_2rystELfSp2SEcZqiYU7) by [Jono Bacon](https://www.linkedin.com/in/jonobacon/)
+   - [The Businesss of Belonging](https://bookhive.buzz/books/bk_jajqzPJlfB41rrmdmYHQ) by [David Spinks](https://www.linkedin.com/in/davidspinks/)
 
 3. Podcasts:
    - [In Before The Lock](https://ib4tl.fm/), by Erica Kuhl and [Brian Oblinger](https://www.linkedin.com/in/brianoblinger/)
@@ -225,7 +225,7 @@ If you made it this far down then A) I'm impressed and B) you might be eager to 
    - [Lessons From The NEW Community Manager Handbook](https://communityroundtable.com/what-we-do/resources/community-management-podcasts/cmgr-handbook-podcast/), by [The Community Roundtable](https://www.linkedin.com/company/the-community-roundtable/)
    - [The B2B Growth Show](https://sweetfishmedia.com/b2b-growth)
 
-> TIP: If your community is catering towards a technical audience with a lot of developers, I can highly recommend the content of [Mary Thengvall](https://www.linkedin.com/in/marythengvall?trk=article-ssr-frontend-pulse_little-mention) ([website](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww%2Emarythengvall%2Ecom%2Fblog&urlhash=-oLt&trk=article-ssr-frontend-pulse_little-text-block)) and [Developer Relations](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww%2Eamazon%2Ecom%2FDeveloper-Relations-Build-Successful-Program-ebook%2Fdp%2FB09G9LGSJ1%3Fref_%3Dast_author_dp&urlhash=dufD&trk=article-ssr-frontend-pulse_little-text-block) by [Caroline Lewko](https://ca.linkedin.com/in/carolinelewko?trk=article-ssr-frontend-pulse_little-mention) , and for you to check out content everywhere marked [#DevRel](https://www.linkedin.com/feed/hashtag/devrel?trk=article-ssr-frontend-pulse_little-text-block).
+> TIP: If your community is catering towards a technical audience with a lot of developers, I can highly recommend the content of [Mary Thengvall](https://www.linkedin.com/in/marythengvall?trk=article-ssr-frontend-pulse_little-mention) ([website](https://www.linkedin.com/redir/redirect?url=https%3A%2F%2Fwww%2Emarythengvall%2Ecom%2Fblog&urlhash=-oLt&trk=article-ssr-frontend-pulse_little-text-block)) and [Developer Relations](https://bookhive.buzz/books/bk_n0nVY8zEFPJMo0Z2pTyd) by [Caroline Lewko](https://ca.linkedin.com/in/carolinelewko?trk=article-ssr-frontend-pulse_little-mention) , and for you to check out content everywhere marked [#DevRel](https://www.linkedin.com/feed/hashtag/devrel?trk=article-ssr-frontend-pulse_little-text-block).
 
 Dig into these and you'll get a better sense of how to build a successful B2B community, and how to use it to drive growth and get people collaborating around your business.
 


### PR DESCRIPTION
## What

Swaps 9 outbound book links across two posts to canonical [bookhive.buzz](https://bookhive.buzz) book pages, matching the site's existing Bookhive reading-shelf integration (`ReadingCard.astro`, `lib/bookhive.ts`).

**`data-driven-decisions-meets-psychology`** (5 Amazon → Bookhive):

| Book | hiveId |
|---|---|
| Thinking, Fast and Slow | `bk_lymQD4PAS4QzUhlPhMYT` |
| Influence | `bk_cZ07xDAyoVccvZGGA3y2` |
| Predictably Irrational | `bk_wNmQZx7MGgIn1hng1yJT` |
| Nudge | `bk_cakv6Mrb42m9vLPLCgpZ` |
| The Culture Map | `bk_qscKoRQRi6xbmO10JAcZ` |

**`how-to-build-an-online-b2b-community`** (4 links → Bookhive):

| Book | Was | hiveId |
|---|---|---|
| The Art of Community | jonobacon.com | `bk_Pqcq0sjg22AJAzijNFqq` |
| People Powered | jonobacon.com | `bk_2rystELfSp2SEcZqiYU7` |
| The Business of Belonging | davidspinks.com | `bk_jajqzPJlfB41rrmdmYHQ` |
| Developer Relations | Amazon (via LinkedIn redirect) | `bk_n0nVY8zEFPJMo0Z2pTyd` |

## Why

- Consolidates book references on Bookhive instead of Amazon, consistent with the site's reading shelf.
- Drops Amazon affiliate/tracking params (the Predictably Irrational and Developer Relations URLs carried long query strings).
- Each hiveId is the canonical edition (real author, not a summary/study-guide), resolved via Bookhive search.

## Verification

- All 9 target pages return HTTP 200.
- `astro check`: 0 errors. `npm run build`: passes; both posts render the new links in `dist/`.

## Out of scope

- Author LinkedIn links and Mary Thengvall's site (not book-purchase links) left unchanged.
- *Antifragile* (Wikipedia link), bol.com, Amazon Music, and Audiobookshelf left unchanged.
- The pre-existing `[The Businesss of Belonging]` typo in link text was left as-is.