### PR TITLE
feat(bookshelf): reorder shelves, read-count teaser, dropdown fixes

### DIFF
--- a/src/components/Reading/BookGrid.astro
+++ b/src/components/Reading/BookGrid.astro
@@ -6,45 +6,76 @@
  * "read" shelf so finished books surface their star rating.
  */
 import Stars from "./Stars.astro";
-import type { Book } from "../../lib/bookhive";
+import type { Book, BookAccent } from "../../lib/bookhive";
 
 interface Props {
-  books: Book[];
+  books?: Book[];
   showRatings?: boolean;
+  /** Render this many faded "mystery" tiles instead of books, as a teaser that
+   *  there are more books than the shelf shows. */
+  mystery?: number;
 }
-const { books, showRatings = false } = Astro.props as Props;
+const { books = [], showRatings = false, mystery = 0 } = Astro.props as Props;
+
+const MYSTERY_ACCENTS: BookAccent[] = [
+  "pine",
+  "iris",
+  "gold",
+  "foam",
+  "love",
+  "rose",
+];
 ---
 
-<div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
-  {
-    books.map((b) => (
-      <div class="flex flex-col gap-2">
-        <a
-          class={`bk-cover bk-${b.accent} no-random-underline aspect-[2/3] w-full`}
-          href={b.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label={`${b.title} on Bookhive`}
+{
+  mystery > 0 ? (
+    <div
+      class="bookgrid-mystery grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4"
+      aria-hidden="true"
+    >
+      {Array.from({ length: mystery }).map((_, i) => (
+        <div
+          class={`bk-cover bk-${MYSTERY_ACCENTS[i % MYSTERY_ACCENTS.length]} bk-mystery aspect-[2/3] w-full`}
         >
-          {/* Placeholder always present; the cover image overlays it and, if it
-              fails to load (e.g. a 403 from the catalog's Goodreads URL), the
-              inline script removes it to reveal this. */}
-          <span class="bk-spine" aria-hidden="true" />
-          <div class="bk-meta">
-            <div class="bk-title">{b.title}</div>
-            <div class="bk-author">{b.author}</div>
-          </div>
-          {b.coverUrl && (
-            <img src={b.coverUrl} alt={`Cover of ${b.title}`} loading="lazy" />
+          <span class="bk-q">?</span>
+        </div>
+      ))}
+    </div>
+  ) : (
+    <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
+      {books.map((b) => (
+        <div class="flex flex-col gap-2">
+          <a
+            class={`bk-cover bk-${b.accent} no-random-underline aspect-[2/3] w-full`}
+            href={b.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${b.title} on Bookhive`}
+          >
+            {/* Placeholder always present; the cover image overlays it and, if it
+                fails to load (e.g. a 403 from the catalog's Goodreads URL), the
+                inline script removes it to reveal this. */}
+            <span class="bk-spine" aria-hidden="true" />
+            <div class="bk-meta">
+              <div class="bk-title">{b.title}</div>
+              <div class="bk-author">{b.author}</div>
+            </div>
+            {b.coverUrl && (
+              <img
+                src={b.coverUrl}
+                alt={`Cover of ${b.title}`}
+                loading="lazy"
+              />
+            )}
+          </a>
+          {showRatings && typeof b.rating === "number" && (
+            <Stars value={b.rating} />
           )}
-        </a>
-        {showRatings && typeof b.rating === "number" && (
-          <Stars value={b.rating} />
-        )}
-      </div>
-    ))
-  }
-</div>
+        </div>
+      ))}
+    </div>
+  )
+}
 
 <script>
   // Drop any cover image that fails to load so the accent placeholder (with the
@@ -59,6 +90,25 @@ const { books, showRatings = false } = Astro.props as Props;
 
 <style>
   @reference "../../styles/tailwind.css";
+
+  /* Teaser row: faded accent tiles with a "?", dissolving downward to imply the
+     shelf continues on Bookhive. Decorative, so aria-hidden and non-interactive. */
+  .bookgrid-mystery {
+    -webkit-mask-image: linear-gradient(to bottom, #000 45%, transparent);
+    mask-image: linear-gradient(to bottom, #000 45%, transparent);
+    pointer-events: none;
+  }
+  .bk-mystery {
+    align-items: center;
+    justify-content: center;
+    opacity: 0.6;
+  }
+  .bk-q {
+    font-family: var(--font-display);
+    font-size: 2rem;
+    font-weight: 800;
+    color: rgb(255 255 255 / 0.6);
+  }
 
   .bk-cover {
     position: relative;

--- a/src/components/Reading/BookGrid.astro
+++ b/src/components/Reading/BookGrid.astro
@@ -11,8 +11,8 @@ import type { Book, BookAccent } from "../../lib/bookhive";
 interface Props {
   books?: Book[];
   showRatings?: boolean;
-  /** Render this many faded "mystery" tiles instead of books, as a teaser that
-   *  there are more books than the shelf shows. */
+  /** Append this many faded "mystery" tiles after the books, in the SAME grid,
+   *  so they read as a continuation of the shelf (there are more on Bookhive). */
   mystery?: number;
 }
 const { books = [], showRatings = false, mystery = 0 } = Astro.props as Props;
@@ -27,55 +27,47 @@ const MYSTERY_ACCENTS: BookAccent[] = [
 ];
 ---
 
-{
-  mystery > 0 ? (
-    <div
-      class="bookgrid-mystery grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4"
-      aria-hidden="true"
-    >
-      {Array.from({ length: mystery }).map((_, i) => (
+<div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
+  {
+    books.map((b) => (
+      <div class="flex flex-col gap-2">
+        <a
+          class={`bk-cover bk-${b.accent} no-random-underline aspect-[2/3] w-full`}
+          href={b.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${b.title} on Bookhive`}
+        >
+          {/* Placeholder always present; the cover image overlays it and, if it
+              fails to load (e.g. a 403 from the catalog's Goodreads URL), the
+              inline script removes it to reveal this. */}
+          <span class="bk-spine" aria-hidden="true" />
+          <div class="bk-meta">
+            <div class="bk-title">{b.title}</div>
+            <div class="bk-author">{b.author}</div>
+          </div>
+          {b.coverUrl && (
+            <img src={b.coverUrl} alt={`Cover of ${b.title}`} loading="lazy" />
+          )}
+        </a>
+        {showRatings && typeof b.rating === "number" && (
+          <Stars value={b.rating} />
+        )}
+      </div>
+    ))
+  }
+  {
+    Array.from({ length: mystery }).map((_, i) => (
+      <div class="flex flex-col gap-2" aria-hidden="true">
         <div
           class={`bk-cover bk-${MYSTERY_ACCENTS[i % MYSTERY_ACCENTS.length]} bk-mystery aspect-[2/3] w-full`}
         >
           <span class="bk-q">?</span>
         </div>
-      ))}
-    </div>
-  ) : (
-    <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
-      {books.map((b) => (
-        <div class="flex flex-col gap-2">
-          <a
-            class={`bk-cover bk-${b.accent} no-random-underline aspect-[2/3] w-full`}
-            href={b.href}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={`${b.title} on Bookhive`}
-          >
-            {/* Placeholder always present; the cover image overlays it and, if it
-                fails to load (e.g. a 403 from the catalog's Goodreads URL), the
-                inline script removes it to reveal this. */}
-            <span class="bk-spine" aria-hidden="true" />
-            <div class="bk-meta">
-              <div class="bk-title">{b.title}</div>
-              <div class="bk-author">{b.author}</div>
-            </div>
-            {b.coverUrl && (
-              <img
-                src={b.coverUrl}
-                alt={`Cover of ${b.title}`}
-                loading="lazy"
-              />
-            )}
-          </a>
-          {showRatings && typeof b.rating === "number" && (
-            <Stars value={b.rating} />
-          )}
-        </div>
-      ))}
-    </div>
-  )
-}
+      </div>
+    ))
+  }
+</div>
 
 <script>
   // Drop any cover image that fails to load so the accent placeholder (with the
@@ -91,17 +83,13 @@ const MYSTERY_ACCENTS: BookAccent[] = [
 <style>
   @reference "../../styles/tailwind.css";
 
-  /* Teaser row: faded accent tiles with a "?", dissolving downward to imply the
-     shelf continues on Bookhive. Decorative, so aria-hidden and non-interactive. */
-  .bookgrid-mystery {
-    -webkit-mask-image: linear-gradient(to bottom, #000 45%, transparent);
-    mask-image: linear-gradient(to bottom, #000 45%, transparent);
-    pointer-events: none;
-  }
+  /* Faded accent tiles with a "?" that trail the real covers in the same grid,
+     implying the shelf continues on Bookhive. Decorative (aria-hidden upstream). */
   .bk-mystery {
     align-items: center;
     justify-content: center;
-    opacity: 0.6;
+    opacity: 0.55;
+    pointer-events: none;
   }
   .bk-q {
     font-family: var(--font-display);

--- a/src/components/Reading/SuggestBook.astro
+++ b/src/components/Reading/SuggestBook.astro
@@ -218,6 +218,24 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
         });
         results.hidden = items.length === 0;
         input.setAttribute("aria-expanded", String(items.length > 0));
+        if (items.length > 0) placeResults();
+      };
+
+      // The suggest box sits near the page bottom, above a footer that lives in
+      // a separate stacking context (it wins over the dropdown no matter its
+      // z-index). Measure the gap to the footer (not just the viewport) and open
+      // the list upward when it wouldn't fit below — so it never tucks under it.
+      const footerEl = document.querySelector("footer");
+      const DROPDOWN_MAX = 340; // ~max-h-80 + margin
+      const placeResults = () => {
+        const inputBottom = input.getBoundingClientRect().bottom;
+        const limit = footerEl
+          ? footerEl.getBoundingClientRect().top
+          : window.innerHeight;
+        results.classList.toggle(
+          "suggest-results--up",
+          limit - inputBottom < DROPDOWN_MAX,
+        );
       };
 
       const search = async (q: string) => {
@@ -309,7 +327,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
     @apply text-base-950 dark:text-base-50 font-display mb-2 text-[1.4rem] font-black tracking-[-0.02em];
   }
   .suggest-lede {
-    @apply max-w-2xl text-[.98rem] leading-relaxed;
+    @apply text-[.98rem] leading-relaxed;
   }
 
   .suggest-field {
@@ -319,31 +337,44 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
     @apply border-base-300 dark:border-base-700 bg-base-100 dark:bg-base-950 text-base-900 dark:text-base-100 placeholder:text-base-500 focus:ring-primary-500 w-full rounded-lg border px-4 py-2.5 text-[.95rem] focus:ring-2 focus:outline-hidden;
   }
 
+  /* z-50 keeps the dropdown above the footer (which sits in its own stacking
+     context via backdrop-blur) when the suggest box is near the page bottom. */
   .suggest-results {
-    @apply border-base-200 dark:border-base-700 bg-base-50 dark:bg-base-900 absolute z-20 mt-1 max-h-80 w-full overflow-y-auto rounded-lg border shadow-lg;
+    @apply border-base-200 dark:border-base-700 bg-base-50 dark:bg-base-900 absolute z-50 mt-1 max-h-80 w-full overflow-y-auto rounded-lg border shadow-lg;
     list-style: none;
     padding: 0.25rem;
     margin-bottom: 0;
   }
-  .suggest-option {
+  /* Open above the input when there's no room below (keeps it clear of the
+     footer, which sits in its own stacking context and would otherwise cover
+     the lower results). */
+  .suggest-results--up {
+    top: auto;
+    bottom: 100%;
+    margin-top: 0;
+    margin-bottom: 0.25rem;
+  }
+  /* Options are created in JS, so Astro's scoped selectors don't match them.
+     Scope these globally under the (template-scoped) results container. */
+  .suggest-results :global(.suggest-option) {
     @apply text-base-800 dark:text-base-200 flex cursor-pointer items-center gap-3 rounded-md px-2.5 py-2;
   }
-  .suggest-option[aria-selected="true"],
-  .suggest-option:hover {
+  .suggest-results :global(.suggest-option[aria-selected="true"]),
+  .suggest-results :global(.suggest-option:hover) {
     @apply bg-base-200/70 dark:bg-base-800/70;
   }
-  .suggest-option-cover {
+  .suggest-results :global(.suggest-option-cover) {
     @apply h-12 w-8 flex-none rounded-sm object-cover;
     background: var(--color-base-200);
   }
-  .suggest-option-text {
-    @apply flex min-w-0 flex-col;
+  .suggest-results :global(.suggest-option-text) {
+    @apply flex min-w-0 flex-col gap-0.5;
   }
-  .suggest-option-title {
-    @apply truncate text-[.9rem] font-semibold;
+  .suggest-results :global(.suggest-option-title) {
+    @apply truncate text-[.9rem] leading-tight font-semibold;
   }
-  .suggest-option-author {
-    @apply text-base-500 dark:text-base-400 truncate text-[.78rem];
+  .suggest-results :global(.suggest-option-author) {
+    @apply text-base-500 dark:text-base-400 truncate text-[.78rem] leading-tight;
   }
 
   .suggest-status {

--- a/src/lib/bookhive.ts
+++ b/src/lib/bookhive.ts
@@ -209,6 +209,8 @@ export interface BookshelfData {
   wantToRead: Book[];
   /** Recently finished, newest first, any genre (fiction included here). */
   finished: Book[];
+  /** Total finished books (before the shelf cap), for the "see all N" link. */
+  finishedCount: number;
 }
 
 // Caps bound the per-render catalog lookups (covers/genres). Want-to-read is
@@ -234,8 +236,8 @@ export async function getBookshelf(): Promise<BookshelfData> {
       .filter((b) => b.value.status === STATUS_WANT)
       .sort(byNewest("createdAt"))
       .slice(0, WANT_CAP);
-    const read = books
-      .filter((b) => b.value.status === STATUS_FINISHED)
+    const finishedAll = books.filter((b) => b.value.status === STATUS_FINISHED);
+    const read = [...finishedAll]
       .sort(byNewest("finishedAt"))
       .slice(0, FINISHED_SHELF_CAP);
 
@@ -245,8 +247,8 @@ export async function getBookshelf(): Promise<BookshelfData> {
       enrich(read).then((e) => e.map(mapBook)),
     ]);
 
-    return { active, wantToRead, finished };
+    return { active, wantToRead, finished, finishedCount: finishedAll.length };
   } catch {
-    return { active: [], wantToRead: [], finished: [] };
+    return { active: [], wantToRead: [], finished: [], finishedCount: 0 };
   }
 }

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -25,6 +25,18 @@ const { active, wantToRead, finished, finishedCount } = await getBookshelf();
 const bookhiveHref = "https://bookhive.buzz/profile/gui.do";
 const nothing =
   active.length === 0 && wantToRead.length === 0 && finished.length === 0;
+
+// When there are more read books than the shelf shows, replace the last few
+// covers with faded "mystery" tiles (a continuation of the same grid) and point
+// to the full list on Bookhive. Keeps the tile count steady so the widest view
+// stays a clean set of rows.
+const READ_TEASER = 3;
+const moreRead =
+  finishedCount > finished.length && finished.length > READ_TEASER;
+const readCovers = moreRead
+  ? finished.slice(0, finished.length - READ_TEASER)
+  : finished;
+const readMystery = moreRead ? READ_TEASER : 0;
 ---
 
 <BaseLayout
@@ -90,27 +102,26 @@ const nothing =
                     Recently read
                   </a>
                 </h2>
-                <BookGrid books={finished} showRatings />
-                {finishedCount > finished.length && (
-                  <>
-                    <div class="mt-4">
-                      <BookGrid mystery={6} />
-                    </div>
-                    <a
-                      href={bookhiveHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      class="shelf-more no-random-underline"
-                    >
-                      <span class="underline underline-offset-2">
-                        Check out all my {finishedCount} read books on Bookhive
-                      </span>
-                      <span class="shelf-more-arrow" aria-hidden="true">
-                        &rarr;
-                      </span>
-                      <span class="sr-only">(opens in new tab)</span>
-                    </a>
-                  </>
+                <BookGrid
+                  books={readCovers}
+                  showRatings
+                  mystery={readMystery}
+                />
+                {moreRead && (
+                  <a
+                    href={bookhiveHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="shelf-more no-random-underline"
+                  >
+                    <span class="underline underline-offset-2">
+                      Check out all my {finishedCount} read books on Bookhive
+                    </span>
+                    <span class="shelf-more-arrow" aria-hidden="true">
+                      &rarr;
+                    </span>
+                    <span class="sr-only">(opens in new tab)</span>
+                  </a>
                 )}
               </section>
             )}

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -21,7 +21,7 @@ Astro.response.headers.set(
   "public, max-age=0, must-revalidate",
 );
 
-const { active, wantToRead, finished } = await getBookshelf();
+const { active, wantToRead, finished, finishedCount } = await getBookshelf();
 const bookhiveHref = "https://bookhive.buzz/profile/gui.do";
 const nothing =
   active.length === 0 && wantToRead.length === 0 && finished.length === 0;
@@ -37,11 +37,11 @@ const nothing =
         <p
           class="text-gold-light dark:text-gold font-hand -rotate-2 text-[1.5rem] leading-none"
         >
-          the whole shelf
+          structured streams of thoughts
         </p>
         <h1 class="h1 mt-2">Bookshelf</h1>
         <p
-          class="text-base-700 dark:text-base-300 mt-3 max-w-2xl text-lg leading-relaxed"
+          class="text-base-700 dark:text-base-300 mt-3 text-lg leading-relaxed"
         >
           What I&rsquo;m reading now, what I want to read next, and what I
           recently finished, pulled straight from my Bookhive shelf. Fair
@@ -76,6 +76,45 @@ const nothing =
               </section>
             )}
 
+            {finished.length > 0 && (
+              <section
+                id="recently-read"
+                class="shelf-section"
+                aria-labelledby="shelf-read"
+              >
+                <h2 id="shelf-read" class="shelf-h">
+                  <a
+                    href="#recently-read"
+                    class="shelf-anchor no-random-underline"
+                  >
+                    Recently read
+                  </a>
+                </h2>
+                <BookGrid books={finished} showRatings />
+                {finishedCount > finished.length && (
+                  <>
+                    <div class="mt-4">
+                      <BookGrid mystery={6} />
+                    </div>
+                    <a
+                      href={bookhiveHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="shelf-more no-random-underline"
+                    >
+                      <span class="underline underline-offset-2">
+                        Check out all my {finishedCount} read books on Bookhive
+                      </span>
+                      <span class="shelf-more-arrow" aria-hidden="true">
+                        &rarr;
+                      </span>
+                      <span class="sr-only">(opens in new tab)</span>
+                    </a>
+                  </>
+                )}
+              </section>
+            )}
+
             {wantToRead.length > 0 && (
               <section
                 id="want-to-read"
@@ -93,40 +132,9 @@ const nothing =
                 <BookGrid books={wantToRead} />
               </section>
             )}
-
-            {finished.length > 0 && (
-              <section
-                id="recently-read"
-                class="shelf-section"
-                aria-labelledby="shelf-read"
-              >
-                <h2 id="shelf-read" class="shelf-h">
-                  <a
-                    href="#recently-read"
-                    class="shelf-anchor no-random-underline"
-                  >
-                    Recently read
-                  </a>
-                </h2>
-                <BookGrid books={finished} showRatings />
-              </section>
-            )}
           </div>
         )
       }
-
-      <a
-        href={bookhiveHref}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="shelf-more no-random-underline"
-      >
-        <span class="underline underline-offset-2"
-          >See the full shelf on Bookhive</span
-        >
-        <span class="shelf-more-arrow" aria-hidden="true">&rarr;</span>
-        <span class="sr-only">(opens in new tab)</span>
-      </a>
 
       <SuggestBook />
     </div>


### PR DESCRIPTION
Follow-up polish to the `/bookshelf` page (builds on #311).

## Changes
- New eyebrow copy; the intro paragraph and the suggest-box description now use the full container width.
- Shelf order is now Reading now, Recently read, Want to read.
- **Read-count teaser**: "Recently read" shows a capped slice, so it used to look like fewer books than were actually read. Added a faded "mystery" row that dissolves downward into a "Check out all my N read books on Bookhive" link (N comes from a new `finishedCount`).
- **Book search dropdown fixes**:
  - The result options are built in JS, so Astro's scoped CSS never reached them and they rendered unstyled. Styled them via a `:global` block under the results container (cover thumbnail, title, author with proper spacing).
  - The dropdown was tucking under the footer, which sits in its own stacking context and wins regardless of z-index. It now opens upward when there isn't room below, so it stays clear of the footer.

## Verification
- Dropdown placement, option styling, upward open near the footer, mystery row, and the count link all checked end-to-end in a real browser.
- Typecheck clean (the pre-existing `sifa-sdk` resolution errors are unrelated).
