### PR TITLE
content(atproto-ep1): copy revisions and typo fixes

### DIFF
--- a/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
+++ b/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
@@ -20,27 +20,27 @@ draft: false
 
 import SeriesBanner from "@components/SeriesBanner.astro";
 
-If your LinkedIn account vanished tomorrow, your contacts wouldn't survive the move. And it didn't have to be this way.
+If your LinkedIn account vanished tomorrow, your contacts wouldn't survive the move. Yet it doesn't have to be this way.
 
-I've moved communities and networks between platforms more times than I'd like: Slack, Facebook Groups, LinkedIn, Meetup, forums, Twitter, sometimes as the main channel, sometimes a side tool. Every move charged a tax on the way out: the people who didn't follow to the new place, the years of conversations stranded in a database neither I nor the members controlled. Realistically, half the audience never makes the jump.
+I've moved communities and networks between platforms more times than I'd like: Slack, Facebook Groups, LinkedIn, Meetup, forums, Twitter, sometimes as the main channel, sometimes a side tool. Every move charged a huge tax on the way out: the people who didn't follow to the new place, the years of conversations stranded in a database neither I nor the members controlled. Realistically, half the audience never makes the jump.
 
-It's built that way on purpose. Platforms like LinkedIn don't want you to leave, and wanting to keep people around is fair enough. But making it impossible to leave with your contacts and your content is less a happy relationship than a hostage situation.
+It's built that way on purpose. Platforms like LinkedIn don't want you to leave: they want everyone to stay put and become dependent on them. But making it impossible to leave with your own contacts and your content is less of a happy relationship and more akin to a hostage situation.
 
-Platforms come and go. However big one looks today, there's a new hype tomorrow. What keeps costing you, and your contacts, is the lock-in architecture underneath them all.
+Platforms come and go. However big one looks today, there's a new hype around the corner. What keeps costing you, and your contacts, is the lock-in architecture underneath them all.
 
 <SeriesBanner part={1} />
 
 ## The tax is built in
 
-Take Slack's free plan: After 90 days your message history vanishes. Not deleted though, just hidden: they keep your data on their servers (and may well keep training on it), then charge you to see your own conversations again. You wrote it, they store it, you rent access to it. SaaS platforms change their pricing simply because they can and the math stops working for you. Twitter became X. Discord decided my community suddenly needed ID verification. None of these were about us, they were business decisions at companies I didn't own, and every time my contacts or community members paid part of the bill.
+Take Slack's free plan: After 90 days your message history vanishes. Not deleted though, just hidden: they keep your data on their servers (and may well keep training on it), then charge you to see your own conversations again. You wrote it, they store it, you rent access to it. SaaS platforms change their pricing simply because they can and the math stops working for you. Twitter not just became X, but it became a very different environment. Discord decided my community suddenly needed ID verification. None of these were about us, they were business decisions at companies I didn't own, and every time my contacts or community members paid part of the bill.
 
-You can't take your LinkedIn, Instagram or Twitter contacts to a different platform. Not because it's technically impossible, but because whoever built it made sure the door only opens one way. That's architecture, not destiny. It should be about the people, not the platform (nicely put by [Anuj Ahooja](https://mu.social/profile/quillmatiq.com)).
+And you can't take your LinkedIn, Instagram or Twitter contacts to a different platform. Not because it's technically impossible, but because whoever built it made sure the door only opens one way. That's purposeful architecture, not just the way it HAS to be. It should be about the people, not the platform (nicely put by [Anuj Ahooja](https://mu.social/profile/quillmatiq.com)).
 
 ## You already accept the opposite, every day
 
 Think about your phone number. You switch carriers and keep it. You call anyone, on any network, and it just works. Same with e-mail. Now picture a phone that only let you call people on your exact carrier, and the day you switched, you lost every contact and every past conversation. Absurd, right? Nobody would sign up for that.
 
-But that's how social platforms work. Your contacts only exist inside one app, and they can't leave with you.
+But that's how social platforms of the past 20 years work. Your contacts only exist inside one app, and you can't bring them with you.
 
 You know what the (yes, boring but important) difference is between social networks and things like e-mail and phone networks?
 
@@ -48,29 +48,29 @@ Protocols.
 
 ## Apps as views, not vaults
 
-Protocols work for e-mail and phone numbers. They can work for social media too. Picture a protocol where the things you make, your posts, your photos, your follows, your reviews, are yours, like the contents of a display cabinet you keep. Apps are just the viewers that look into it. Swap the viewer, your things stay put.
+Open Protocols work for e-mail and phone numbers. They can work for social media too. Picture a protocol where the things you make, your posts, your photos, your follows, your reviews, are all yours, stored and shown off in something like a display cabinet that others can view, but you own and control. Apps are just the viewers that look into it. You can swap the app, and just give them access to your cabinet.
 
 ![A single display cabinet with nine labelled compartments (Posts, Books, Photos, Films & reviews, a private compartment marked "?" for Episode 6, Professional profile, Code repo, Events, Publishing), surrounded by atproto apps reading from different compartments as views: Bluesky, mu.social and Blacksky, Sifa, Popfeed, Tangled, Leaflet, Offprint and more. Caption: your cabinet, your data, one per person, rent the space or self-host. Apps are views, not vaults; swap the app, your cabinet stays.](./apps-as-views.png)
 
-[Dan Abramov](https://bsky.app/profile/danabra.mov) wrote the best technical explainer of this, ["A Social Filesystem"](https://overreacted.io/a-social-filesystem/), if you ever want the mechanics. This series comes at it from the other side: what living through the alternative actually costs you and me, and why that should change how you pick the tools you depend on.
+[Dan Abramov](https://bsky.app/profile/danabra.mov) wrote a great technical explainer of this in his ["A Social Filesystem"](https://overreacted.io/a-social-filesystem/). If you ever want the mechanics: read this. The series you are reading now comes at it from the other side: what living through the alternative actually costs you and me, and why that should change how you pick the tools you depend on.
 
-The specific protocol is called the [AT Protocol](https://atproto.com/) (atproto for short). The wider ecosystem of apps and servers built on top has its own name: the Atmosphere. Bluesky, the app most people have heard of, is just one app in the Atmosphere. Not the protocol itself. Just one view among many. (Credit to [Roel Donckers](https://bsky.app/profile/donckrr.eurosky.social) for the ["the Atmosphere is already here"](https://donckrr.offprint.app/a/3mlgssxt6xa23-the-atmosphere-is-already-here) framing.)
+The specific protocol we are talking about is called the [AT Protocol](https://atproto.com/) (atproto for short). The wider ecosystem of apps and servers built on top has its own name: the _Atmosphere_, and the single account you have (that gives you access to all apps and the whole cabinet) is thus called your _Atmosphere account_. Bluesky, the app most people have heard of, is just one app in the Atmosphere. Not the protocol itself. Just one view among many. (Also see [Roel van Hooydonck's](https://bsky.app/profile/roel.vanhooydonck.nl) ["the Atmosphere is already here"](https://donckrr.offprint.app/a/3mlgssxt6xa23-the-atmosphere-is-already-here))
 
-When someone wants a feature Bluesky doesn't have (like a lot of users keep screaming about edit buttons), the answer is increasingly "use a different app on the same network." Apps like [mu.social](https://mu.social) or [Skywalker](https://play.google.com/store/apps/details?id=com.gmail.mfnboer.skywalker&hl=en-US) read the exact same posts and followers, and they do have the edit button Bluesky lacks. Same data, a different view, different features.
+When someone wants a feature Bluesky doesn't have (like a lot of users keep screaming about wanting an edit button), the answer is increasingly "just use a different app on the same network." Apps like [mu.social](https://mu.social) or [Skywalker](https://play.google.com/store/apps/details?id=com.gmail.mfnboer.skywalker&hl=en-US) read the exact same posts and followers, and they do have the edit button Bluesky lacks. Same data, a different view, different features.
 
-And it isn't only microblogging. Any app can add a new kind of thing to the cabinet, so it can hold almost anything: writing, photos, films you've rated, events, even a code repo. One app shows your photos, another your writing, another your reviews. Some apps even show you multiple content types. And all are just looking into the same cabinet. (Episode 4 gets into how.)
+And it isn't only microblogging. Any app can add a new kind of content type to the cabinet, so it can hold almost anything: writing, photos, films you've rated, events, even a code repo. One app shows your photos, another your writing, another your reviews. Some apps even show you multiple content types. And all are just looking into the same cabinet. (Episode 4 gets into how.)
 
-Worth being precise about "yours," because this is where most "own your data" pitches oversell. The cabinet and everything in it is yours: what you make, and your identity. You don't have to own the building it sits in, most people let a host keep the cabinet (often free), some self-host. Either way you can move the whole thing elsewhere whenever you want. It still feels like a bit of magic, even after years in closed systems: you move hosts, your links don't break, and every app you use keeps working, nothing to change.
+Sidenote: The cabinet and everything in it is yours: what you make, and your identity. But you don't have to own the building it sits in: most people let a host keep the cabinet (often free), some self-host. Either way you can move the whole thing elsewhere whenever you want. It still feels like a bit of magic, even after years in closed systems: you can move all your content to a new host, yet your links don't break, and every app you use keeps working, nothing to change. And if you ever tried to do this with Mastodon and are afraid this is going to be hard: the UX is actually surprisingly good and simple.
 
-That's the opposite of a vault like LinkedIn or Instagram, where your stuff sits in their building, behind their lock; you leave, they keep it.
+That's the opposite of a vault like LinkedIn or Instagram, where your stuff sits in their building, behind their lock; you can leave, but they keep all your contacts and content.
 
 ## One company runs most of this today
 
-Before this turns into a sales pitch: today, one company (Bluesky PBC) runs most of the atproto infrastructure, the main data server, the relay, the app most people use. The protocol is decentralized in its architecture. The operation, right now, isn't. The whole bet of this series is that this changes, that the protocol outlives any single company. If you watched email get swallowed by a handful of inboxes, that skepticism is earned, and I'm not going to argue you out of it.
+Before this turns into a sales pitch: today, one company ([Bluesky PBC](https://en.wikipedia.org/wiki/Bluesky#Corporate_structure)) created and still runs most of the atproto infrastructure, the main data server, the relay, the app most people use. The protocol is decentralized in its architecture. The operation, right now, isn't. The whole bet of this series is that this changes, that the protocol outlives any single company. If you watched email get swallowed by a handful of inboxes, that skepticism is earned, and I'm not going to argue you out of it.
 
-But it's already changing: [Eurosky](https://eurosky.tech/), a European non-profit, now runs its own independent slice of the stack and shipped [mu.social](https://mu.social/), a full replacement for the Bluesky app, without asking anyone (including Bluesky) for permission. That's the thing about a protocol: nobody has to. Concrete alternative infrastructure is running right now, governed by people who aren't the original company. The bet's starting to pay out.
+But it's already changing fast: [Blacksky](https://blacksky.community/) already hosts over 35K accounts, [Eurosky](https://eurosky.tech/) is a European non-profit that hosts over 20K accounts, now runs its own independent slice of the stack and also shipped [mu.social](https://mu.social/), a full replacement for the Bluesky app. And they all can just do this without asking anyone (including Bluesky) for permission. That's the thing about a protocol: nobody has to. Concrete alternative infrastructure is running right now, governed by people who aren't the original company. The bet's starting to pay out.
 
-Of course atproto isn't the only attempt at an open social web: The fediverse (Mastodon and friends) runs on an older protocol, ActivityPub, and has been at it longer. I build on atproto, so that's what this series follows. My bet's on it because, in my view, it does the two things this piece is about better: your account is portable (take it, contacts and all, to another provider without starting over), and a whole range of apps read and write the same data instead of each walling off its own. Episode 7 compares them properly.
+Of course atproto isn't the only attempt at an open social web: The fediverse (Mastodon and friends) runs on an older protocol, ActivityPub, and has been at it longer. I build on atproto, so that's what this series follows. My bet's on it because, in my view, it does two things better: your account is portable (take it, contacts and all, to another provider without starting over), and a whole range of apps read and write the same data instead of each walling off its own. Episode 7 compares them in more detail.
 
 ## What changes when you own the cabinet
 
@@ -80,7 +80,7 @@ When your data and your contacts live in a place you actually control, a few imp
 - Apps compete on how good the view is, not on how well they onboard you and trap your data so you won't leave.
 - When an app dies (and apps die), your data always survives it.
 
-You can feel the incentive shift in small things. On most platforms, posting a link quietly costs you reach, because they'd rather you didn't send people elsewhere. Bluesky's COO [Rose Wang](https://bsky.app/profile/rose.bsky.team) put it the other way round: ["we don't de-promote your links. Post all the links you want, Bluesky is a lobby to the open web."](https://www.nbcnews.com/tech/social-media/bluesky-x-becomes-social-media-rcna181685) When an app doesn't own your audience, it has less reason to hold it hostage.
+You can feel the incentive shift in small things. On most platforms like LinkedIn and X, posting a link quietly costs you reach, because they'd rather you didn't send users elsewhere. Bluesky's COO [Rose Wang](https://bsky.app/profile/rose.bsky.team) put it the other way round: ["we don't de-promote your links. Post all the links you want, Bluesky is a lobby to the open web."](https://www.nbcnews.com/tech/social-media/bluesky-x-becomes-social-media-rcna181685) When an app doesn't own your audience, it has less reason to hold it hostage.
 
 Another concrete example: I'm building [Sifa](https://sifa.id/), a professional profile on atproto, the useful parts of LinkedIn (your work history, your skills, your contacts) living in your own cabinet, not in Sifa's database. If Sifa disappears tomorrow, you keep your profile, your CV and your contacts, and any other app can still read them. That's how building on this protocol works, and it's pretty much the opposite of the LinkedIn problem in the opening above. Episode 4 walks through the wider ecosystem of apps already doing this.
 
@@ -88,7 +88,7 @@ Another concrete example: I'm building [Sifa](https://sifa.id/), a professional 
 
 This is all still young: Bluesky only opened to the public in February 2024, and the protocol under it dates to 2023. Early enough that the momentum is hard to look away from, and early enough that plenty still needs fixing. The rest of this series digs into both.
 
-There's a hole in everything I just told you, though. If your posts and contacts are yours, what actually proves you're you, and not someone who grabbed your handle? That's where this whole thing either falls apart or holds together. Let's talk about that in Part 2.
+This also brings us to an interesting next step that is getting some heated discussions lately: who are you actually? If your posts and contacts are yours, what actually proves you're you, and not someone who grabbed your name/handle? That's where this whole thing could either fall apart or hold together. Let's talk about that in Part 2.
 
 ---
 


### PR DESCRIPTION
Copy revisions to the published Episode 1 post (`Who actually owns your network?`):

- Tightened framing on lock-in/ownership
- Expanded the host/portability sidenote (Mastodon UX note)
- Added Blacksky (35K) and Eurosky (20K) account numbers
- Updated the Atmosphere attribution and added `_Atmosphere account_` definition
- Fixed four spelling typos: dependent, purposeful, talking, hosts

Single-file content change; no component or layout impact.