### PR TITLE
fix(bookshelf): honest read-count caption, drop mystery-tile tease

### DIFF
--- a/src/components/Reading/BookGrid.astro
+++ b/src/components/Reading/BookGrid.astro
@@ -6,25 +6,13 @@
  * "read" shelf so finished books surface their star rating.
  */
 import Stars from "./Stars.astro";
-import type { Book, BookAccent } from "../../lib/bookhive";
+import type { Book } from "../../lib/bookhive";
 
 interface Props {
-  books?: Book[];
+  books: Book[];
   showRatings?: boolean;
-  /** Append this many faded "mystery" tiles after the books, in the SAME grid,
-   *  so they read as a continuation of the shelf (there are more on Bookhive). */
-  mystery?: number;
 }
-const { books = [], showRatings = false, mystery = 0 } = Astro.props as Props;
-
-const MYSTERY_ACCENTS: BookAccent[] = [
-  "pine",
-  "iris",
-  "gold",
-  "foam",
-  "love",
-  "rose",
-];
+const { books, showRatings = false } = Astro.props as Props;
 ---
 
 <div class="grid grid-cols-[repeat(auto-fill,minmax(140px,1fr))] gap-4">
@@ -56,17 +44,6 @@ const MYSTERY_ACCENTS: BookAccent[] = [
       </div>
     ))
   }
-  {
-    Array.from({ length: mystery }).map((_, i) => (
-      <div class="flex flex-col gap-2" aria-hidden="true">
-        <div
-          class={`bk-cover bk-${MYSTERY_ACCENTS[i % MYSTERY_ACCENTS.length]} bk-mystery aspect-[2/3] w-full`}
-        >
-          <span class="bk-q">?</span>
-        </div>
-      </div>
-    ))
-  }
 </div>
 
 <script>
@@ -82,21 +59,6 @@ const MYSTERY_ACCENTS: BookAccent[] = [
 
 <style>
   @reference "../../styles/tailwind.css";
-
-  /* Faded accent tiles with a "?" that trail the real covers in the same grid,
-     implying the shelf continues on Bookhive. Decorative (aria-hidden upstream). */
-  .bk-mystery {
-    align-items: center;
-    justify-content: center;
-    opacity: 0.55;
-    pointer-events: none;
-  }
-  .bk-q {
-    font-family: var(--font-display);
-    font-size: 2rem;
-    font-weight: 800;
-    color: rgb(255 255 255 / 0.6);
-  }
 
   .bk-cover {
     position: relative;

--- a/src/pages/bookshelf.astro
+++ b/src/pages/bookshelf.astro
@@ -26,17 +26,9 @@ const bookhiveHref = "https://bookhive.buzz/profile/gui.do";
 const nothing =
   active.length === 0 && wantToRead.length === 0 && finished.length === 0;
 
-// When there are more read books than the shelf shows, replace the last few
-// covers with faded "mystery" tiles (a continuation of the same grid) and point
-// to the full list on Bookhive. Keeps the tile count steady so the widest view
-// stays a clean set of rows.
-const READ_TEASER = 3;
-const moreRead =
-  finishedCount > finished.length && finished.length > READ_TEASER;
-const readCovers = moreRead
-  ? finished.slice(0, finished.length - READ_TEASER)
-  : finished;
-const readMystery = moreRead ? READ_TEASER : 0;
+// The shelf shows a recent slice; a plain caption states the real total so it
+// doesn't read as if that's everything I've read.
+const moreRead = finishedCount > finished.length;
 ---
 
 <BaseLayout
@@ -102,27 +94,26 @@ const readMystery = moreRead ? READ_TEASER : 0;
                     Recently read
                   </a>
                 </h2>
-                <BookGrid
-                  books={readCovers}
-                  showRatings
-                  mystery={readMystery}
-                />
-                {moreRead && (
+                <BookGrid books={finished} showRatings />
+                <p class="shelf-caption text-base-500 dark:text-base-400">
+                  {moreRead ? (
+                    <>
+                      The {finished.length} most recent of the {finishedCount}{" "}
+                      books I&rsquo;ve read.{" "}
+                    </>
+                  ) : (
+                    <>All {finishedCount} books I&rsquo;ve read. </>
+                  )}
+                  View them all on my{" "}
                   <a
                     href={bookhiveHref}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="shelf-more no-random-underline"
                   >
-                    <span class="underline underline-offset-2">
-                      Check out all my {finishedCount} read books on Bookhive
-                    </span>
-                    <span class="shelf-more-arrow" aria-hidden="true">
-                      &rarr;
-                    </span>
-                    <span class="sr-only">(opens in new tab)</span>
-                  </a>
-                )}
+                    Bookhive
+                  </a>{" "}
+                  profile.
+                </p>
               </section>
             )}
 
@@ -163,6 +154,9 @@ const readMystery = moreRead ? READ_TEASER : 0;
   .shelf-h {
     @apply text-base-950 dark:text-base-50 font-display mb-4 text-[1.4rem] font-black tracking-[-0.02em];
   }
+  .shelf-caption {
+    @apply mt-5 text-[0.9rem];
+  }
   /* The heading links to its own section so the anchor is copyable; keep the
      heading's colour and only surface an underline on hover/focus. */
   .shelf-anchor {
@@ -173,16 +167,5 @@ const readMystery = moreRead ? READ_TEASER : 0;
     text-decoration: underline;
     text-underline-offset: 0.15em;
     text-decoration-thickness: 2px;
-  }
-  .shelf-more {
-    @apply text-primary-600 dark:text-primary-400 mt-8 inline-flex items-center gap-1 self-start text-[0.9rem] font-semibold;
-    text-decoration: none;
-  }
-  .shelf-more-arrow {
-    transition: transform 0.2s ease;
-  }
-  .shelf-more:hover .shelf-more-arrow,
-  .shelf-more:focus-visible .shelf-more-arrow {
-    transform: translateX(2px);
   }
 </style>


### PR DESCRIPTION
Replaces the "mystery tile" teaser on the `/bookshelf` "Recently read" section with a plain, honest treatment.

## Why
The faded placeholder tiles + "Check out all my N read books" CTA were a growth-hack nudge toward an external site. The real goal was just to signal that the shelf shows a recent slice, not everything. A factual caption does that without the gimmick.

## Changes
- Removed the mystery-tile machinery from `BookGrid` (back to a plain cover grid).
- "Recently read" now shows real covers plus a caption: "The N most recent of the M books I've read. View them all on my Bookhive profile" (Bookhive is a normal inline text link, not a CTA button).

Note: the mystery-tile version reached production through an earlier auto-merge before this treatment was finished; this restores the intended plain version.

## Verification
- Caption and covers render correctly; no mystery tiles; count is live.
- Typecheck clean (pre-existing `sifa-sdk` resolution errors unrelated).
