### PR TITLE
feat(og): custom OpenGraph card for /bookshelf

### DIFF
--- a/src/lib/og/cards.tsx
+++ b/src/lib/og/cards.tsx
@@ -95,6 +95,16 @@ const ArrowIcon = ({ size = 22 }: IconProps) => (
   </svg>
 );
 
+const BooksIcon = ({ size = 20 }: IconProps) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" {...stroke()}>
+    <path d="M5 4m0 1a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1z" />
+    <path d="M9 4m0 1a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v14a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1z" />
+    <path d="M5 8h4" />
+    <path d="M9 16h4" />
+    <path d="M14 5.5l2.5 -.5l3 14l-2.5 .5z" />
+  </svg>
+);
+
 /* --------------------------------------------------------- shared bits */
 
 const FONT_DISPLAY = `"${FONTS.display}"`;
@@ -795,6 +805,100 @@ export function FallbackCard({
       </Middle>
 
       <Byline who="Guido X Jansen" />
+    </Frame>
+  );
+}
+
+/* 8 · Bookshelf ---------------------------------------------------------- */
+
+/** A row of book spines (the shelf motif) in the cover-grid accent palette. */
+const SPINES: { c: string; h: number; w: number }[] = [
+  { c: ACCENTS.pine, h: 128, w: 44 },
+  { c: ACCENTS.gold, h: 150, w: 48 },
+  { c: ACCENTS.iris, h: 116, w: 42 },
+  { c: ACCENTS.love, h: 142, w: 46 },
+  { c: ACCENTS.foam, h: 124, w: 50 },
+  { c: ACCENTS.rose, h: 150, w: 44 },
+  { c: ACCENTS.pine, h: 112, w: 46 },
+  { c: ACCENTS.gold, h: 136, w: 42 },
+  { c: ACCENTS.iris, h: 126, w: 48 },
+  { c: ACCENTS.foam, h: 146, w: 44 },
+  { c: ACCENTS.love, h: 118, w: 46 },
+];
+
+function Shelf() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-end",
+        gap: 11,
+        height: 156,
+        marginBottom: 26,
+      }}
+    >
+      {SPINES.map((s, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "flex-start",
+            width: s.w,
+            height: s.h,
+            paddingTop: 18,
+            backgroundColor: s.c,
+            borderTopLeftRadius: 6,
+            borderTopRightRadius: 6,
+          }}
+        >
+          {/* faint "title band" so the spines read as books */}
+          <div
+            style={{
+              display: "flex",
+              width: "58%",
+              height: 5,
+              borderRadius: 3,
+              backgroundColor: "rgba(25,23,36,0.30)",
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function BookshelfCard() {
+  const ac = ACCENTS.gold;
+  return (
+    <Frame accent={ac} paddingTop={64}>
+      <EyebrowRow
+        pill={
+          <Pill accent={ac} icon={<BooksIcon />}>
+            gui.do/bookshelf
+          </Pill>
+        }
+        hand={
+          <Hand color={ac} size={1.85}>
+            <span style={{ display: "flex" }}>
+              structured streams of thoughts
+            </span>
+          </Hand>
+        }
+      />
+
+      <Middle justify="center">
+        <Title size={3.4}>What I&apos;m reading &amp; want to read next</Title>
+        <Lead>
+          Reading now, the to-read pile, and recently finished. Pulled live from
+          Bookhive.
+        </Lead>
+      </Middle>
+
+      <Shelf />
+
+      <Byline who="Guido X Jansen · my reading shelf" />
     </Frame>
   );
 }

--- a/src/lib/og/routes.ts
+++ b/src/lib/og/routes.ts
@@ -132,6 +132,7 @@ export function ogImageForPath(pathname: string): string {
   if (p === "/") return "/og/home.png";
   if (p === "/retainer") return "/og/retainer.png";
   if (p === "/training") return "/og/training.png";
+  if (p === "/bookshelf") return "/og/bookshelf.png";
 
   // Landing pages (presentations index lives at /presentations).
   if (p === "/presentations") return "/og/landing/presentations.png";

--- a/src/pages/og/[...path].png.ts
+++ b/src/pages/og/[...path].png.ts
@@ -23,6 +23,7 @@ import {
   RetainerCard,
   TrainingCard,
   FallbackCard,
+  BookshelfCard,
 } from "../../lib/og/cards";
 import { LANDING_PAGES } from "../../lib/og/routes";
 import { ACCENT_ROTATION } from "../../lib/og/tokens";
@@ -45,6 +46,7 @@ async function buildCardMap(): Promise<Record<string, CardElement>> {
   map["home"] = React.createElement(HomeCard, { years, countries });
   map["retainer"] = React.createElement(RetainerCard, {});
   map["training"] = React.createElement(TrainingCard, {});
+  map["bookshelf"] = React.createElement(BookshelfCard, {});
   map["default"] = React.createElement(FallbackCard, {
     h1: "Guido X Jansen",
     lead: "I build community functions for tech products.",


### PR DESCRIPTION
Adds a dedicated OpenGraph share card for `/bookshelf`, so it no longer falls back to the default card.

## The card
Reuses the site's Satori OG card system (same frame, wash, bloom, byline lockup) with a bespoke bookshelf treatment:
- Gold accent, a books-icon pill (`gui.do/bookshelf`), and the page's "structured streams of thoughts" hand-note.
- A row of coloured book-spine shapes in the cover-grid palette (pine/gold/iris/love/foam/rose) as the shelf motif.
- Title "What I'm reading & want to read next" with a short lead.

## Wiring
- New `BookshelfCard` in `src/lib/og/cards.tsx`.
- `ogImageForPath("/bookshelf")` now returns `/og/bookshelf.png` (routes.ts).
- Registered in the `/og/[...path].png` endpoint's card map, so it prerenders at build and `Seo.astro` emits it as the `og:image` / `twitter:image` for `/bookshelf`.

## Verification
- Rendered the card directly (Satori to PNG) and reviewed it. Layout, palette, and copy all correct.
- Confirmed `Seo.astro` resolves `/bookshelf` to the absolute `og:image` URL.
- Typecheck clean (pre-existing `sifa-sdk` resolution errors unrelated).
