### PR TITLE
content(series): publish Ep2 now + drop fabricated planned dates

### DIFF
--- a/src/content/post/atproto-series-02-your-identity-isnt-your-username/index.mdx
+++ b/src/content/post/atproto-series-02-your-identity-isnt-your-username/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your identity isn't your username"
 description: "Your handle is a label; your identity is a key you own. atproto splits who you are from what you're called, so you can rename freely, prove who you are with a domain you control, and carry one identity across the apps you use. Part of 'Apps as Views, Not Vaults': the things you make are yours; apps are just the viewers."
-pubDate: 2026-07-02T08:00:00+02:00
+pubDate: 2026-07-01T08:00:00+02:00
 heroImage: ./heroImage.png
 heroImageAlt: "'Apps as Views, Not Vaults' series title card, Identity / Part 02: the headline 'Your identity isn't your username' with the subtitle 'Change your handle, change your host, keep every follower', beside a line-drawn display cabinet."
 ogImage: hero

--- a/src/pages/series/atproto.astro
+++ b/src/pages/series/atproto.astro
@@ -16,10 +16,9 @@ const now = new Date();
 // Presentation manifest — the spine's source of truth (SERIES.md "Episode
 // titles + pills + glosses" + design/HANDOVER-TO-CODE.md accents & acts).
 // Links for RELEASED episodes come from the matched post; scheduled cards never
-// link. `plannedDate` drives the "Coming {date}" label for episodes not yet
-// written; the real pubDate takes over once an episode ships. Only Episode 1 is
-// drafted so far — the rest render as scheduled until their MDX lands and their
-// pubDate passes.
+// link. Dates come only from a real post's `pubDate`: a matched-but-unreleased
+// episode shows "Coming {pubDate}", and an episode with no post yet shows a
+// dateless "Coming soon" — nothing is planned until its MDX lands.
 const MANIFEST = [
   {
     episode: 1,
@@ -28,7 +27,6 @@ const MANIFEST = [
     title: "You don't own your network",
     gloss:
       "If a platform vanished tomorrow, your network wouldn't survive the move. Someone chose that, and it can be unmade.",
-    plannedDate: "2026-06-25T06:00:00+02:00",
   },
   {
     episode: 2,
@@ -37,7 +35,6 @@ const MANIFEST = [
     title: "Your identity isn't your username",
     gloss:
       "Change your handle, keep every follower. Why atproto splits who you are from what you're called.",
-    plannedDate: "2026-07-02T08:00:00+02:00",
   },
   {
     episode: 3,
@@ -46,7 +43,6 @@ const MANIFEST = [
     title: "Where your posts actually live",
     gloss:
       "When an app shuts down, what happens to five years of your stuff? Depends who's holding it.",
-    plannedDate: "2026-07-07T08:00:00+02:00",
   },
   {
     episode: 4,
@@ -55,7 +51,6 @@ const MANIFEST = [
     title: "Apps that don't need permission",
     gloss:
       "A new app can already know your network: no partnership deals, no API keys, no “log in with X” tax.",
-    plannedDate: "2026-07-14T08:00:00+02:00",
   },
   {
     episode: 5,
@@ -64,7 +59,6 @@ const MANIFEST = [
     title: "You don't have to like the algorithm",
     gloss:
       "When a feed decides your reach, you don't get a vote. There's an architecture where you do.",
-    plannedDate: "2026-07-28T08:00:00+02:00",
   },
   {
     episode: 6,
@@ -73,7 +67,6 @@ const MANIFEST = [
     title: "What atproto can't do (yet)",
     gloss:
       "The gaps the hype skips. Plus: your whole identity can run on a Raspberry Pi, or hosted free.",
-    plannedDate: "2026-08-04T08:00:00+02:00",
   },
   {
     episode: 7,
@@ -82,7 +75,6 @@ const MANIFEST = [
     title: "Bigger than social media",
     gloss:
       "I ran Doom over the AT Protocol at five frames per second. Nobody needs that, but it proved what the protocol really is.",
-    plannedDate: "2026-08-11T08:00:00+02:00",
   },
 ] as const;
 
@@ -144,7 +136,9 @@ const episodes = MANIFEST.map((m) => {
     notLast: m.episode < TOTAL,
     statusLabel: released
       ? `Released ${format(new Date(post!.data.pubDate), "MMM d, yyyy")}`
-      : `Coming ${format(new Date(m.plannedDate), "MMM d, yyyy")}`,
+      : post
+        ? `Coming ${format(new Date(post.data.pubDate), "MMM d, yyyy")}`
+        : "Coming soon",
   };
 });
 


### PR DESCRIPTION
Two related series-hub changes.

## 1. Publish Episode 2 now
- Ep2 `pubDate` 2026-07-02 → **2026-07-01** (today), so it goes live on this deploy instead of waiting.
- Reason: there is **no scheduled/daily deploy** in `.github/workflows/` (only security-alerts, CodeQL, link-check crons — none rebuild the site), so a future-dated post would not auto-release on its own.
- Result: `/post/atproto-series-02-your-identity-isnt-your-username/` builds as a live page; series hub shows Ep2 as **Released**.

## 2. Drop fabricated `plannedDate` values
- Removed the placeholder dates from the series manifest (`src/pages/series/atproto.astro`) — nothing is scheduled beyond what's actually written.
- Label logic now derives dates only from a real post's `pubDate`:
  - released post → `Released {pubDate}`
  - matched but future-dated post → `Coming {pubDate}`
  - no post yet → dateless **`Coming soon`**

## Verification
- `npm run build` passes.
- Series hub renders: Ep1 "Released Jun 25, 2026", Ep2 "Released Jul 1, 2026", Ep3–7 "Coming soon".

## Note
- Auto-release of future-dated posts still has no automation. If you want hands-off scheduling later, add a daily GitHub Actions cron hitting a Netlify build hook. Not included here.