### PR TITLE
content: voice/copy fixes across latest 4 posts

### DIFF
--- a/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
+++ b/src/content/post/atproto-series-01-you-dont-own-your-network/index.mdx
@@ -33,7 +33,7 @@ Platforms come and go. However big one looks today, there's a new hype around th
 
 ## The tax is built in
 
-Take Slack's free plan: After 90 days your message history vanishes. Not deleted though, just hidden: they keep your data on their servers (and may well keep training on it), then charge you to see your own conversations again. You wrote it, they store it, you rent access to it. SaaS platforms change their pricing simply because they can and the math stops working for you. Twitter not just became X, but it became a very different environment. Discord decided my community suddenly needed ID verification. None of these were about us, they were business decisions at companies I didn't own, and every time my contacts or community members paid part of the bill.
+Take Slack's free plan: After 90 days your message history vanishes. Not deleted though, just hidden: they keep your data on their servers (and may well keep training on it), then charge you to see your own conversations again. You wrote it, they store it, you rent access to it. SaaS platforms change their pricing simply because they can and the math stops working for you. Twitter didn't just rename to X, the whole environment changed. Discord decided my community suddenly needed ID verification. None of these were about us, they were business decisions at companies I didn't own, and every time my contacts or community members paid part of the bill.
 
 And you can't take your LinkedIn, Instagram or Twitter contacts to a different platform. Not because it's technically impossible, but because whoever built it made sure the door only opens one way. That's purposeful architecture, not just the way it HAS to be. It should be about the people, not the platform (nicely put by [Anuj Ahooja](https://mu.social/profile/quillmatiq.com)).
 
@@ -51,11 +51,11 @@ Protocols.
 
 Open Protocols work for e-mail and phone numbers. They can work for social media too. Picture a protocol where the things you make, your posts, your photos, your follows, your reviews, are all yours, stored and shown off in something like a display cabinet that others can view, but you own and control. Apps are just the viewers that look into it. You can swap the app, and just give them access to your cabinet.
 
-![A single display cabinet with nine labelled compartments (Posts, Books, Photos, Films & reviews, a private compartment marked "?" for Episode 6, Professional profile, Code repo, Events, Publishing), surrounded by atproto apps reading from different compartments as views: Bluesky, mu.social and Blacksky, Sifa, Popfeed, Tangled, Leaflet, Offprint and more. Caption: your cabinet, your data, one per person, rent the space or self-host. Apps are views, not vaults; swap the app, your cabinet stays.](./apps-as-views.png)
+![A single display cabinet with nine labelled compartments (Posts, Books, Photos, Films & reviews, a private compartment marked "?" for Episode 6, Professional profile, Code repo, Events, Publishing), surrounded by atproto apps reading from different compartments as views: Bluesky, mu.social and Blacksky, Sifa, Popfeed, Tangled, Leaflet, Offprint and more. Caption: your cabinet, your data, one per person, rent the space or self-host. Apps are views, not vaults. Swap the app, your cabinet stays.](./apps-as-views.png)
 
 [Dan Abramov](https://bsky.app/profile/danabra.mov) wrote a great technical explainer of this in his ["A Social Filesystem"](https://overreacted.io/a-social-filesystem/). If you ever want the mechanics: read this. The series you are reading now comes at it from the other side: what living through the alternative actually costs you and me, and why that should change how you pick the tools you depend on.
 
-The specific protocol we are talking about is called the [AT Protocol](https://atproto.com/) (atproto for short). The wider ecosystem of apps and servers built on top has its own name: the _Atmosphere_, and the single account you have (that gives you access to all apps and the whole cabinet) is thus called your _Atmosphere account_. Bluesky, the app most people have heard of, is just one app in the Atmosphere. Not the protocol itself. Just one view among many. (Also see [Roel van Hooydonck's](https://bsky.app/profile/roel.vanhooydonck.nl) ["the Atmosphere is already here"](https://donckrr.offprint.app/a/3mlgssxt6xa23-the-atmosphere-is-already-here))
+The specific protocol we are talking about is called [AT Protocol](https://atproto.com/) (atproto for short). The wider ecosystem of apps and servers built on top has its own name: the _Atmosphere_, and the single account you have (that gives you access to all apps and the whole cabinet) is thus called your _Atmosphere account_. Bluesky, the app most people have heard of, is just one app in the Atmosphere. Not the protocol itself. Just one view among many. (Also see [Roel van Hooydonck's](https://bsky.app/profile/roel.vanhooydonck.nl) ["the Atmosphere is already here"](https://donckrr.offprint.app/a/3mlgssxt6xa23-the-atmosphere-is-already-here))
 
 When someone wants a feature Bluesky doesn't have (like a lot of users keep screaming about wanting an edit button), the answer is increasingly "just use a different app on the same network." Apps like [mu.social](https://mu.social) or [Skywalker](https://play.google.com/store/apps/details?id=com.gmail.mfnboer.skywalker&hl=en-US) read the exact same posts and followers, and they do have the edit button Bluesky lacks. Same data, a different view, different features.
 
@@ -63,7 +63,7 @@ And it isn't only microblogging. Any app can add a new kind of content type to t
 
 Sidenote: The cabinet and everything in it is yours: what you make, and your identity. But you don't have to own the building it sits in: most people let a host keep the cabinet (often free), some self-host. Either way you can move the whole thing elsewhere whenever you want. It still feels like a bit of magic, even after years in closed systems: you can move all your content to a new host, yet your links don't break, and every app you use keeps working, nothing to change. And if you ever tried to do this with Mastodon and are afraid this is going to be hard: the UX is actually surprisingly good and simple.
 
-That's the opposite of a vault like LinkedIn or Instagram, where your stuff sits in their building, behind their lock; you can leave, but they keep all your contacts and content.
+That's the opposite of a vault like LinkedIn or Instagram, where your stuff sits in their building, behind their lock: you can leave, but they keep all your contacts and content.
 
 ## One company runs most of this today
 
@@ -83,7 +83,7 @@ When your data and your contacts live in a place you actually control, a few imp
 
 You can feel the incentive shift in small things. On most platforms like LinkedIn and X, posting a link quietly costs you reach, because they'd rather you didn't send users elsewhere. Bluesky's COO [Rose Wang](https://bsky.app/profile/rose.bsky.team) put it the other way round: ["we don't de-promote your links. Post all the links you want, Bluesky is a lobby to the open web."](https://www.nbcnews.com/tech/social-media/bluesky-x-becomes-social-media-rcna181685) When an app doesn't own your audience, it has less reason to hold it hostage.
 
-Another concrete example: I'm building [Sifa](https://sifa.id/), a professional profile on atproto, the useful parts of LinkedIn (your work history, your skills, your contacts) living in your own cabinet, not in Sifa's database. If Sifa disappears tomorrow, you keep your profile, your CV and your contacts, and any other app can still read them. That's how building on this protocol works, and it's pretty much the opposite of the LinkedIn problem in the opening above. Episode 4 walks through the wider ecosystem of apps already doing this.
+Another concrete example: I'm building [Sifa ID](https://sifa.id/), a professional profile on atproto, the useful parts of LinkedIn (your work history, your skills, your contacts) living in your own cabinet, not in Sifa's database. If Sifa disappears tomorrow, you keep your profile, your CV and your contacts, and any other app can still read them. That's how building on this protocol works, and it's pretty much the opposite of the LinkedIn problem in the opening above. Episode 4 walks through the wider ecosystem of apps already doing this.
 
 ## Still early, and worth watching
 
@@ -93,4 +93,4 @@ This also brings us to an interesting next step that is getting some heated disc
 
 ---
 
-_Part 1 of 7. Full series at [/series/atproto/](/series/atproto/). I'm building two products on atproto, full disclosure on the series page._
+_Part 1 of 7. Full series at [/series/atproto/](/series/atproto/). I'm building two products on atproto (details on the series page)._

--- a/src/content/post/atproto-series-02-your-identity-isnt-your-username/index.mdx
+++ b/src/content/post/atproto-series-02-your-identity-isnt-your-username/index.mdx
@@ -31,7 +31,7 @@ On the platforms you're used to, you can change your name but you can't own it. 
 
 ## The problem: Identity as a row in their database
 
-Think about what your identity actually is on a closed platform. You don't own your handle; it's a name they let you use, one row in their database with your posts and connections hanging off it. Useful for them, fragile for you.
+Think about what your identity actually is on a closed platform. You don't own your handle: it's a name they let you use, one row in their database with your posts and connections hanging off it. Useful for them, fragile for you.
 
 Delete that row and you stop existing there. Get suspended, and your name can be handed to someone else. You can't take it with you, and you can't run it anywhere they don't allow. Because your name, your identity and your followers are all fused into that one row, the name carries all the weight: lose it and you've lost the person, the handle gets reassigned, old links break, and there's nothing underneath to fall back on.
 
@@ -47,7 +47,7 @@ The display cabinet from [Episode 1](https://gui.do/post/atproto-series-01-you-d
 
 ### ...your host
 
-If you own your own domain name, you already had this flexibility since the beginning. Switching to another e-mail provider is easy: your own address @ your own domain stays the same whether Google, Fastmail, Proton or your own server is delivering it, because it belongs to your domain, not the provider. Same with your phone number: switch carriers, keep the number, nothing breaks. The thing you hold stays put; the company behind it is swappable.
+If you own your own domain name, you already had this flexibility since the beginning. Switching to another e-mail provider is easy: your own address @ your own domain stays the same whether Google, Fastmail, Proton or your own server is delivering it, because it belongs to your domain, not the provider. Same with your phone number: switch carriers, keep the number, nothing breaks. The thing you hold stays put: the company behind it is swappable.
 
 atproto brings that same portability to where your identity is hosted. Dan Abramov did exactly this recently: he [moved his hosting from Bluesky to Eurosky](https://overreacted.io/there-are-no-instances-in-atproto/) (the European non-profit from Episode 1) and his handle, his followers and his posts didn't budge, same as repointing your domain at a new e-mail host. As he puts it, where your data is hosted and who you are were never the same thing: _"hosting and aggregation are two separate things."_
 
@@ -57,7 +57,7 @@ If you make things for an audience, your name is your reputation, and on a close
 
 On closed platforms your audience is recognising an account inside an app, and that account only exists there. The same person is a fresh, unconnected account on every other network. When your identity is a key you own, recognition attaches to _you_ instead, and the app becomes just today's viewer.
 
-You can see this already. [Flashes](https://flashes.blue/) shows your photos to the same Bluesky followers you already have; [Leaflet](https://leaflet.pub/) lets you publish long-form under that same identity. One name, recognisably the same person in each, because it's one identity underneath, not separate accounts that happen to share a name.
+You can see this already. [Flashes](https://flashes.blue/) shows your photos to the same Bluesky followers you already have. [Leaflet](https://leaflet.pub/) lets you publish long-form under that same identity. One name, recognisably the same person in each, because it's one identity underneath, not separate accounts that happen to share a name.
 
 ### ...one content format
 
@@ -65,9 +65,9 @@ Each platform centres one format and rewards it above the rest. Instagram leans 
 
 If you publish in more than one format, the old platforms make you choose: stop doing it, force everything into a single app's shape, or run multiple accounts and grow a separate audience on each.
 
-Of course there are (strained) workarounds: people post Instagram "stories" that are really just text on a coloured background, because that's the only way to say something wordy to an Instagram crowd. Musicians upload a track to YouTube as a still image over audio, because that's where the listeners are. The format is wrong for the medium; the reach is the only thing keeping them there.
+Of course there are (strained) workarounds: people post Instagram "stories" that are really just text on a coloured background, because that's the only way to say something wordy to an Instagram crowd. Musicians upload a track to YouTube as a still image over audio, because that's where the listeners are. The format is wrong for the medium: the reach is the only thing keeping them there.
 
-atproto doesn't fully fix this: an app still shows what it's built to show. But the app can actually show multiple formats (e.g. both [Sifa activity stream](https://sifa.id/p/gui.do/activity) and [sill.social](https://sill.social) already do this). And because your identity, your followers and your posts are yours, not locked inside one app, a new medium doesn't mean a new identity or starting from zero. You publish in whatever format fits, under the same you, and the people who know you can pick it up wherever it lives. (Episode 4 gets into how apps share posts and audiences across formats.)
+atproto doesn't fully fix this: an app still shows what it's built to show. But the app can actually show multiple formats (e.g. both [Sifa ID's activity stream](https://sifa.id/p/gui.do/activity) and [sill.social](https://sill.social) already do this). And because your identity, your followers and your posts are yours, not locked inside one app, a new medium doesn't mean a new identity or starting from zero. You publish in whatever format fits, under the same you, and the people who know you can pick it up wherever it lives. (Episode 4 gets into how apps share posts and audiences across formats.)
 
 ![A wireframe display cabinet holding your things (Posts, Videos, Photos, Contacts, Profile, Notes). A "@gui.do" handle card sits on the door with the note "a card you can slide out and swap", while the old handle "@gxjansen.bsky.social" lies faded to one side, set aside. Etched into the base is a serial number, "did:plc:45uheisi25szrjvjurfpritx", marked "etched in, permanent, yours", with an arrow noting "everything hangs off this, not the label". Caption: change the name, the location, the content types, or how you view it. It's yours regardless.](./handle-and-key.png)
 
@@ -100,4 +100,4 @@ See you in Episode 3.
 
 ---
 
-_Episode 2 of 7. Full series at [/series/atproto/](/series/atproto/). I'm building two products on atproto, full disclosure on the series page._
+_Episode 2 of 7. Full series at [/series/atproto/](/series/atproto/). I'm building two products on atproto (details on the series page)._

--- a/src/content/post/self-hosted-github-runner-vps/index.mdx
+++ b/src/content/post/self-hosted-github-runner-vps/index.mdx
@@ -37,22 +37,22 @@ If you've already moved your code to [Tangled](https://tangled.org/) (the atprot
 
 If you want to keep using something other than Spindle's native pipelines, take a look at [mitchellh.com/tack](https://tangled.org/mitchellh.com/tack), which helps you stitch arbitrary CI into Tangled.
 
-The rest of this guide is GitHub-specific, but the sizing, security, and "what else to do with the box" sections are the same
+The rest of this guide is GitHub-specific, but the sizing, security, and "what else to do with the box" sections are the same.
 
 ## The problem with paying GitHub for hosted minutes
 
 Four things that bit me:
 
 - **The price stacks up fast if you actually use it.** I blow through the allotted 3,000 minutes (that come with the paid plan) in a few busy days, then pay $0.008/min compute + $0.002/min platform fee for every additional minute on a 2-core runner. Bigger runners cost more. For context, last month (May 2026) my org burned **14,987 Linux minutes** across active repos: $89.92 gross, $55.28 net after the included minutes. The bulk of that ($60) came from one repo with a heavy Next.js build + test suite. That's heavy active development, not "a few PRs a day", but the maths scales linearly: cut your usage in half and you're still well past the free tier on any non-toy project.
-- Github's **`ubuntu-latest` is small.** 2 cores, 8GB RAM. Fine for linting, painful for a Next.js build plus a typecheck plus a vitest suite plus an audit job.
+- GitHub's **`ubuntu-latest` is small.** 2 cores, 8GB RAM. Fine for linting, painful for a Next.js build plus a typecheck plus a vitest suite plus an audit job.
 - **Wall-clock is bounded by node-startup overhead.** Even when your actual job is fast, GitHub has to pick up the job, allocate a runner, and bring it online before any of your steps execute. On a hot self-hosted runner, that startup is near zero.
-- Github's reliability is not great lately, trying to make myself more and more independant of it is just a smart way to go about it imho...
+- GitHub's reliability is not great lately. Trying to make myself more and more independent of it is just a smart way to go about it imho...
 
 The result: I pay more, wait longer, and have less control over the runtime.
 
 ## What I did instead
 
-I rented a single 8 vCPU / 16 GB RAM Hetzner Cloud VPS (CPX42, AMD EPYC, 320GB NVMe storage, ~€32/month at the time of writing). [Hetzner adjusted prices on 1 April 2026](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/), so check the current rate. If you are happy to host outside the EU, cheaper option are available.
+I rented a single 8 vCPU / 16 GB RAM Hetzner Cloud VPS (CPX42, AMD EPYC, 320GB NVMe storage, ~€32/month at the time of writing). [Hetzner adjusted prices on 1 April 2026](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/), so check the current rate. If you are happy to host outside the EU, cheaper options are available.
 
 On that box I run four parallel runner agents, all registered to the same self-hosted pool with a shared label. Each runner picks up one job at a time, so the box can chew through four CI jobs concurrently. That matters a lot once you split your test suite into shards.
 
@@ -75,7 +75,7 @@ A note on security: a self-hosted runner runs whatever your workflow tells it to
 
 ## The setup, step by step
 
-Here's the setups step by step for you to execute, or to point your LLM to. In may experience, agents can do a pretty good job in handling this setup much faster than you can manually set this up.
+Here's the setup step by step for you to execute, or to point your LLM to. In my experience, agents can do a pretty good job of handling this much faster than you can manually.
 
 ### 1. Provision the VPS
 
@@ -209,7 +209,7 @@ check:
       run: echo "All jobs passed"
 ```
 
-I did this becasue the aggregator is the required check that gates merges. If your self-hosted box goes down mid-run, jobs that haven't started yet get stuck in "queued" forever, but the aggregator on `ubuntu-latest` will still resolve and at least give you a clean failure signal. It's also a near-zero-cost job: GitHub-hosted minutes for a 5-second `exit 0` are noise on the bill.
+I did this because the aggregator is the required check that gates merges. If your self-hosted box goes down mid-run, jobs that haven't started yet get stuck in "queued" forever, but the aggregator on `ubuntu-latest` will still resolve and at least give you a clean failure signal. It's also a near-zero-cost job: GitHub-hosted minutes for a 5-second `exit 0` are noise on the bill.
 
 ### 7. (Optional) Keep e2e on GitHub-hosted
 

--- a/src/content/post/standard-site-card-on-bluesky/index.mdx
+++ b/src/content/post/standard-site-card-on-bluesky/index.mdx
@@ -16,7 +16,7 @@ categories:
 
 You may have recently started seeing really nice article URL preview cards on Bluesky with their logo, your own accent color and a neat CTA button to View or Subscribe. If you want that too for your articles on your own domain: this guide is for you!
 
-Bluesky [v1.122](https://bsky.app/profile/bsky.app/post/3mmwmla3xph26) now renders Standard.site publications as rich link cards: title, reading time, author, site name, theme colours, and an action button. The card title links to the exact post you shared; the action button (Subscribe / View publication) goes to the publication's home, not that specific post. In the same week, WordPress shipped its [ATmosphere 1.0.0 plugin](https://activitypub.blog/2026/05/20/atmosphere-1-0-0-liftoff/), so a chunk of the open web can now publish as Standard.site too.
+Bluesky [v1.122](https://bsky.app/profile/bsky.app/post/3mmwmla3xph26) now renders Standard.site publications as rich link cards: title, reading time, author, site name, theme colours, and an action button. The card title links to the exact post you shared. The action button (Subscribe / View publication) goes to the publication's home, not that specific post. In the same week, WordPress shipped its [ATmosphere 1.0.0 plugin](https://activitypub.blog/2026/05/20/atmosphere-1-0-0-liftoff/), so a chunk of the open web can now publish as Standard.site too.
 
 > _One thing about the card before you set this up: it has two separate tap targets. The title, image and body go to the post you shared. The filled "Subscribe" / "View publication" button goes to the publication's home instead. That's intended, but it caught me out (the button is the loudest thing on the card, yet it doesn't open the article), so I wrote it up as [a UX issue on social-app](https://github.com/bluesky-social/social-app/issues/10905)._
 
@@ -42,7 +42,7 @@ Three paths:
 
 2. **WordPress with the [ATmosphere plugin](https://activitypub.blog/2026/05/20/atmosphere-1-0-0-liftoff/).** Installing it gives your WP site a Standard.site publication record automatically, with `url` set to your blog. The card's button reads **"View publication"** with a generic arrow icon (your domain isn't on the hardcoded allowlist, so no platform branding). Functionally identical otherwise.
 
-3. **Roll your own.** If you have your own AT Protocol account and a static blog, you publish a `site.standard.publication` record pointing to your domain, plus a `site.standard.document` record per post (its `path` joined to the publication `url` is what Bluesky matches against the shared link). Steve Simkins' [Sequoia CLI](https://sequoia.pub/) is the most common tool for this; he also wrote a [guide on indexing Standard.site records](https://atproto.com/blog/indexing-standard-site) that doubles as a primer on the data model. The card again reads "View publication."
+3. **Roll your own.** If you have your own AT Protocol account and a static blog, you publish a `site.standard.publication` record pointing to your domain, plus a `site.standard.document` record per post (its `path` joined to the publication `url` is what Bluesky matches against the shared link). Steve Simkins' [Sequoia CLI](https://sequoia.pub/) is the most common tool for this. He also wrote a [guide on indexing Standard.site records](https://atproto.com/blog/indexing-standard-site) that doubles as a primer on the data model. The card again reads "View publication."
 
 In all three cases, the card appears in Bluesky once the AppView has indexed the record from the firehose, usually within seconds.
 
@@ -81,7 +81,7 @@ Here's how:
 
 ### Colours: edit the record on pdsls.dev
 
-[pdsls.dev](https://pdsls.dev) is a web UI for browsing and editing AT Protocol records. Log in with your handle + an app password (Bluesky → Settings → App Passwords), navigate to your `site.standard.publication` record, and paste this `basicTheme` block into the existing JSON:
+[pdsls.dev](https://pdsls.dev) is a web UI for browsing and editing AT Protocol records. Log in with your handle + an app password (Bluesky, then Settings, then App Passwords), navigate to your `site.standard.publication` record, and paste this `basicTheme` block into the existing JSON:
 
 ```json
 "basicTheme": {
@@ -208,7 +208,7 @@ Two things Jason flagged from doing it for real: you can't set a per-post author
 Post a link to your publication URL on Bluesky and watch the embed render. If the card doesn't appear:
 
 - Confirm a `site.standard.publication` record actually exists on your account's PDS. You can browse your records with [pdsls.dev](https://pdsls.dev).
-- Confirm its `url` field exactly matches the URL you're linking to. The AppView canonicalises (lowercase host, strip trailing slash, drop query/fragment) but otherwise needs a match. On the Leaflet/pckt/Offprint hosts (and their subdomains) a post link can extend the record URL with extra path segments and still match; everywhere else the publication URL must match exactly, which is why individual posts need their own document record.
+- Confirm its `url` field exactly matches the URL you're linking to. The AppView canonicalises (lowercase host, strip trailing slash, drop query/fragment) but otherwise needs a match. On the Leaflet/pckt/Offprint hosts (and their subdomains) a post link can extend the record URL with extra path segments and still match. Everywhere else the publication URL must match exactly, which is why individual posts need their own document record.
 - Give the firehose a minute to propagate.
 
 That's the entire mechanism. The well-known files have their own value, but they're not on the critical path for the Bluesky card. The publication record is.


### PR DESCRIPTION
Voice-guide review of the 4 most recently published posts, with the P0/P1 fixes applied. Voice targeted: personal "I".

## self-hosted-github-runner-vps
- Typos: "may experience"→"my experience", "setups"→"setup", "independant"→"independent", "becasue"→"because", "cheaper option are"→"options are"
- "Github"→"GitHub" casing (2 spots)
- Split a comma-splice run-on; added a missing end-of-sentence period

## atproto Ep1 & Ep2
- Series footer: dropped the "full disclosure" honesty label → plain parenthetical
- Sifa ID first-mention rule (Ep1 body, Ep2 first mention)
- Ep1: removed "not just X, but Y" construction; "called AT Protocol" (no definite article)
- Semicolons → colons/periods (Guido rarely uses semicolons)

## standard-site-card-on-bluesky
- Unicode arrows (→) → "then" (matches house style)
- Semicolons → periods

## Left as-is (per review scope)
- Bold-inline-header bullets in the runner guide (defensible in a step-by-step)
- Ep1 "However big one looks" (not the contrastive "However,"; lint false positive)
- Ep1 image alt-text listing "Sifa" (describes a diagram tile literally)
- Single technical uses of "complexity"/"navigate"

lint.py: Ep2 clean; remaining flags are the intentionally-left items above.