### PR TITLE
feat(bookshelf): live Bookhive shelves + book suggestions

### DIFF
--- a/src/components/Footer/Footer.astro
+++ b/src/components/Footer/Footer.astro
@@ -33,6 +33,7 @@ const columns: {
       { text: "Events", href: rel("/events") },
       { text: "Projects", href: rel("/projects") },
       { text: "Communities", href: rel("/communities") },
+      { text: "Bookshelf", href: rel("/bookshelf") },
     ],
   },
   {

--- a/src/components/Reading/BookGrid.astro
+++ b/src/components/Reading/BookGrid.astro
@@ -1,0 +1,181 @@
+---
+/**
+ * A grid of Bookhive book covers, in the same visual language as ReadingCard
+ * (tonal accent placeholder when a cover is missing). Each cover links to its
+ * Bookhive page. Used across the /bookshelf sections; pass `showRatings` for the
+ * "read" shelf so finished books surface their star rating.
+ */
+import Stars from "./Stars.astro";
+import type { Book } from "../../lib/bookhive";
+
+interface Props {
+  books: Book[];
+  showRatings?: boolean;
+}
+const { books, showRatings = false } = Astro.props as Props;
+---
+
+<div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
+  {
+    books.map((b) => (
+      <div class="flex flex-col gap-2">
+        <a
+          class={`bk-cover bk-${b.accent} no-random-underline aspect-[2/3] w-full`}
+          href={b.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${b.title} on Bookhive`}
+        >
+          {/* Placeholder always present; the cover image overlays it and, if it
+              fails to load (e.g. a 403 from the catalog's Goodreads URL), the
+              inline script removes it to reveal this. */}
+          <span class="bk-spine" aria-hidden="true" />
+          <div class="bk-meta">
+            <div class="bk-title">{b.title}</div>
+            <div class="bk-author">{b.author}</div>
+          </div>
+          {b.coverUrl && (
+            <img src={b.coverUrl} alt={`Cover of ${b.title}`} loading="lazy" />
+          )}
+        </a>
+        {showRatings && typeof b.rating === "number" && (
+          <Stars value={b.rating} />
+        )}
+      </div>
+    ))
+  }
+</div>
+
+<script>
+  // Drop any cover image that fails to load so the accent placeholder (with the
+  // title) shows through instead of a broken-image icon. Handles images that
+  // already errored before this module ran via the complete/naturalWidth check.
+  const covers = document.querySelectorAll<HTMLImageElement>(".bk-cover img");
+  covers.forEach((img) => {
+    img.addEventListener("error", () => img.remove());
+    if (img.complete && img.naturalWidth === 0) img.remove();
+  });
+</script>
+
+<style>
+  @reference "../../styles/tailwind.css";
+
+  .bk-cover {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    color: #fff;
+    box-shadow: 0 6px 16px -8px rgb(0 0 0 / 0.5);
+    text-decoration: none;
+    transition:
+      transform 0.2s ease,
+      box-shadow 0.2s ease;
+  }
+  a.bk-cover[href] {
+    cursor: pointer;
+  }
+  a.bk-cover[href]:hover,
+  a.bk-cover[href]:focus-visible {
+    transform: translateY(-3px);
+    box-shadow: 0 12px 24px -8px rgb(0 0 0 / 0.55);
+    outline: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .bk-cover {
+      transition: none;
+    }
+    a.bk-cover[href]:hover,
+    a.bk-cover[href]:focus-visible {
+      transform: none;
+    }
+  }
+  .bk-cover img {
+    position: absolute;
+    inset: 0;
+    height: 100%;
+    width: 100%;
+    object-fit: cover;
+  }
+  .bk-cover:not(:has(img)) .bk-meta {
+    position: relative;
+    z-index: 1;
+    padding: 0.6rem 0.65rem;
+    background: linear-gradient(180deg, transparent, rgb(0 0 0 / 0.55));
+  }
+  /* Spine + title only decorate the gradient placeholder; when a real cover is
+     present it sits on top and these would just clutter it. */
+  .bk-cover:has(img) .bk-spine,
+  .bk-cover:has(img) .bk-meta {
+    display: none;
+  }
+  .bk-spine {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 5px;
+    background: rgb(255 255 255 / 0.22);
+    z-index: 1;
+  }
+  .bk-title {
+    font-family: var(--font-display);
+    font-weight: 800;
+    font-size: 0.92rem;
+    line-height: 1.12;
+    letter-spacing: -0.01em;
+    text-shadow: 0 1px 4px rgb(0 0 0 / 0.35);
+  }
+  .bk-author {
+    font-size: 0.68rem;
+    opacity: 0.92;
+    margin-top: 0.18rem;
+    text-shadow: 0 1px 3px rgb(0 0 0 / 0.35);
+  }
+
+  /* Two-tone accent gradients for cover placeholders. */
+  .bk-pine {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-pine) 96%, #000),
+      color-mix(in oklab, var(--color-pine) 48%, #000)
+    );
+  }
+  .bk-iris {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-iris) 92%, #000),
+      color-mix(in oklab, var(--color-iris) 42%, #000)
+    );
+  }
+  .bk-gold {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-gold) 90%, #000),
+      color-mix(in oklab, var(--color-gold) 45%, #000)
+    );
+  }
+  .bk-foam {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-foam) 92%, #000),
+      color-mix(in oklab, var(--color-foam) 45%, #000)
+    );
+  }
+  .bk-love {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-love) 92%, #000),
+      color-mix(in oklab, var(--color-love) 45%, #000)
+    );
+  }
+  .bk-rose {
+    background: linear-gradient(
+      155deg,
+      color-mix(in oklab, var(--color-rose) 90%, #000),
+      color-mix(in oklab, var(--color-rose) 45%, #000)
+    );
+  }
+</style>

--- a/src/components/Reading/SuggestBook.astro
+++ b/src/components/Reading/SuggestBook.astro
@@ -1,0 +1,337 @@
+---
+/**
+ * "Suggest a book" block for /bookshelf.
+ *
+ * Ingest-social, no store to moderate: the suggestion is a normal Bluesky post
+ * that mentions @gui.do. A typeahead (proxied through /api/book-search) lets a
+ * visitor optionally attach the exact Bookhive book — purely a convenience so
+ * Guido doesn't have to look it up. Progressive enhancement: with no JS, the
+ * button is still a plain compose link addressed to @gui.do.
+ */
+const HANDLE = "gui.do";
+
+// No-JS / no-book fallback: a plain compose intent mentioning Guido.
+const fallbackText = `@${HANDLE} a book I think you should read: `;
+const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(fallbackText)}`;
+---
+
+<section class="suggest" aria-labelledby="suggest-heading" data-suggest>
+  <h2 id="suggest-heading" class="suggest-h">Got one I should read?</h2>
+  <p class="suggest-lede text-base-700 dark:text-base-300">
+    Send it my way on Bluesky. Search Bookhive below to attach the exact book if
+    you want (just saves me the lookup), or skip it and describe the book in
+    your own words.
+  </p>
+
+  <div class="suggest-field" hidden data-suggest-field>
+    <label for="book-q" class="sr-only"
+      >Search for a book by title or author</label
+    >
+    <input
+      id="book-q"
+      type="text"
+      class="suggest-input"
+      autocomplete="off"
+      placeholder="Search a book (optional)"
+      role="combobox"
+      aria-expanded="false"
+      aria-controls="book-results"
+      aria-autocomplete="list"
+      data-suggest-input
+    />
+    <ul
+      id="book-results"
+      class="suggest-results"
+      role="listbox"
+      aria-label="Book search results"
+      hidden
+      data-suggest-results
+    >
+    </ul>
+
+    <div class="suggest-selected" hidden data-suggest-selected>
+      <img alt="" class="suggest-selected-cover" data-selected-cover hidden />
+      <span class="suggest-selected-text">
+        <span class="suggest-selected-title" data-selected-title></span>
+        <span class="suggest-selected-author" data-selected-author></span>
+      </span>
+      <button
+        type="button"
+        class="suggest-clear"
+        data-suggest-clear
+        aria-label="Remove selected book"
+      >
+        &times;
+      </button>
+    </div>
+  </div>
+
+  <a
+    class="no-random-underline suggest-button"
+    href={fallbackHref}
+    target="_blank"
+    rel="noopener noreferrer"
+    data-suggest-link
+  >
+    Suggest on Bluesky
+  </a>
+</section>
+
+<script>
+  const HANDLE = "gui.do";
+
+  const root = document.querySelector<HTMLElement>("[data-suggest]");
+  if (root) {
+    const field = root.querySelector<HTMLElement>("[data-suggest-field]");
+    const input = root.querySelector<HTMLInputElement>("[data-suggest-input]");
+    const results = root.querySelector<HTMLUListElement>(
+      "[data-suggest-results]",
+    );
+    const link = root.querySelector<HTMLAnchorElement>("[data-suggest-link]");
+    const selected = root.querySelector<HTMLElement>("[data-suggest-selected]");
+    const selCover = root.querySelector<HTMLImageElement>(
+      "[data-selected-cover]",
+    );
+    const selTitle = root.querySelector<HTMLElement>("[data-selected-title]");
+    const selAuthor = root.querySelector<HTMLElement>("[data-selected-author]");
+    const clearBtn = root.querySelector<HTMLButtonElement>(
+      "[data-suggest-clear]",
+    );
+
+    type Book = {
+      id: string;
+      title: string;
+      author: string;
+      thumbnail: string;
+    };
+
+    if (field && input && results && link) {
+      // JS is on: reveal the optional search field.
+      field.hidden = false;
+
+      const composeUrl = (book: Book | null) => {
+        const text = book
+          ? `@${HANDLE} a book for your want-to-read list: ${book.title}` +
+            (book.author ? ` by ${book.author}` : "") +
+            `\n\nhttps://bookhive.buzz/books/${book.id}`
+          : `@${HANDLE} a book I think you should read: `;
+        return `https://bsky.app/intent/compose?text=${encodeURIComponent(text)}`;
+      };
+
+      let items: Book[] = [];
+      let active = -1;
+      let debounce: number | undefined;
+      let controller: AbortController | null = null;
+
+      const closeList = () => {
+        results.hidden = true;
+        results.innerHTML = "";
+        input.setAttribute("aria-expanded", "false");
+        input.removeAttribute("aria-activedescendant");
+        items = [];
+        active = -1;
+      };
+
+      const selectBook = (book: Book) => {
+        link.href = composeUrl(book);
+        link.textContent = "Suggest this book on Bluesky";
+        if (selected && selTitle && selAuthor) {
+          selTitle.textContent = book.title;
+          selAuthor.textContent = book.author ? `by ${book.author}` : "";
+          if (selCover) {
+            if (book.thumbnail) {
+              selCover.src = book.thumbnail;
+              selCover.hidden = false;
+            } else {
+              selCover.hidden = true;
+            }
+          }
+          selected.hidden = false;
+        }
+        input.value = "";
+        closeList();
+      };
+
+      const clearBook = () => {
+        link.href = composeUrl(null);
+        link.textContent = "Suggest on Bluesky";
+        if (selected) selected.hidden = true;
+        input.focus();
+      };
+
+      const render = () => {
+        results.innerHTML = "";
+        items.forEach((book, i) => {
+          const li = document.createElement("li");
+          li.role = "option";
+          li.id = `book-opt-${i}`;
+          li.className = "suggest-option";
+          li.setAttribute("aria-selected", String(i === active));
+          if (book.thumbnail) {
+            const img = document.createElement("img");
+            img.src = book.thumbnail;
+            img.alt = "";
+            img.className = "suggest-option-cover";
+            img.loading = "lazy";
+            li.appendChild(img);
+          }
+          const txt = document.createElement("span");
+          txt.className = "suggest-option-text";
+          const t = document.createElement("span");
+          t.className = "suggest-option-title";
+          t.textContent = book.title;
+          const a = document.createElement("span");
+          a.className = "suggest-option-author";
+          a.textContent = book.author;
+          txt.append(t, a);
+          li.appendChild(txt);
+          li.addEventListener("mousedown", (e) => {
+            e.preventDefault();
+            selectBook(book);
+          });
+          results.appendChild(li);
+        });
+        results.hidden = items.length === 0;
+        input.setAttribute("aria-expanded", String(items.length > 0));
+      };
+
+      const search = async (q: string) => {
+        controller?.abort();
+        controller = new AbortController();
+        try {
+          // Trailing slash required — the site uses trailingSlash: "always",
+          // so `/api/book-search?q=` would 404-redirect and drop the query.
+          const res = await fetch(
+            `/api/book-search/?q=${encodeURIComponent(q)}`,
+            { signal: controller.signal },
+          );
+          if (!res.ok) return closeList();
+          const data = (await res.json()) as { books?: Book[] };
+          items = data.books ?? [];
+          active = -1;
+          render();
+        } catch (err) {
+          if ((err as Error).name !== "AbortError") closeList();
+        }
+      };
+
+      input.addEventListener("input", () => {
+        const q = input.value.trim();
+        window.clearTimeout(debounce);
+        if (q.length < 2) return closeList();
+        debounce = window.setTimeout(() => search(q), 250);
+      });
+
+      input.addEventListener("keydown", (e) => {
+        if (results.hidden || items.length === 0) return;
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          active = (active + 1) % items.length;
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          active = (active - 1 + items.length) % items.length;
+        } else if (e.key === "Enter") {
+          if (active >= 0) {
+            e.preventDefault();
+            selectBook(items[active]);
+          }
+          return;
+        } else if (e.key === "Escape") {
+          closeList();
+          return;
+        } else {
+          return;
+        }
+        const nodes =
+          results.querySelectorAll<HTMLLIElement>(".suggest-option");
+        nodes.forEach((n, i) =>
+          n.setAttribute("aria-selected", String(i === active)),
+        );
+        if (active >= 0)
+          input.setAttribute("aria-activedescendant", `book-opt-${active}`);
+      });
+
+      input.addEventListener("blur", () => {
+        // Delay so a click on an option registers before the list closes.
+        window.setTimeout(closeList, 120);
+      });
+
+      clearBtn?.addEventListener("click", clearBook);
+    }
+  }
+</script>
+
+<style>
+  @reference "../../styles/tailwind.css";
+
+  .suggest {
+    @apply bg-base-50 dark:bg-base-900 border-base-200 dark:border-base-800 mt-12 rounded-2xl border p-6 shadow-sm md:p-7;
+  }
+  .suggest-h {
+    @apply text-base-950 dark:text-base-50 font-display mb-2 text-[1.4rem] font-black tracking-[-0.02em];
+  }
+  .suggest-lede {
+    @apply max-w-2xl text-[.98rem] leading-relaxed;
+  }
+
+  .suggest-field {
+    @apply relative mt-5 max-w-md;
+  }
+  .suggest-input {
+    @apply border-base-300 dark:border-base-700 bg-base-100 dark:bg-base-950 text-base-900 dark:text-base-100 placeholder:text-base-500 focus:ring-primary-500 w-full rounded-lg border px-4 py-2.5 text-[.95rem] focus:ring-2 focus:outline-hidden;
+  }
+
+  .suggest-results {
+    @apply border-base-200 dark:border-base-700 bg-base-50 dark:bg-base-900 absolute z-20 mt-1 max-h-80 w-full overflow-y-auto rounded-lg border shadow-lg;
+    list-style: none;
+    padding: 0.25rem;
+    margin-bottom: 0;
+  }
+  .suggest-option {
+    @apply text-base-800 dark:text-base-200 flex cursor-pointer items-center gap-3 rounded-md px-2.5 py-2;
+  }
+  .suggest-option[aria-selected="true"],
+  .suggest-option:hover {
+    @apply bg-base-200/70 dark:bg-base-800/70;
+  }
+  .suggest-option-cover {
+    @apply h-12 w-8 flex-none rounded-sm object-cover;
+    background: var(--color-base-200);
+  }
+  .suggest-option-text {
+    @apply flex min-w-0 flex-col;
+  }
+  .suggest-option-title {
+    @apply truncate text-[.9rem] font-semibold;
+  }
+  .suggest-option-author {
+    @apply text-base-500 dark:text-base-400 truncate text-[.78rem];
+  }
+
+  .suggest-selected {
+    @apply border-primary-300 dark:border-primary-800 bg-primary-50 dark:bg-primary-950/40 mt-3 flex items-center gap-3 rounded-lg border px-3 py-2;
+  }
+  .suggest-selected-cover {
+    @apply h-12 w-8 flex-none rounded-sm object-cover;
+  }
+  .suggest-selected-text {
+    @apply flex min-w-0 flex-col;
+  }
+  .suggest-selected-title {
+    @apply text-base-900 dark:text-base-100 truncate text-[.9rem] font-semibold;
+  }
+  .suggest-selected-author {
+    @apply text-base-500 dark:text-base-400 truncate text-[.78rem];
+  }
+  .suggest-clear {
+    @apply text-base-500 hover:text-base-900 dark:hover:text-base-100 focus:ring-primary-500 ml-auto flex-none rounded-md px-2 text-xl leading-none focus:ring-2 focus:outline-hidden;
+  }
+
+  /* Primary CTA — mirrors the site's Button--primary (bg-primary-600 + white),
+     kept local because those styles are scoped to the Button component. The
+     "button" in the class name also opts it out of the global link-colouring
+     rule in links.scss (its :not([class*="button"]) carve-out). */
+  .suggest-button {
+    @apply bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500 dark:bg-primary-500 dark:hover:bg-primary-400 dark:text-base-100 mt-5 inline-flex items-center justify-center rounded-md px-7 py-3 font-medium text-white shadow-md transition focus:outline-hidden focus-visible:ring-2;
+  }
+</style>

--- a/src/components/Reading/SuggestBook.astro
+++ b/src/components/Reading/SuggestBook.astro
@@ -49,6 +49,14 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
     >
     </ul>
 
+    <p
+      class="suggest-status text-base-500 dark:text-base-400"
+      hidden
+      aria-live="polite"
+      data-suggest-status
+    >
+    </p>
+
     <div class="suggest-selected" hidden data-suggest-selected>
       <img alt="" class="suggest-selected-cover" data-selected-cover hidden />
       <span class="suggest-selected-text">
@@ -97,6 +105,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
     const clearBtn = root.querySelector<HTMLButtonElement>(
       "[data-suggest-clear]",
     );
+    const status = root.querySelector<HTMLElement>("[data-suggest-status]");
 
     type Book = {
       id: string;
@@ -122,6 +131,20 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
       let active = -1;
       let debounce: number | undefined;
       let controller: AbortController | null = null;
+
+      const UNAVAILABLE =
+        "Book search isn't available right now. Just hit the button and tell me in your own words.";
+      const NO_MATCH =
+        "No matches on Bookhive. Hit the button and describe it in your own words.";
+
+      const showStatus = (msg: string) => {
+        if (!status) return;
+        status.textContent = msg;
+        status.hidden = false;
+      };
+      const hideStatus = () => {
+        if (status) status.hidden = true;
+      };
 
       const closeList = () => {
         results.hidden = true;
@@ -149,6 +172,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
           selected.hidden = false;
         }
         input.value = "";
+        hideStatus();
         closeList();
       };
 
@@ -156,6 +180,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
         link.href = composeUrl(null);
         link.textContent = "Suggest on Bluesky";
         if (selected) selected.hidden = true;
+        hideStatus();
         input.focus();
       };
 
@@ -205,20 +230,33 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
             `/api/book-search/?q=${encodeURIComponent(q)}`,
             { signal: controller.signal },
           );
-          if (!res.ok) return closeList();
+          if (!res.ok) {
+            items = [];
+            render();
+            return showStatus(UNAVAILABLE);
+          }
           const data = (await res.json()) as { books?: Book[] };
           items = data.books ?? [];
           active = -1;
           render();
+          if (items.length === 0) showStatus(NO_MATCH);
+          else hideStatus();
         } catch (err) {
-          if ((err as Error).name !== "AbortError") closeList();
+          if ((err as Error).name !== "AbortError") {
+            items = [];
+            render();
+            showStatus(UNAVAILABLE);
+          }
         }
       };
 
       input.addEventListener("input", () => {
         const q = input.value.trim();
         window.clearTimeout(debounce);
-        if (q.length < 2) return closeList();
+        if (q.length < 2) {
+          hideStatus();
+          return closeList();
+        }
         debounce = window.setTimeout(() => search(q), 250);
       });
 
@@ -306,6 +344,10 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
   }
   .suggest-option-author {
     @apply text-base-500 dark:text-base-400 truncate text-[.78rem];
+  }
+
+  .suggest-status {
+    @apply mt-2 text-[.85rem];
   }
 
   .suggest-selected {

--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -1,5 +1,6 @@
 /**
- * Bookhive reading data for the /now page.
+ * Bookhive reading data for the /now page (currently-reading + recently-read)
+ * and the /bookshelf page (the "want to read" list).
  *
  * Ingests Guido's `buzz.bookhive.book` records from his PDS (read-only, no auth)
  * and resolves genres from the shared Bookhive catalog so the card can show
@@ -18,6 +19,7 @@ const CATALOG_PDS = "https://bluesky.nickthesick.com";
 const BOOK_COLLECTION = "buzz.bookhive.book";
 const STATUS_READING = "buzz.bookhive.defs#reading";
 const STATUS_FINISHED = "buzz.bookhive.defs#finished";
+const STATUS_WANT = "buzz.bookhive.defs#wantToRead";
 
 // Genres that mark a title as fiction (excluded from the non-fiction card).
 const FICTION_GENRES = new Set([
@@ -197,5 +199,54 @@ export async function getReading(): Promise<ReadingData> {
     return { active, recent };
   } catch {
     return { active: [], recent: [] };
+  }
+}
+
+export interface BookshelfData {
+  /** Currently reading, any genre. */
+  active: Book[];
+  /** "Want to read", newest first, any genre — the aspirational shelf. */
+  wantToRead: Book[];
+  /** Recently finished, newest first, any genre (fiction included here). */
+  finished: Book[];
+}
+
+// Caps bound the per-render catalog lookups (covers/genres). Want-to-read is
+// the point of /bookshelf, so it's the most generous; the "read" shelf shows a
+// recent slice with a "See all on Bookhive" link for the rest.
+const WANT_CAP = 60;
+const FINISHED_SHELF_CAP = 24;
+
+// Full bookshelf for /bookshelf: currently-reading + want-to-read + recently
+// read. Genre-agnostic across the board (unlike the /now card, this is the
+// whole shelf). One listBooks call, three buckets, each enriched for covers.
+// The list stays owned on Bookhive/PDS — this is an ingested view of it.
+export async function getBookshelf(): Promise<BookshelfData> {
+  try {
+    const books = await listBooks();
+
+    const byNewest =
+      (key: "createdAt" | "finishedAt") => (a: RawBook, b: RawBook) =>
+        (b.value[key] ?? "").localeCompare(a.value[key] ?? "");
+
+    const reading = books.filter((b) => b.value.status === STATUS_READING);
+    const wanted = books
+      .filter((b) => b.value.status === STATUS_WANT)
+      .sort(byNewest("createdAt"))
+      .slice(0, WANT_CAP);
+    const read = books
+      .filter((b) => b.value.status === STATUS_FINISHED)
+      .sort(byNewest("finishedAt"))
+      .slice(0, FINISHED_SHELF_CAP);
+
+    const [active, wantToRead, finished] = await Promise.all([
+      enrich(reading).then((e) => e.map(mapBook)),
+      enrich(wanted).then((e) => e.map(mapBook)),
+      enrich(read).then((e) => e.map(mapBook)),
+    ]);
+
+    return { active, wantToRead, finished };
+  } catch {
+    return { active: [], wantToRead: [], finished: [] };
   }
 }

--- a/src/pages/api/book-search.ts
+++ b/src/pages/api/book-search.ts
@@ -1,0 +1,63 @@
+// Same-origin proxy for Bookhive's book search, used by the /bookshelf
+// "suggest a book" typeahead. Bookhive's `searchBooks` XRPC works but sends no
+// CORS header, so the browser can't call it from gui.do directly — this endpoint
+// fetches it server-side and returns a trimmed, stable shape. Read-only, no auth.
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+const BOOKHIVE_SEARCH = "https://bookhive.buzz/xrpc/buzz.bookhive.searchBooks";
+const MAX_RESULTS = 8;
+
+interface HiveBook {
+  id?: string;
+  title?: string;
+  authors?: string;
+  thumbnail?: string;
+  cover?: string;
+}
+
+export const GET: APIRoute = async ({ url }) => {
+  const q = (url.searchParams.get("q") ?? "").trim();
+
+  // Too short to be a meaningful search — return empty rather than hammering
+  // Bookhive on every keystroke.
+  if (q.length < 2) {
+    return json({ books: [] });
+  }
+
+  try {
+    const res = await fetch(`${BOOKHIVE_SEARCH}?q=${encodeURIComponent(q)}`, {
+      signal: AbortSignal.timeout(6000),
+    });
+    if (!res.ok) return json({ books: [] });
+
+    const data = (await res.json()) as { books?: HiveBook[] };
+    const books = (data.books ?? [])
+      .filter((b) => b.id && b.title)
+      .slice(0, MAX_RESULTS)
+      .map((b) => ({
+        id: b.id,
+        title: b.title,
+        author: b.authors ?? "",
+        thumbnail: b.thumbnail ?? b.cover ?? "",
+      }));
+
+    return json({ books });
+  } catch {
+    // Network/timeout — the client falls back to a plain suggest link.
+    return json({ books: [] });
+  }
+};
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "Content-Type": "application/json",
+      // Short edge cache: identical queries are cheap to reuse, but the shelf
+      // stays fresh as Bookhive's catalog grows.
+      "Netlify-CDN-Cache-Control":
+        "public, s-maxage=600, stale-while-revalidate=3600",
+    },
+  });
+}

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -29,7 +29,7 @@ const nothing =
 
 <BaseLayout
   title="Bookshelf"
-  description="What Guido is reading now, wants to read next, and recently finished — pulled live from Bookhive. Suggest a book while you're here."
+  description="What Guido is reading now, wants to read next, and recently finished, pulled live from Bookhive. Suggest a book while you're here."
 >
   <section class="mt-24 w-full px-4">
     <div class="mx-auto max-w-5xl">
@@ -59,27 +59,54 @@ const nothing =
         ) : (
           <div class="flex flex-col gap-12">
             {active.length > 0 && (
-              <section aria-labelledby="shelf-reading">
+              <section
+                id="reading-now"
+                class="shelf-section"
+                aria-labelledby="shelf-reading"
+              >
                 <h2 id="shelf-reading" class="shelf-h">
-                  Reading now
+                  <a
+                    href="#reading-now"
+                    class="shelf-anchor no-random-underline"
+                  >
+                    Reading now
+                  </a>
                 </h2>
                 <BookGrid books={active} />
               </section>
             )}
 
             {wantToRead.length > 0 && (
-              <section aria-labelledby="shelf-want">
+              <section
+                id="want-to-read"
+                class="shelf-section"
+                aria-labelledby="shelf-want"
+              >
                 <h2 id="shelf-want" class="shelf-h">
-                  Want to read
+                  <a
+                    href="#want-to-read"
+                    class="shelf-anchor no-random-underline"
+                  >
+                    Want to read
+                  </a>
                 </h2>
                 <BookGrid books={wantToRead} />
               </section>
             )}
 
             {finished.length > 0 && (
-              <section aria-labelledby="shelf-read">
+              <section
+                id="recently-read"
+                class="shelf-section"
+                aria-labelledby="shelf-read"
+              >
                 <h2 id="shelf-read" class="shelf-h">
-                  Recently read
+                  <a
+                    href="#recently-read"
+                    class="shelf-anchor no-random-underline"
+                  >
+                    Recently read
+                  </a>
                 </h2>
                 <BookGrid books={finished} showRatings />
               </section>
@@ -109,8 +136,24 @@ const nothing =
 <style>
   @reference "../styles/tailwind.css";
 
+  /* Offset the scroll target so a deep-link (#want-to-read) doesn't tuck the
+     heading under the fixed nav. */
+  .shelf-section {
+    scroll-margin-top: 6rem;
+  }
   .shelf-h {
     @apply text-base-950 dark:text-base-50 font-display mb-4 text-[1.4rem] font-black tracking-[-0.02em];
+  }
+  /* The heading links to its own section so the anchor is copyable; keep the
+     heading's colour and only surface an underline on hover/focus. */
+  .shelf-anchor {
+    color: inherit;
+  }
+  .shelf-anchor:hover,
+  .shelf-anchor:focus-visible {
+    text-decoration: underline;
+    text-underline-offset: 0.15em;
+    text-decoration-thickness: 2px;
   }
   .shelf-more {
     @apply text-primary-600 dark:text-primary-400 mt-8 inline-flex items-center gap-1 self-start text-[0.9rem] font-semibold;

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -1,0 +1,126 @@
+---
+// /bookshelf — Guido's full Bookhive shelf, ingested live: what he's reading
+// now, the "want to read" pile, and recently-read titles — plus a low-friction
+// way for visitors to suggest a book (a Bluesky mention, optionally with a
+// Bookhive book attached via the /api/book-search typeahead). The list stays
+// owned on Bookhive/PDS; this page is an ingested view of it.
+import BaseLayout from "@layouts/BaseLayout.astro";
+import BookGrid from "@components/Reading/BookGrid.astro";
+import SuggestBook from "@components/Reading/SuggestBook.astro";
+import { getBookshelf } from "../lib/bookhive";
+
+// SSR + CDN stale-while-revalidate, mirroring /now: the shelves stay fresh as
+// the Bookhive list changes, without needing a rebuild.
+export const prerender = false;
+Astro.response.headers.set(
+  "Netlify-CDN-Cache-Control",
+  "public, s-maxage=300, stale-while-revalidate=86400",
+);
+Astro.response.headers.set(
+  "Cache-Control",
+  "public, max-age=0, must-revalidate",
+);
+
+const { active, wantToRead, finished } = await getBookshelf();
+const bookhiveHref = "https://bookhive.buzz/profile/gui.do";
+const nothing =
+  active.length === 0 && wantToRead.length === 0 && finished.length === 0;
+---
+
+<BaseLayout
+  title="Bookshelf"
+  description="What Guido is reading now, wants to read next, and recently finished — pulled live from Bookhive. Suggest a book while you're here."
+>
+  <section class="mt-24 w-full px-4">
+    <div class="mx-auto max-w-5xl">
+      <header class="mb-10">
+        <p
+          class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.5rem] leading-none"
+        >
+          the whole shelf
+        </p>
+        <h1 class="h1 mt-2">Bookshelf</h1>
+        <p
+          class="text-base-700 dark:text-base-300 mt-3 max-w-2xl text-lg leading-relaxed"
+        >
+          What I&rsquo;m reading now, what I want to read next, and what I
+          recently finished, pulled straight from my Bookhive shelf. Fair
+          warning: the to-read pile grows faster than I get through it. Spot a
+          favourite of yours, or think I&rsquo;m missing an obvious one? Suggest
+          it at the bottom.
+        </p>
+      </header>
+
+      {
+        nothing ? (
+          <p class="text-base-500 dark:text-base-400 text-[.94rem]">
+            The shelf is taking a breather. Check back soon.
+          </p>
+        ) : (
+          <div class="flex flex-col gap-12">
+            {active.length > 0 && (
+              <section aria-labelledby="shelf-reading">
+                <h2 id="shelf-reading" class="shelf-h">
+                  Reading now
+                </h2>
+                <BookGrid books={active} />
+              </section>
+            )}
+
+            {wantToRead.length > 0 && (
+              <section aria-labelledby="shelf-want">
+                <h2 id="shelf-want" class="shelf-h">
+                  Want to read
+                </h2>
+                <BookGrid books={wantToRead} />
+              </section>
+            )}
+
+            {finished.length > 0 && (
+              <section aria-labelledby="shelf-read">
+                <h2 id="shelf-read" class="shelf-h">
+                  Recently read
+                </h2>
+                <BookGrid books={finished} showRatings />
+              </section>
+            )}
+          </div>
+        )
+      }
+
+      <a
+        href={bookhiveHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="shelf-more no-random-underline"
+      >
+        <span class="underline underline-offset-2"
+          >See the full shelf on Bookhive</span
+        >
+        <span class="shelf-more-arrow" aria-hidden="true">&rarr;</span>
+        <span class="sr-only">(opens in new tab)</span>
+      </a>
+
+      <SuggestBook />
+    </div>
+  </section>
+</BaseLayout>
+
+<style>
+  @reference "../styles/tailwind.css";
+
+  .shelf-h {
+    @apply text-base-950 dark:text-base-50 font-display mb-4 text-[1.4rem] font-black tracking-[-0.02em];
+  }
+  .shelf-more {
+    @apply text-primary-600 dark:text-primary-400 mt-8 inline-flex items-center gap-1 self-start text-[0.9rem] font-semibold;
+    text-decoration: none;
+  }
+  .shelf-more-arrow {
+    transition: transform 0.2s ease;
+  }
+  .shelf-more:hover .shelf-more-arrow,
+  .shelf-more:focus-visible .shelf-more-arrow {
+    transform: translateX(2px);
+  }
+</style>


### PR DESCRIPTION
New `/bookshelf` page: a live view of my Bookhive shelf plus a way for visitors to suggest a book.

## What's on the page
- **Reading now**, **Want to read**, and **Recently read** (with star ratings), all ingested live from Bookhive via the same read-only PDS + catalog pattern as the `/now` reading card. The list stays owned on Bookhive; this is an ingested view.
- **Suggest a book**: a "Suggest on Bluesky" button that opens a compose intent mentioning `@gui.do`. An optional Bookhive typeahead lets someone attach the exact title, which pre-fills the post with the book's Bookhive link. Progressive enhancement: without JS the button is a plain compose link.
- Deep-link anchors: `#reading-now`, `#want-to-read`, `#recently-read`. Headings are copyable self-links.
- Linked from the footer (Creations).

## Notable engineering
- **`/api/book-search` SSR proxy**: Bookhive's `searchBooks` XRPC works but sends no CORS header, so the browser can't call it directly. A same-origin proxy solves it and keeps Bookhive's shape hidden. It needs the SSR runtime (dev / Netlify), so this deploy preview is the place to confirm the live search.
- Covers fall back to a tonal placeholder when a catalog image 404s.
- Search failures surface a visible hint (no matches / unavailable) instead of failing silently.

## Verification
- Typeahead, book selection, compose-URL building, clear, deep-link anchors, and cover fallback all driven end-to-end in a real browser.
- Typecheck clean (the pre-existing `sifa-sdk` resolution errors are unrelated).
