### PR TITLE
feat(bookshelf): loading spinner on book search

### DIFF
--- a/src/components/Reading/SuggestBook.astro
+++ b/src/components/Reading/SuggestBook.astro
@@ -39,6 +39,8 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
       aria-autocomplete="list"
       data-suggest-input
     />
+    <span class="suggest-spinner" hidden aria-hidden="true" data-suggest-spinner
+    ></span>
     <ul
       id="book-results"
       class="suggest-results"
@@ -106,6 +108,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
       "[data-suggest-clear]",
     );
     const status = root.querySelector<HTMLElement>("[data-suggest-status]");
+    const spinner = root.querySelector<HTMLElement>("[data-suggest-spinner]");
 
     type Book = {
       id: string;
@@ -146,6 +149,18 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
         if (status) status.hidden = true;
       };
 
+      // Loading indicator: Bookhive search can take a couple of seconds, so
+      // show a spinner (and set aria-busy) from the keystroke until results,
+      // no-match, or an error settle it.
+      const showLoading = () => {
+        if (spinner) spinner.hidden = false;
+        input.setAttribute("aria-busy", "true");
+      };
+      const hideLoading = () => {
+        if (spinner) spinner.hidden = true;
+        input.removeAttribute("aria-busy");
+      };
+
       const closeList = () => {
         results.hidden = true;
         results.innerHTML = "";
@@ -153,6 +168,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
         input.removeAttribute("aria-activedescendant");
         items = [];
         active = -1;
+        hideLoading();
       };
 
       const selectBook = (book: Book) => {
@@ -249,6 +265,7 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
             { signal: controller.signal },
           );
           if (!res.ok) {
+            hideLoading();
             items = [];
             render();
             return showStatus(UNAVAILABLE);
@@ -256,11 +273,14 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
           const data = (await res.json()) as { books?: Book[] };
           items = data.books ?? [];
           active = -1;
+          hideLoading();
           render();
           if (items.length === 0) showStatus(NO_MATCH);
           else hideStatus();
         } catch (err) {
+          // On abort a newer search is already in flight, so keep the spinner.
           if ((err as Error).name !== "AbortError") {
+            hideLoading();
             items = [];
             render();
             showStatus(UNAVAILABLE);
@@ -275,6 +295,8 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
           hideStatus();
           return closeList();
         }
+        // Immediate feedback while debouncing + fetching.
+        showLoading();
         debounce = window.setTimeout(() => search(q), 250);
       });
 
@@ -334,7 +356,40 @@ const fallbackHref = `https://bsky.app/intent/compose?text=${encodeURIComponent(
     @apply relative mt-5 max-w-md;
   }
   .suggest-input {
-    @apply border-base-300 dark:border-base-700 bg-base-100 dark:bg-base-950 text-base-900 dark:text-base-100 placeholder:text-base-500 focus:ring-primary-500 w-full rounded-lg border px-4 py-2.5 text-[.95rem] focus:ring-2 focus:outline-hidden;
+    @apply border-base-300 dark:border-base-700 bg-base-100 dark:bg-base-950 text-base-900 dark:text-base-100 placeholder:text-base-500 focus:ring-primary-500 w-full rounded-lg border py-2.5 pr-10 pl-4 text-[.95rem] focus:ring-2 focus:outline-hidden;
+  }
+
+  /* Loading spinner, right-aligned inside the input while a search is pending. */
+  .suggest-spinner {
+    position: absolute;
+    top: 0.8rem;
+    right: 0.85rem;
+    width: 1.05rem;
+    height: 1.05rem;
+    border-radius: 50%;
+    border: 2px solid
+      color-mix(in oklab, var(--color-base-500) 30%, transparent);
+    border-top-color: var(--color-primary-600);
+    animation: suggest-spin 0.6s linear infinite;
+  }
+  :global(.dark) .suggest-spinner {
+    border-top-color: var(--color-primary-400);
+  }
+  @keyframes suggest-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  /* Respect reduced-motion: swap the spin for a gentle opacity pulse. */
+  @media (prefers-reduced-motion: reduce) {
+    .suggest-spinner {
+      animation: suggest-pulse 1.1s ease-in-out infinite;
+    }
+  }
+  @keyframes suggest-pulse {
+    50% {
+      opacity: 0.3;
+    }
   }
 
   /* z-50 keeps the dropdown above the footer (which sits in its own stacking


### PR DESCRIPTION
Adds a loading indicator to the `/bookshelf` book search, since the Bookhive lookup can take a couple of seconds.

## Changes
- A small spinner appears inside the search input (right side) from the keystroke until the search settles (results, no-match, or error).
- Sets `aria-busy` on the input while loading, so screen readers announce the busy state.
- Respects `prefers-reduced-motion`: a gentle opacity pulse instead of a spin.
- Handles rapid typing: an aborted (superseded) request keeps the spinner up because a newer request is already in flight.

## Verification
- Confirmed in a real browser: spinner shows while a request is pending, clears when results arrive, and `aria-busy` toggles on/off.
- Typecheck clean (pre-existing `sifa-sdk` resolution errors unrelated).
